### PR TITLE
Add Associated Projects card to DLP

### DIFF
--- a/web/src/components/DLP/OverviewTab.vue
+++ b/web/src/components/DLP/OverviewTab.vue
@@ -177,11 +177,28 @@
         </div>
       </v-list>
     </v-card>
+
+    <MetadataCard
+      v-if="associatedProjects && associatedProjects.length"
+      :items="associatedProjects"
+      name="Associated Projects"
+      icon="mdi-file-document-multiple"
+    >
+      <template #content="slotProps">
+        <span
+          v-if="slotProps.item.identifier"
+          class="text-caption grey--text text--darken-1 related-resource"
+        >
+          <strong>Identifier: </strong>{{ slotProps.item.identifier }}
+          <br>
+        </span>
+      </template>
+    </MetadataCard>
   </div>
 </template>
 
 <script lang="ts">
-import { DandisetMetadata, RelatedResource } from '@/types';
+import { AssociatedProjects, DandisetMetadata, RelatedResource } from '@/types';
 import {
   computed,
   ComputedRef,
@@ -241,6 +258,11 @@ export default defineComponent({
     const relatedResources: ComputedRef<RelatedResource|undefined> = computed(
       () => props.meta.relatedResource,
     );
+
+    const associatedProjects: ComputedRef<AssociatedProjects|undefined> = computed(
+      () => props.meta.wasGeneratedBy,
+    );
+
     const assetSummary = computed(
       () => Object.fromEntries(Object.entries(props.meta.assetsSummary).filter(
         // filter out assetSummary fields we don't want to display
@@ -271,6 +293,7 @@ export default defineComponent({
       contributors,
       fundingInformation,
       relatedResources,
+      associatedProjects,
       assetSummary,
       assetSummaryColumnCount,
       contactPeople,


### PR DESCRIPTION
Fixes 2nd point in #707.

@satra what fields from associated projects should be displayed on the DLP? So far it displays just the `name` and `identifier`. 

To provide context since it's been some time since we've discussed DLP - this is only for the general "overview" display, in the future we will have separate tabs for the metadata, so we'll have a view like [this](https://www.figma.com/file/rBobiAvSLCsJmyYUYmU1OX/DLP?node-id=504%3A36884) for associated projects where we can display more detailed info with more/all of the fields.