### PR TITLE
Specify minimum black version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skipsdist = true
 skip_install = true
 deps =
     flake8
-    flake8-black
+    flake8-black >= 0.2.4
     flake8-bugbear
     flake8-docstrings
     flake8-isort
@@ -32,7 +32,7 @@ commands =
 skipsdist = true
 skip_install = true
 deps =
-    black
+    black >= 22.1.0
     isort
 commands =
     isort {posargs:.}


### PR DESCRIPTION
Black was recently released as [non-beta](https://github.com/psf/black/releases/tag/22.1.0). This change pins black to at
least use this version (exclude previous beta versions)