### PR TITLE
Pin minio version

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -27,7 +27,7 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:latest
+        image: bitnami/minio:2022.3.3
         env:
           MINIO_ACCESS_KEY: minioAccessKey
           MINIO_SECRET_KEY: minioSecretKey

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,7 +27,7 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:latest
+        image: bitnami/minio:2022.3.3
         env:
           MINIO_ACCESS_KEY: minioAccessKey
           MINIO_SECRET_KEY: minioSecretKey

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ${DOCKER_RABBITMQ_CONSOLE_PORT-15672}:15672
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:2022.3.3
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ${DOCKER_RABBITMQ_CONSOLE_PORT-15672}:15672
 
   minio:
-    image: minio/minio:2022.3.3
+    image: minio/minio:RELEASE.2022-03-03T21-21-16Z
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]


### PR DESCRIPTION
Some of the recent backend CI runs have been [failing](https://github.com/dandi/dandi-archive/runs/5454211381?check_suite_focus=true), and it seems to be tied to the latest `bitnami/minio` container image. I'm not sure the underlying cause, but pinning the version seems to fix the issue.