### PR TITLE
Create/update assets with embargoed blobs

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -143,16 +143,22 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
 
     @property
     def is_blob(self):
-        return self.blob is not None and self.zarr is None
+        return self.blob is not None
+
+    @property
+    def is_embargoed_blob(self):
+        return self.embargoed_blob is not None
 
     @property
     def is_zarr(self):
-        return self.zarr is not None and self.blob is None
+        return self.zarr is not None
 
     @property
     def size(self):
         if self.is_blob:
             return self.blob.size
+        elif self.is_embargoed_blob:
+            return self.embargoed_blob.size
         else:
             return self.zarr.size
 
@@ -164,6 +170,8 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
     def digest(self) -> Dict[str, str]:
         if self.is_blob:
             return self.blob.digest
+        elif self.is_embargoed_blob:
+            return self.embargoed_blob.digest
         else:
             return self.zarr.digest
 
@@ -175,6 +183,8 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
         )
         if self.is_blob:
             s3_url = self.blob.s3_url
+        elif self.is_embargoed_blob:
+            s3_url = self.embargoed_blob.s3_url
         else:
             s3_url = self.zarr.s3_url
 

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -328,8 +328,17 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
             if asset.blob.sha256 is not None:
                 # We do not bother to delay it because it should run very quickly.
                 validate_asset_metadata(asset.id)
+        elif asset.is_embargoed_blob:
+            # Refresh the blob to be sure the sha256 values is up to date
+            asset.embargoed_blob.refresh_from_db()
+            # If the blob is still waiting to have it's checksum calculated, there's no point in
+            # validating now; in fact, it could cause a race condition. Once the blob's sha256 is
+            # calculated, it will revalidate this asset.
+            # If the blob already has a sha256, then the asset metadata is ready to validate.
+            if asset.embargoed_blob.sha256 is not None:
+                # We do not bother to delay it because it should run very quickly.
+                validate_asset_metadata(asset.id)
         elif asset.is_zarr:
-            # TODO what to do here?
             pass
 
         serializer = AssetDetailSerializer(instance=asset)
@@ -441,8 +450,17 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
             if new_asset.blob.sha256 is not None:
                 # We do not bother to delay it because it should run very quickly.
                 validate_asset_metadata(new_asset.id)
+        elif new_asset.is_embargoed_blob:
+            # Refresh the blob to be sure the sha256 values is up to date
+            new_asset.embargoed_blob.refresh_from_db()
+            # If the blob is still waiting to have it's checksum calculated, there's no point in
+            # validating now; in fact, it could cause a race condition. Once the blob's sha256 is
+            # calculated, it will revalidate this asset.
+            # If the blob already has a sha256, then the asset metadata is ready to validate.
+            if new_asset.embargoed_blob.sha256 is not None:
+                # We do not bother to delay it because it should run very quickly.
+                validate_asset_metadata(new_asset.id)
         elif new_asset.is_zarr:
-            # TODO what to do here?
             pass
 
         serializer = AssetDetailSerializer(instance=new_asset)

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -130,6 +130,26 @@ class AssetValidationSerializer(serializers.ModelSerializer):
         fields = ['status', 'validation_errors']
 
 
+class EmbargoedSlugRelatedField(serializers.SlugRelatedField):
+    """
+    A Field for cleanly serializing embargoed model fields.
+
+    Embargoed fields are paired with their non-embargoed equivalents, like "blob" and
+    "embargoed_blob", or "zarr" and "embargoed_zarr". There are DB constraints in place to ensure
+    that only one field is defined at a time. When serializing one of those pairs, we would like to
+    conceal the fact that the field might be embargoed by silently using the embargoed model field
+    in place of the normal field if it is defined.
+    """
+
+    def get_attribute(self, instance: Asset):
+        attr = super().get_attribute(instance)
+        if attr is None:
+            # The normal field was not defined on the model, try the embargoed_ variant instead
+            embargoed_source = f'embargoed_{self.source}'
+            attr = getattr(instance, embargoed_source, None)
+        return attr
+
+
 class AssetSerializer(serializers.ModelSerializer):
     class Meta:
         model = Asset
@@ -144,7 +164,7 @@ class AssetSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['created']
 
-    blob = serializers.SlugRelatedField(slug_field='blob_id', read_only=True)
+    blob = EmbargoedSlugRelatedField(slug_field='blob_id', read_only=True)
     zarr = serializers.SlugRelatedField(slug_field='zarr_id', read_only=True)
 
 


### PR DESCRIPTION
Fixes #810 

I added all the necessary API code to upload embargoed data, but I forgot about the part that creates/updates assets to point to that embargoed data.

Also I added a new serializer field that is used to "combine" two fields (like `blob` and `embargoed_blob`) into a single field for serialization purposes. Now the `blob` field returned from the API call will refer to either `blob` or `embargoed_blob` in the DB as appropriate for that Asset.