### PR TITLE
Fix race condition when overwriting manifest file

### DIFF
--- a/dandiapi/api/manifests.py
+++ b/dandiapi/api/manifests.py
@@ -61,13 +61,9 @@ def _write_manifest_file(path: str, metadata, logger):
     # Piggyback on the AssetBlob storage since we want to store manifests in the same bucket
     storage = AssetBlob.blob.field.storage
 
-    if storage.exists(path):
-        if logger:
-            logger.info('%s already exists, deleting it', path)
-        storage.delete(path)
     if logger:
         logger.info('Saving %s', path)
-    storage.save(path, ContentFile(metadata))
+    storage._save(path, ContentFile(metadata))
 
 
 def write_dandiset_jsonld(version: Version, logger=None):


### PR DESCRIPTION
There were some instances of Django storage's `save` method appending a
randomized suffix to the name of the checksum file before saving to
preserve the existing file contents.
I believe this was a race condition, since we were deleting the file,
then saving it. If S3 did not propogate the delete before the save,
Django would see the existing file and erroneously try to preserve it.

Use `_save`, which simply writes the file directly, instead of `save`,
which handles altering the file name.

Fixes #580 