### PR TITLE
Fix DRF UI for Asset endpoints

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -159,17 +159,9 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
         self.raise_if_unauthorized()
         return super().get_queryset()
 
-    @swagger_auto_schema(
-        responses={
-            200: 'The asset metadata.',
-        },
-        manual_parameters=[ASSET_ID_PARAM],
-        operation_summary="Get an asset\'s metadata",
-        operation_description='',
-    )
     def retrieve(self, request, **kwargs):
         asset = self.get_object()
-        return JsonResponse(asset.metadata)
+        return Response(asset.metadata)
 
     @swagger_auto_schema(
         method='GET',
@@ -271,8 +263,6 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
                 # The user does not have ownership permission
                 raise PermissionDenied()
 
-    # Redefine info and download actions to update swagger manual_parameters
-
     def asset_from_request(self) -> Asset:
         """
         Return an unsaved Asset, constructed from the request data.
@@ -313,6 +303,8 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         )
 
         return asset
+
+    # Redefine info and download actions to update swagger manual_parameters
 
     @swagger_auto_schema(
         method='GET',

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -14,7 +14,7 @@ from urllib.parse import urlencode
 
 from django.core.paginator import EmptyPage, Page, Paginator
 from django.db import models, transaction
-from django.http import HttpResponseRedirect, JsonResponse
+from django.http import HttpResponseRedirect
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -159,6 +159,12 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
         self.raise_if_unauthorized()
         return super().get_queryset()
 
+    @swagger_auto_schema(
+        responses={
+            200: 'The asset metadata.',
+        },
+        operation_summary="Get an asset\'s metadata",
+    )
     def retrieve(self, request, **kwargs):
         asset = self.get_object()
         return Response(asset.metadata)


### PR DESCRIPTION
Closes #917

I'm not sure why this ever worked in the past but apparently using `JsonResponse` instead of just `Response` was the issue.
