### PR TITLE
Set up new frontend-deploy-to-staging on merge to master workflow

### DIFF
--- a/.github/workflows/frontend-staging-deploy.yml
+++ b/.github/workflows/frontend-staging-deploy.yml
@@ -1,0 +1,20 @@
+name: Trigger staging deploy of frontend application on push to master
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "web/**"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Deploy frontend to staging
+        uses: netlify/actions/build@master
+        env:
+          NETLIFY_SITE_ID: ${{secrets.NETLIFY_STAGING_SITE_ID}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This adds a GitHub Action workflow to automatically deploy the frontend to staging on every merge to master (if there are changes in the frontend code). This is the first step in unifying the release/deploy procedure for the full web app.