### PR TITLE
Only revalidate invalids in revalidate command

### DIFF
--- a/dandiapi/api/management/commands/revalidate.py
+++ b/dandiapi/api/management/commands/revalidate.py
@@ -8,22 +8,31 @@ from dandiapi.api.tasks import validate_asset_metadata, validate_version_metadat
 @click.command()
 @click.option('--assets', is_flag=True, default=False)
 @click.option('--versions', is_flag=True, default=False)
-def revalidate(assets: bool, versions: bool):
+@click.option('--revalidate-all', is_flag=True, default=False)
+@click.option('--dry-run', is_flag=True, default=False)
+def revalidate(assets: bool, versions: bool, revalidate_all: bool, dry_run: bool):
     """
     Revalidate all Versions and Assets.
 
     This script will run the validation immediately in band without dispatching tasks to the queue.
     """
     if assets:
-        click.echo('Revalidating assets')
-        for asset in Asset.objects.filter(status=Asset.Status.INVALID).values('id'):
-            validate_asset_metadata(asset['id'])
+        asset_qs = Asset.objects
+        if not revalidate_all:
+            asset_qs = asset_qs.filter(status=Asset.Status.INVALID)
+        click.echo(f'Revalidating {asset_qs.count()} assets')
+        if not dry_run:
+            for asset in asset_qs.values('id'):
+                validate_asset_metadata(asset['id'])
 
     if versions:
-        click.echo('Revalidating versions')
         # Only revalidate draft versions
-        for version in Version.objects.filter(
-            version='draft',
-            status=Version.Status.INVALID,
-        ).values('id'):
-            validate_version_metadata(version['id'])
+        version_qs = Version.objects.filter(version='draft')
+        if not revalidate_all:
+            version_qs = version_qs.filter(
+                status=Version.Status.INVALID,
+            )
+        click.echo(f'Revalidating {version_qs.count()} versions')
+        if not dry_run:
+            for version in version_qs.values('id'):
+                validate_version_metadata(version['id'])

--- a/dandiapi/api/management/commands/revalidate.py
+++ b/dandiapi/api/management/commands/revalidate.py
@@ -1,4 +1,3 @@
-from django.db.models import Exists, OuterRef
 import djclick as click
 
 from dandiapi.api.models import Asset, Version

--- a/dandiapi/api/management/commands/revalidate.py
+++ b/dandiapi/api/management/commands/revalidate.py
@@ -1,3 +1,4 @@
+from django.db.models import Exists, OuterRef
 import djclick as click
 
 from dandiapi.api.models import Asset, Version
@@ -15,11 +16,14 @@ def revalidate(assets: bool, versions: bool):
     """
     if assets:
         click.echo('Revalidating assets')
-        for asset in Asset.objects.values('id'):
+        for asset in Asset.objects.filter(status=Asset.Status.INVALID).values('id'):
             validate_asset_metadata(asset['id'])
 
     if versions:
         click.echo('Revalidating versions')
         # Only revalidate draft versions
-        for version in Version.objects.filter(version='draft').values('id'):
+        for version in Version.objects.filter(
+            version='draft',
+            status=Version.Status.INVALID,
+        ).values('id'):
             validate_version_metadata(version['id'])


### PR DESCRIPTION
Only revalidate invalid assets/versions when running the `revalidate` command.

Add `--revalidate-all` flag to disable that behavior.
Add `--dry-run` flag to only log the number of assets/versions being revalidated without revalidating.