### PR TITLE
Embargo permissions

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -1192,35 +1192,3 @@ def test_asset_direct_info(api_client, asset):
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
     }
-
-
-@pytest.mark.parametrize(
-    ('embargo_status'),
-    [
-        Dandiset.EmbargoStatus.EMBARGOED,
-        Dandiset.EmbargoStatus.UNEMBARGOING,
-    ],
-)
-@pytest.mark.django_db
-def test_asset_embargoed_visibility(
-    api_client, dandiset_factory, draft_version_factory, asset_factory, embargo_status
-):
-    dandiset = dandiset_factory(embargo_status=embargo_status)
-    version = draft_version_factory(dandiset=dandiset)
-    asset = asset_factory()
-    version.assets.add(asset)
-
-    # The version should be hidden because the dandiset it belongs to is embargoed
-    response = api_client.get(
-        f'/api/dandisets/{dandiset.identifier}/versions/{version.version}/assets/'
-    )
-    assert response.json() == {
-        'count': 0,
-        'next': None,
-        'previous': None,
-        'results': [],
-    }
-    response = api_client.get(
-        f'/api/dandisets/{dandiset.identifier}/versions/{version.version}/assets/{asset.asset_id}/'
-    )
-    assert response.status_code == 404

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 from rest_framework.test import APIClient
 
-from dandiapi.api.models import Asset, AssetBlob, Dandiset, EmbargoedAssetBlob, Version
+from dandiapi.api.models import Asset, AssetBlob, EmbargoedAssetBlob, Version
 from dandiapi.api.views.serializers import AssetFolderSerializer, AssetSerializer
 
 from .fuzzy import HTTP_URL_RE, TIMESTAMP_RE, URN_RE, UTC_ISO_TIMESTAMP_RE, UUID_RE

