### PR TITLE
Remove github_username from admin search

### DIFF
--- a/dandiapi/api/admin.py
+++ b/dandiapi/api/admin.py
@@ -39,7 +39,7 @@ class UserMetadataInline(TabularInline):
 class UserAdmin(BaseUserAdmin):
     list_select_related = ['metadata']
     list_display = ['email', 'first_name', 'last_name', 'github_username', 'status', 'date_joined']
-    search_fields = ['email', 'first_name', 'last_name', 'github_username']
+    search_fields = ['email', 'first_name', 'last_name']
     inlines = [UserMetadataInline]
 
     @admin.action(description="Export selected users\' emails")


### PR DESCRIPTION
`github_username` is a display only property that we extract from the
user metadata, so it cannot be searched. Whenever searches tried to they
encountered an error.

fixes #874 