### PR TITLE
Add threads to delete_from_versioned_bucket

### DIFF
--- a/dev/delete_from_versioned_bucket.py
+++ b/dev/delete_from_versioned_bucket.py
@@ -34,7 +34,7 @@ def delete_version(bucket, thing):
 @click.option('--bucket', prompt='Bucket', help='The bucket to delete from')
 @click.option('--prefix', prompt='Path to delete', help='The prefix to delete all files under')
 @click.option('--force', is_flag=True, help='Skip confirmation prompts')
-@click.option('--threads', prompt='Threads', help='How many threads to use')
+@click.option('--threads', prompt='Threads', default=30, help='How many threads to use')
 def delete_objects(profile: str, bucket: str, prefix: str, force: bool, threads: int):
     session = boto3.Session(profile_name=profile)
     s3 = session.resource('s3')


### PR DESCRIPTION
This speeds up the versioned bucket delete script pretty substantially.

AWS doesn't have a good way to delete a lot of stuff from a versioned bucket, their [official recommendation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html) is to just write your own script. 