### PR TITLE
Add `NETLIFY_AUTH_TOKEN` var to netlify env var step

### DIFF
--- a/.github/workflows/frontend-production-deploy.yml
+++ b/.github/workflows/frontend-production-deploy.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Set production deploy environment variables
         run: npx netlify env:import .env.production
         env:
+          NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
           # The CLI complains if this is not specified, even though the command
           # succeeds without it.
           NETLIFY_SITE_ID: ${{secrets.NETLIFY_PRODUCTION_SITE_ID}}


### PR DESCRIPTION
Netlify-cli deploys are currently [failing](https://github.com/dandi/dandi-archive/actions/runs/1761849006). I think this is happening because we're not specifying `NETLIFY_AUTH_TOKEN` as an environment variable for one of the steps. https://answers.netlify.com/t/netlify-deploy-texthttperror-unauthorized/28591/4

I don't believe we ever tested deploying after adding [this line](https://github.com/dandi/dandi-archive/blob/master/.github/workflows/frontend-production-deploy.yml#L42), I'm guessing that is what introduced this error.