### PR TITLE
Do not filter out empty and draft dandisets in the "My Dandisets" view

### DIFF
--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -2,6 +2,7 @@
   <div v-page-title="pageTitle">
     <v-toolbar color="grey darken-2 white--text">
       <v-menu
+        v-if="!user"
         offset-y
         :close-on-content-click="false"
       >

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -165,8 +165,8 @@ export default defineComponent({
         ordering,
         user: props.user ? 'me' : null,
         search: props.search ? route.query.search : null,
-        draft: showDrafts.value,
-        empty: showEmpty.value,
+        draft: props.user ? true : showDrafts.value,
+        empty: props.user ? true : showEmpty.value,
       });
       djangoDandisetRequest.value = response.data;
     });

--- a/web/test/src/tests/dandisetsPage.test.js
+++ b/web/test/src/tests/dandisetsPage.test.js
@@ -1,4 +1,4 @@
-import { vBtn, vIcon } from 'jest-puppeteer-vuetify';
+import { vBtn } from 'jest-puppeteer-vuetify';
 import moment from 'moment';
 import {
   uniqueId,
@@ -19,10 +19,6 @@ describe('dandisets page', () => {
     await waitForRequestsToFinish();
 
     await expect(page).toClickXPath(vBtn(MY_DANDISETS_BTN_TEXT));
-    await expect(page).toClickXPath(vIcon('mdi-cog'));
-    // Wait for the settings menu to open
-    await page.waitForTimeout(500);
-    await expect(page).toClickXPath('//label[.= "Empty Dandisets"]');
     await waitForRequestsToFinish();
 
     await expect(page).toMatch(name);


### PR DESCRIPTION
This PR also hides the filtering menu when on the My Dandisets page. A person could become confused as to why changing those options doesn't change what is shown in that view, and could become further confused as to why changes happen *later* when they return to the public dandisets view (if the time between making the change and seeing the change is long enough for the state change to be forgotten by the user).

Closes #696.