### PR TITLE
Don't send emails when existing users fill out the name form

### DIFF
--- a/dandiapi/api/views/auth.py
+++ b/dandiapi/api/views/auth.py
@@ -112,8 +112,12 @@ def user_questionnaire_form_view(request: HttpRequest) -> HttpResponse:
 
         # Only send emails when the user fills out the questionnaire for the first time.
         # If they go back later and update it for whatever reason, they should not receive
-        # another email confirming their registration.
-        if not questionnaire_already_filled_out:
+        # another email confirming their registration. Additionally, users who have already
+        # been approved that go back and update the form later should also not receive an email.
+        if (
+            not questionnaire_already_filled_out
+            and user_metadata.status == UserMetadata.Status.PENDING
+        ):
             # send email indicating the user has signed up
             for socialaccount in user.socialaccount_set.all():
                 send_registered_notice_email(user, socialaccount)


### PR DESCRIPTION
We have a lot of users in the system who signed up before the user questionnaire was a thing. All such users were "grandfathered in" and simply approved via a database migration. Currently, If one of these users fills out the first/last name form, the questionnaire code will send emails to them + the admins; this occurs because they have no answers to the signup questionnaire stored, and because of that the system thinks they are new users.

This PR fixes this by checking that the user is actually new (i.e. they have a `status` of `PENDING`) before sending any emails.