### PR TITLE
Add Dandiset Zarr Ingestion Script

### DIFF
--- a/dandiapi/api/admin.py
+++ b/dandiapi/api/admin.py
@@ -26,7 +26,7 @@ from dandiapi.api.models import (
     ZarrArchive,
     ZarrUploadFile,
 )
-from dandiapi.api.tasks.zarr import ingest_zarr_archive
+from dandiapi.api.tasks.zarr import ingest_dandiset_zarrs, ingest_zarr_archive
 from dandiapi.api.views.users import social_account_to_dict
 
 admin.site.site_header = 'DANDI Admin'
@@ -96,6 +96,23 @@ class DandisetAdmin(GuardedModelAdmin):
     list_display = ['identifier', 'modified', 'created']
     readonly_fields = ['identifier', 'created']
     inlines = [VersionInline]
+
+    @admin.action(description='Ingest selected dandiset zarr archives')
+    def ingest_dandiset_zarrs(self, request, queryset):
+        for dandiset in queryset:
+            ingest_dandiset_zarrs(dandiset_id=dandiset.id)
+
+        # Return message
+        plural = 's' if queryset.count() > 1 else ''
+        self.message_user(
+            request,
+            f'Ingesting zarr archives for {queryset.count()} dandiset{plural}.',
+            messages.SUCCESS,
+        )
+
+    def __init__(self, model, admin_site) -> None:
+        super().__init__(model, admin_site)
+        self.actions += ['ingest_dandiset_zarrs']
 
 
 @admin.register(Version)

--- a/dandiapi/api/admin.py
+++ b/dandiapi/api/admin.py
@@ -162,8 +162,7 @@ class ZarrArchiveAdmin(admin.ModelAdmin):
     @admin.action(description='Ingest selected zarr archives')
     def ingest_zarr_archive(self, request, queryset):
         for zarr in queryset:
-            zarr: ZarrArchive
-            ingest_zarr_archive.delay(zarr_id=(str(zarr.id)))
+            ingest_zarr_archive.delay(zarr_id=(str(zarr.zarr_id)))
 
         # Return message
         self.message_user(

--- a/dandiapi/api/management/commands/ingest_dandiset_zarrs.py
+++ b/dandiapi/api/management/commands/ingest_dandiset_zarrs.py
@@ -1,0 +1,12 @@
+import djclick as click
+
+from dandiapi.api.tasks.zarr import ingest_dandiset_zarrs as _ingest_dandiset_zarrs
+
+
+@click.command()
+@click.argument('dandiset_id', type=str)
+@click.option('--no-checksum', help="Don't recompute checksums", is_flag=True)
+@click.option('--no-size', help="Don't recompute total size", is_flag=True)
+@click.option('--no-count', help="Don't recompute total file count", is_flag=True)
+def ingest_dandiset_zarrs(dandiset_id: str, **kwargs):
+    _ingest_dandiset_zarrs(dandiset_id=int(dandiset_id.lstrip('0')), **kwargs)

--- a/dandiapi/api/management/commands/ingest_zarr_archive.py
+++ b/dandiapi/api/management/commands/ingest_zarr_archive.py
@@ -4,7 +4,7 @@ from dandiapi.api.tasks.zarr import ingest_zarr_archive as _ingest_zarr_archive
 
 
 @click.command()
-@click.argument('zarr_id', type=int)
+@click.argument('zarr_id', type=str)
 @click.option('--no-checksum', help="Don't recompute checksums", is_flag=True)
 @click.option('--no-size', help="Don't recompute total size", is_flag=True)
 @click.option('--no-count', help="Don't recompute total file count", is_flag=True)

--- a/dandiapi/api/tasks/zarr.py
+++ b/dandiapi/api/tasks/zarr.py
@@ -113,10 +113,10 @@ def get_client():
 
 @shared_task
 def ingest_zarr_archive(
-    zarr_id: int, no_checksum: bool = False, no_size: bool = False, no_count: bool = False
+    zarr_id: str, no_checksum: bool = False, no_size: bool = False, no_count: bool = False
 ):
     client = get_client()
-    zarr: ZarrArchive = ZarrArchive.objects.get(id=zarr_id)
+    zarr: ZarrArchive = ZarrArchive.objects.get(zarr_id=zarr_id)
 
     # Reset before compute
     if not no_size:

--- a/dandiapi/api/tasks/zarr.py
+++ b/dandiapi/api/tasks/zarr.py
@@ -147,3 +147,8 @@ def ingest_zarr_archive(
 
     # Save zarr after completion
     zarr.save()
+
+
+def ingest_dandiset_zarrs(dandiset_id: int, **kwargs):
+    for zarr in ZarrArchive.objects.filter(dandiset__id=dandiset_id):
+        ingest_zarr_archive.delay(str(zarr.zarr_id), **kwargs)

--- a/dandiapi/api/tests/test_ingest_zarr_archive.py
+++ b/dandiapi/api/tests/test_ingest_zarr_archive.py
@@ -57,7 +57,7 @@ def test_ingest_zarr_archive(zarr_upload_file_factory, zarr_archive_factory, fak
     assert zarr.file_count == 0
 
     # Compute checksum
-    ingest_zarr_archive(str(zarr.id))
+    ingest_zarr_archive(str(zarr.zarr_id))
 
     # Assert files computed correctly
     assert ZarrChecksumFileUpdater(zarr, 'foo/bar').read_checksum_file() == foo_bar_listing
@@ -115,7 +115,7 @@ def test_ingest_zarr_archive_existing(zarr_upload_file_factory, zarr_archive_fac
     assert ZarrChecksumFileUpdater(zarr, '').read_checksum_file() is not None
 
     # Compute checksum
-    ingest_zarr_archive(str(zarr.id))
+    ingest_zarr_archive(str(zarr.zarr_id))
 
     # Assert files computed correctly
     assert ZarrChecksumFileUpdater(zarr, 'foo/bar').read_checksum_file() == foo_bar_listing
@@ -128,7 +128,7 @@ def test_ingest_zarr_archive_empty(zarr_archive_factory):
     zarr: ZarrArchive = zarr_archive_factory()
 
     # Compute checksum
-    ingest_zarr_archive(str(zarr.id))
+    ingest_zarr_archive(str(zarr.zarr_id))
 
     # Assert files computed correctly
     assert ZarrChecksumFileUpdater(zarr, '').read_checksum_file() is None

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -117,6 +117,9 @@ class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
     # This makes the dandischema pydantic model allow URLs with localhost in them.
     DANDI_ALLOW_LOCALHOST_URLS = True
 
+    # Ensure celery tasks run synchronously
+    CELERY_TASK_ALWAYS_EAGER = True
+
 
 class ProductionConfiguration(DandiMixin, ProductionBaseConfiguration):
     pass


### PR DESCRIPTION
This is a follow up to #914, which adds a method for dispatching ingestion for all zarrs within a given dandiset.