### PR TITLE
boost copyright to 2022 from 2019

### DIFF
--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -15,7 +15,7 @@
       </cookie-law>
       <v-row>
         <v-col offset="2">
-          &copy; 2022 - present The DANDI Team<br>
+          &copy; 2019 - 2022 The DANDI Team<br>
           version
           <a
             class="version-link"

--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -15,7 +15,7 @@
       </cookie-law>
       <v-row>
         <v-col offset="2">
-          &copy; 2019 - present The DANDI Team<br>
+          &copy; 2022 - present The DANDI Team<br>
           version
           <a
             class="version-link"


### PR DESCRIPTION
or should we just make it correspond to current  year (programmatically) or the year of the last commit in the repo?