### PR TITLE
Fix meditor data loss issue

### DIFF
--- a/web/src/components/Meditor.vue
+++ b/web/src/components/Meditor.vue
@@ -187,7 +187,7 @@
 import type { JSONSchema7 } from 'json-schema';
 
 import {
-  defineComponent, ref, computed, ComputedRef,
+  defineComponent, ref, computed, ComputedRef, onMounted,
 } from '@vue/composition-api';
 
 import jsYaml from 'js-yaml';
@@ -333,6 +333,19 @@ export default defineComponent({
     const fieldsToRender = Object.keys(complexSchema.properties as any).filter(
       (p) => renderField((complexSchema as any).properties[p]),
     );
+
+    onMounted(() => {
+      window.addEventListener('beforeunload', (e) => {
+        // display a confirmation prompt if attempting to navigate away from the
+        // page with unsaved changes in the meditor
+        if (modified.value) {
+          e.preventDefault();
+          // Required for Chrome-based browsers -
+          // see https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#example
+          e.returnValue = 'test';
+        }
+      });
+    });
 
     return {
       allModelsValid: modelValid,

--- a/web/src/components/Meditor.vue
+++ b/web/src/components/Meditor.vue
@@ -7,8 +7,8 @@
     <v-row>
       <v-col>
         <v-card
-          class="mb-2"
-          outlined
+          rounded="0"
+          flat
         >
           <v-card-actions class="pt-0">
             <v-tooltip top>
@@ -96,6 +96,14 @@
               </template>
               <span>Download Metadata</span>
             </v-tooltip>
+            <v-btn
+              elevation="0"
+              color="info"
+              :disabled="modified"
+              @click="$emit('close')"
+            >
+              Done
+            </v-btn>
           </v-card-actions>
         </v-card>
       </v-col>

--- a/web/src/views/DandisetLandingView/DandisetActions.vue
+++ b/web/src/views/DandisetLandingView/DandisetActions.vue
@@ -88,7 +88,11 @@
         </v-btn>
       </v-row>
       <v-row no-gutters>
-        <v-dialog max-width="85vw">
+        <v-dialog
+          v-model="meditorOpen"
+          persistent
+          max-width="85vw"
+        >
           <template #activator="{ on }">
             <v-btn
               id="view-edit-metadata"
@@ -106,7 +110,7 @@
               <v-spacer />
             </v-btn>
           </template>
-          <meditor />
+          <meditor @close="meditorOpen = false" />
         </v-dialog>
       </v-row>
     </div>
@@ -148,7 +152,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ComputedRef } from '@vue/composition-api';
+import {
+  defineComponent, computed, ComputedRef, ref,
+} from '@vue/composition-api';
 import { Location } from 'vue-router';
 
 import { dandiRest } from '@/rest';
@@ -168,6 +174,8 @@ export default defineComponent({
     Meditor,
   },
   setup() {
+    const meditorOpen = ref(false);
+
     const currentDandiset = computed(() => store.state.dandiset.dandiset);
     const currentVersion = computed(() => store.getters.dandiset.version);
 
@@ -198,6 +206,7 @@ export default defineComponent({
       currentVersion,
       fileBrowserLink,
       manifestLocation,
+      meditorOpen,
     };
   },
 });


### PR DESCRIPTION
- Add `beforeunload` event listener that displays a browser prompt if user tries to navigate away from page (clicking refresh, ~~back button~~, closing window, etc) with unsaved meditor changes.
- Prevent meditor dialog window from being closed if there are unsaved meditor changes.

Closes #728 

Edit: this actually doesn't work for the back button. Due to how SPAs work, it looks like we'll need to use some `vue-router` hook to handle that case.