### PR TITLE
Fall back to identifier for AssetsSummary DLP card

### DIFF
--- a/web/src/components/DLP/OverviewTab.vue
+++ b/web/src/components/DLP/OverviewTab.vue
@@ -146,7 +146,7 @@
                   <v-col
                     cols="10"
                   >
-                    <span>{{ item.name || item }}</span>
+                    <span>{{ item.name || item.identifier || item.id || item }}</span>
                   </v-col>
                   <v-col>
                     <v-btn


### PR DESCRIPTION
If `name` isn't present on an `AssetsSummary` item, fall back to the identifier instead of rendering JSON.

Fixes #695 