### PR TITLE
Add `dense` prop to meditor form elements

### DIFF
--- a/web/src/components/Meditor.vue
+++ b/web/src/components/Meditor.vue
@@ -248,12 +248,14 @@ export default defineComponent({
       initialValidation: 'all',
       disableAll: readonly.value,
       autoFixArrayItems: false,
-      childrenClass: 'my-1 px-2',
+      childrenClass: 'px-2',
       fieldProps: {
         outlined: true,
+        dense: true,
       },
       arrayItemCardProps: {
         outlined: true,
+        dense: true,
       },
       editMode: 'inline',
       hideReadOnly: true,


### PR DESCRIPTION
This slightly improves the look of the meditor by condensing the sizes of the form inputs.

Before / After:

![before](https://user-images.githubusercontent.com/37340715/155608016-97a1733d-6e66-4fa1-b9e5-6c31e985ebed.png)
![after](https://user-images.githubusercontent.com/37340715/155608012-740cb34d-c3a9-42d9-aac9-bcfcad785c05.png)


