### PR TITLE
Make DANDI svg icon a fixed size

### DIFF
--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -47,8 +47,8 @@
         <v-img
           alt="DANDI logo"
           contain
-          max-height="48px"
-          max-width="120px"
+          height="48px"
+          width="120px"
           src="@/assets/logo.svg"
           class="mr-2"
         />


### PR DESCRIPTION
Closes #933

This is just a stopgap measure to make sure the behavior of the DANDI logo is consistent across both chrome and firefox; there's an underlying issue with the styling that causes this issue and others that I have captured in #934.