### PR TITLE
Fix partial filename from paths_prefix

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -440,6 +440,8 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
             is_folder = folder_index >= 0
 
             if not is_folder:
+                # Ensure base_path is entire filename
+                base_path = asset.path[asset.path.rfind('/') + 1 :]
                 files[base_path] = asset
             else:
                 base_path = base_path[:folder_index]


### PR DESCRIPTION
I was using the asset paths code for [OASIS](https://github.com/ResonantGeoData/RD-OASIS) project, and I noticed a bug: If you provide part of an asset's path in `path_prefix`, the resulting path in `files` will be the remainder, not the entire filename, as you'd expect.

For example, given an asset with the name `a/b/c.zip`, providing `a/b/c` to `path_prefix` yields an entry in `files` with `.zip`.

This PR just fixes the name if it's a file. The behavior is still valid if it's a folder, so it doesn't touch that branch.

While that endpoint does have the following description

>The specified path must be a folder; it either must end in a slash or
(to refer to the root folder) must be the empty string.

I don't see a reason not to handle this case  :man_shrugging: 