### PR TITLE
Fix DLP console errors

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -27,7 +27,7 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:latest
+        image: bitnami/minio:2022.3.3
         env:
           MINIO_ACCESS_KEY: minioAccessKey
           MINIO_SECRET_KEY: minioSecretKey

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,7 +27,7 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:latest
+        image: bitnami/minio:2022.3.3
         env:
           MINIO_ACCESS_KEY: minioAccessKey
           MINIO_SECRET_KEY: minioSecretKey

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -66,7 +66,7 @@ export default defineComponent({
   //
   beforeRouteLeave(to: Route, from: Route, next: NavigationGuardNext) {
     // Prompt user if they try to leave the DLP with unsaved changes in the meditor
-    if (!editorInterface.value.transactionTracker.isModified()
+    if (!editorInterface.value?.transactionTracker?.isModified()
     // eslint-disable-next-line no-alert
     || window.confirm('You have unsaved changes, are you sure you want to leave?')) {
       next();
@@ -145,7 +145,7 @@ export default defineComponent({
       window.addEventListener('beforeunload', (e) => {
         // display a confirmation prompt if attempting to navigate away from the
         // page with unsaved changes in the meditor
-        if (editorInterface.value.transactionTracker.isModified()) {
+        if (editorInterface.value?.transactionTracker?.isModified()) {
           e.preventDefault();
           e.returnValue = 'You have unsaved changes, are you sure you want to leave?';
         }


### PR DESCRIPTION
#947 introduced some console errors on the DLP, causing tests to fail. This PR fixes them and should cause CI to pass again on that PR.