### PR TITLE
Add checksum fields to zarr explore API

### DIFF
--- a/dandiapi/api/views/zarr.py
+++ b/dandiapi/api/views/zarr.py
@@ -211,7 +211,7 @@ def explore_zarr_archive(request, zarr_id: str, path: str):
     If the path does not end with /, it is assumed to be a file and a redirect to that file in S3 is returned.
 
     This API is compatible with https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.http.HTTPFileSystem.
-    """
+    """  # noqa: E501
     zarr_archive = get_object_or_404(ZarrArchive, zarr_id=zarr_id)
     if path == '':
         path = '/'

--- a/dandiapi/api/views/zarr.py
+++ b/dandiapi/api/views/zarr.py
@@ -204,6 +204,14 @@ class ZarrViewSet(ReadOnlyModelViewSet):
 )
 @api_view(['GET'])
 def explore_zarr_archive(request, zarr_id: str, path: str):
+    """
+    Get information about files in a zarr archive.
+
+    If the path ends with /, it is assumed to be a directory and metadata about the directory is returned.
+    If the path does not end with /, it is assumed to be a file and a redirect to that file in S3 is returned.
+
+    This API is compatible with https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.http.HTTPFileSystem.
+    """
     zarr_archive = get_object_or_404(ZarrArchive, zarr_id=zarr_id)
     if path == '':
         path = '/'


### PR DESCRIPTION
* Add a `checksum` field to the zarr directory listing endpoint containing the checksum for the directory
* Add a `checksums` field to the zarr directory listing endpoint containing the checksums for all subfiles and subdirectories of the directory

Addresses API deficiencies brought up in #674 