### PR TITLE
Only show embargoed dandisets in My Dandisets view

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -105,9 +105,10 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                 queryset = get_objects_for_user(
                     self.request.user, 'owner', Dandiset, with_superuser=False
                 ).order_by('created')
-            # Same deal for filtering out draft or empty dandisets
+            # Same deal for filtering out draft, empty, or embargoed dandisets
             show_draft = self.request.query_params.get('draft', 'true') == 'true'
             show_empty = self.request.query_params.get('empty', 'true') == 'true'
+            show_embargoed = self.request.query_params.get('embargoed', 'true') == 'true'
 
             if not show_draft:
                 # Only include dandisets that have more than one version, i.e. published dandisets.
@@ -125,6 +126,8 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                     draft_asset_count=Subquery(most_recent_version.values('asset_count'))
                 )
                 queryset = queryset.filter(draft_asset_count__gt=0)
+            if not show_embargoed:
+                queryset = queryset.filter(embargo_status='OPEN')
         return queryset
 
     def get_object(self):

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -168,6 +168,7 @@ export default defineComponent({
         search: props.search ? route.query.search : null,
         draft: props.user ? true : showDrafts.value,
         empty: props.user ? true : showEmpty.value,
+        embargoed: props.user,
       });
       djangoDandisetRequest.value = response.data;
     });


### PR DESCRIPTION
This essentially keeps embargoed dandisets out of the Public Dandisets
view, showing them in the My Dandisets view of their owners, and admins.

Closes #834.

EDIT: The deploy preview (https://deploy-preview-889--gui-staging-dandiarchive-org.netlify.app/#/dandiset) doesn't work properly because this PR involves a backend change that isn't deployed to staging yet. But it works locally, so if reviewers want to build locally to see it in action and give me feedback on the code changes, we can deploy this to staging to make sure it works there.