### PR TITLE
Enable embargo UI

### DIFF
--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -24,8 +24,7 @@
           outlined
           class="my-4"
         />
-        <!-- TODO: remove v-if to enable embargoed dandiset creation -->
-        <div v-if="false">
+        <div>
           <v-checkbox
             v-model="embargoed"
             hide-details

--- a/web/src/views/DandisetLandingView/DandisetSidebar.vue
+++ b/web/src/views/DandisetLandingView/DandisetSidebar.vue
@@ -5,7 +5,7 @@
       :user-can-modify-dandiset="userCanModifyDandiset"
     />
 
-    <div v-if="true">
+    <div v-if="currentDandiset.dandiset.embargo_status === 'OPEN'">
       <DandisetPublish
         :user-can-modify-dandiset="userCanModifyDandiset"
       />

--- a/web/src/views/DandisetLandingView/DandisetSidebar.vue
+++ b/web/src/views/DandisetLandingView/DandisetSidebar.vue
@@ -5,7 +5,7 @@
       :user-can-modify-dandiset="userCanModifyDandiset"
     />
 
-    <div v-if="currentDandiset.dandiset.embargo_status === 'OPEN'">
+    <div v-if="true">
       <DandisetPublish
         :user-can-modify-dandiset="userCanModifyDandiset"
       />


### PR DESCRIPTION
All of the embargo UI has been merged and is currently sitting behind feature flags - this PR removes those feature flags. We do not want to merge this until we are ready to release embargo to production, so I'll mark this as draft for now.

Closes #833 (visual indicator for embargoed in dandisets list)