### PR TITLE
Allow running frontend/backend prod deploy actions from github UI

### DIFF
--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
       - "web/**"
 
+  workflow_dispatch:
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -1,4 +1,4 @@
-name: Trigger production deploy of backend server on new release
+name: Deploy backend to production
 
 on:
   release:

--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -1,4 +1,4 @@
-name: Trigger staging deploy of backend server on push to master
+name: Deploy backend to staging
 
 on:
   push:

--- a/.github/workflows/frontend-production-deploy.yml
+++ b/.github/workflows/frontend-production-deploy.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "web/**"
 
+  workflow_dispatch:
+
 jobs:
   deploy-frontend-production:
     defaults:


### PR DESCRIPTION
This will let us bypass the release process and run the deploy actions directly from the GitHub UI, and will prevent us from having to cherry-pick out commits when releasing to production.