--- a/dandiapi/api/tests/test_embargo.py
+++ b/dandiapi/api/tests/test_embargo.py
@@ -1,0 +1,77 @@
+import pytest
+
+from dandiapi.api.models import Dandiset
+
+
+@pytest.fixture(
+    params=[
+        Dandiset.EmbargoStatus.EMBARGOED,
+        Dandiset.EmbargoStatus.UNEMBARGOING,
+    ]
+)
+def embargo_status(request):
+    return request.param
+
+
+EMPTY_PAGINATION = {
+    'count': 0,
+    'next': None,
+    'previous': None,
+    'results': [],
+}
+
+
+@pytest.mark.parametrize(
+    ('method', 'url_format'),
+    [
+        ('get', '/api/dandisets/{dandiset.identifier}/versions/'),
+        ('get', '/api/dandisets/{dandiset.identifier}/versions/draft/'),
+        ('put', '/api/dandisets/{dandiset.identifier}/versions/draft/'),
+        ('delete', '/api/dandisets/{dandiset.identifier}/versions/draft/'),
+        ('get', '/api/dandisets/{dandiset.identifier}/versions/draft/info/'),
+        ('post', '/api/dandisets/{dandiset.identifier}/versions/draft/publish/'),
+        ('get', '/api/dandisets/{dandiset.identifier}/versions/draft/assets/'),
+        ('post', '/api/dandisets/{dandiset.identifier}/versions/draft/assets/'),
+        ('get', '/api/dandisets/{dandiset.identifier}/versions/draft/assets/paths/'),
+        ('get', '/api/dandisets/{dandiset.identifier}/versions/draft/assets/{asset.asset_id}/'),
+        ('put', '/api/dandisets/{dandiset.identifier}/versions/draft/assets/{asset.asset_id}/'),
+        ('delete', '/api/dandisets/{dandiset.identifier}/versions/draft/assets/{asset.asset_id}/'),
+        (
+            'get',
+            '/api/dandisets/{dandiset.identifier}/versions/draft/assets/{asset.asset_id}/download/',
+        ),
+        (
+            'get',
+            '/api/dandisets/{dandiset.identifier}/versions/draft/assets/{asset.asset_id}/info/',
+        ),
+        (
+            'get',
+            '/api/dandisets/{dandiset.identifier}/versions/draft/assets/{asset.asset_id}/validation/',
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_embargo_visibility(
+    api_client,
+    user,
+    dandiset_factory,
+    draft_version_factory,
+    draft_asset_factory,
+    embargoed_asset_blob,
+    embargo_status,
+    method,
+    url_format,
+):
+    dandiset = dandiset_factory(embargo_status=embargo_status)
+    version = draft_version_factory(dandiset=dandiset)
+    asset = draft_asset_factory(blob=None, embargoed_blob=embargoed_asset_blob)
+
+    url = url_format.format(dandiset=dandiset, asset=asset)
+    response = getattr(api_client, method)(url)
+    # The client is not authenticated, so all response codes should be 401
+    assert response.status_code == 401
+
+    api_client.force_authenticate(user=user)
+    response = getattr(api_client, method)(url)
+    # The client is now authenticated but not an owner, so all response codes should be 403
+    assert response.status_code == 403

--- a/dandiapi/api/tests/test_embargo.py
+++ b/dandiapi/api/tests/test_embargo.py
@@ -46,7 +46,7 @@ EMPTY_PAGINATION = {
         ),
         (
             'get',
-            '/api/dandisets/{dandiset.identifier}/versions/draft/assets/{asset.asset_id}/validation/',
+            '/api/dandisets/{dandiset.identifier}/versions/draft/assets/{asset.asset_id}/validation/',  # noqa: E501
         ),
     ],
 )
@@ -65,6 +65,7 @@ def test_embargo_visibility(
     dandiset = dandiset_factory(embargo_status=embargo_status)
     version = draft_version_factory(dandiset=dandiset)
     asset = draft_asset_factory(blob=None, embargoed_blob=embargoed_asset_blob)
+    version.assets.add(asset)
 
     url = url_format.format(dandiset=dandiset, asset=asset)
     response = getattr(api_client, method)(url)

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -7,7 +7,6 @@ import pytest
 
 from dandiapi.api import tasks
 from dandiapi.api.models import Asset, Version
-from dandiapi.api.models.dandiset import Dandiset
 
 from .fuzzy import TIMESTAMP_RE, URN_RE, UTC_ISO_TIMESTAMP_RE, VERSION_ID_RE
 

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -888,29 +888,3 @@ def test_version_rest_delete_draft_admin(api_client, admin_user, draft_version):
     assert response.status_code == 403
     assert response.data == 'Cannot delete draft versions'
     assert draft_version in Version.objects.all()
-
-
-@pytest.mark.parametrize(
-    ('embargo_status'),
-    [
-        Dandiset.EmbargoStatus.EMBARGOED,
-        Dandiset.EmbargoStatus.UNEMBARGOING,
-    ],
-)
-@pytest.mark.django_db
-def test_version_embargoed_visibility(
-    api_client, dandiset_factory, draft_version_factory, embargo_status
-):
-    dandiset = dandiset_factory(embargo_status=embargo_status)
-    version = draft_version_factory(dandiset=dandiset)
-
-    # The version should be hidden because the dandiset it belongs to is embargoed
-    response = api_client.get(f'/api/dandisets/{dandiset.identifier}/versions/')
-    assert response.json() == {
-        'count': 0,
-        'next': None,
-        'previous': None,
-        'results': [],
-    }
-    response = api_client.get(f'/api/dandisets/{dandiset.identifier}/versions/{version.version}/')
-    assert response.status_code == 404


### PR DESCRIPTION
* Throw 401 whenever a client attempts to do anything to an embargoed version/asset without authenticating.
* Throw 403 whenever a client attempts to do anything to an embargoed version/asset without owning the dandiset.
* Add a single test for all embargo permissions. This should cover all negative testing for embargo permissions.

Fixes #669