### PR TITLE
Prevent responsive breakpoints from closing meditor

### DIFF
--- a/web/src/components/Meditor/Meditor.vue
+++ b/web/src/components/Meditor/Meditor.vue
@@ -1,222 +1,227 @@
 <template>
-  <v-card
-    v-if="schema && model"
-    v-page-title="model.name"
-    class="overflow-hidden"
+  <v-dialog
+    v-model="open"
+    max-width="85vw"
   >
-    <v-dialog
-      v-model="loadFromLocalStoragePrompt"
-      persistent
-      max-width="60vh"
+    <v-card
+      v-if="schema && model && editorInterface"
+      v-page-title="model.name"
+      class="overflow-hidden"
     >
-      <v-card class="pb-3">
-        <v-card-title class="text-h5 font-weight-light">
-          Attention
-        </v-card-title>
-        <v-divider class="my-3" />
-        <v-card-text>
-          You have previously edited this dandiset and have unsaved data.
-        </v-card-text>
-        <v-card-text>
-          Would you like to load that data?
-        </v-card-text>
+      <v-dialog
+        v-model="loadFromLocalStoragePrompt"
+        persistent
+        max-width="60vh"
+      >
+        <v-card class="pb-3">
+          <v-card-title class="text-h5 font-weight-light">
+            Attention
+          </v-card-title>
+          <v-divider class="my-3" />
+          <v-card-text>
+            You have previously edited this dandiset and have unsaved data.
+          </v-card-text>
+          <v-card-text>
+            Would you like to load that data?
+          </v-card-text>
 
-        <v-card-text class="font-weight-bold">
-          WARNING: this will overwrite any changes that were made by others since your last edit.
-        </v-card-text>
+          <v-card-text class="font-weight-bold">
+            WARNING: this will overwrite any changes that were made by others since your last edit.
+          </v-card-text>
 
-        <v-card-actions>
-          <v-btn
-            color="error"
-            depressed
-            @click="loadDataFromLocalStorage()"
-          >
-            Yes
-          </v-btn>
-          <v-btn
-            depressed
-            @click="discardDataFromLocalStorage()"
-          >
-            No, discard it
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-    <v-row>
-      <v-col>
-        <v-card
-          class="mb-2"
-          outlined
-        >
-          <v-card-actions class="pt-0">
-            <v-tooltip top>
-              <template #activator="{ on }">
-                <v-icon
-                  left
-                  :color="allModelsValid ? 'success' : 'error'"
-                  v-on="on"
-                >
-                  <template v-if="allModelsValid">
-                    mdi-checkbox-marked-circle
-                  </template>
-                  <template v-else>
-                    mdi-alert-circle
-                  </template>
-                </v-icon>
-              </template>
-              <template v-if="allModelsValid">
-                All metadata for this dandiset is valid.
-              </template>
-              <template v-else>
-                There are errors in the metadata for this Dandiset.
-              </template>
-            </v-tooltip>
-            <v-tooltip bottom>
-              <template #activator="{ on }">
-                <v-btn
-                  icon
-                  :color="modified ? 'warning' : 'primary'"
-                  :disabled="readonly"
-                  v-on="on"
-                  @click="save"
-                >
-                  <v-icon
-                    v-text="modified ? 'mdi-content-save-alert' : 'mdi-content-save'"
-                  />
-                </v-btn>
-              </template>
-              <span>Save</span>
-            </v-tooltip>
-            <v-tooltip bottom>
-              <template #activator="{ on }">
-                <v-btn
-                  icon
-                  color="secondary"
-                  :disabled="disableUndo"
-                  v-on="on"
-                  @click="undoChange"
-                >
-                  <v-icon>
-                    mdi-undo
-                  </v-icon>
-                </v-btn>
-              </template>
-              <span>Undo</span>
-            </v-tooltip>
-            <v-tooltip bottom>
-              <template #activator="{ on }">
-                <v-btn
-                  icon
-                  color="secondary"
-                  :disabled="disableRedo"
-                  v-on="on"
-                  @click="redoChange"
-                >
-                  <v-icon>
-                    mdi-redo
-                  </v-icon>
-                </v-btn>
-              </template>
-              <span>Redo</span>
-            </v-tooltip>
-            <v-spacer />
-            <v-tooltip bottom>
-              <template #activator="{ on }">
-                <v-btn
-                  icon
-                  v-on="on"
-                  @click="download"
-                >
-                  <v-icon>
-                    mdi-download
-                  </v-icon>
-                </v-btn>
-              </template>
-              <span>Download Metadata</span>
-            </v-tooltip>
+          <v-card-actions>
+            <v-btn
+              color="error"
+              depressed
+              @click="loadDataFromLocalStorage()"
+            >
+              Yes
+            </v-btn>
+            <v-btn
+              depressed
+              @click="discardDataFromLocalStorage()"
+            >
+              No, discard it
+            </v-btn>
           </v-card-actions>
         </v-card>
-      </v-col>
-    </v-row>
-    <v-row class="px-2 justify-center">
-      <v-tabs
-        v-model="tab"
-        background-color="grey darken-2"
-        slider-color="highlight"
-        dark
-        show-arrows
-        align-with-title
-      >
-        <v-tab
-          key="tab-0"
-          class="font-weight-medium text-caption ml-2"
-        >
-          <v-badge
-            color="error"
-            dot
-            :value="!basicModelValid"
+      </v-dialog>
+      <v-row>
+        <v-col>
+          <v-card
+            class="mb-2"
+            outlined
           >
-            General
-          </v-badge>
-        </v-tab>
-        <v-tab
-          v-for="(propKey, i) in fieldsToRender"
-          :key="`tab-${i+1}`"
-          class="font-weight-medium text-caption"
+            <v-card-actions class="pt-0">
+              <v-tooltip top>
+                <template #activator="{ on }">
+                  <v-icon
+                    left
+                    :color="allModelsValid ? 'success' : 'error'"
+                    v-on="on"
+                  >
+                    <template v-if="allModelsValid">
+                      mdi-checkbox-marked-circle
+                    </template>
+                    <template v-else>
+                      mdi-alert-circle
+                    </template>
+                  </v-icon>
+                </template>
+                <template v-if="allModelsValid">
+                  All metadata for this dandiset is valid.
+                </template>
+                <template v-else>
+                  There are errors in the metadata for this Dandiset.
+                </template>
+              </v-tooltip>
+              <v-tooltip bottom>
+                <template #activator="{ on }">
+                  <v-btn
+                    icon
+                    :color="modified ? 'warning' : 'primary'"
+                    :disabled="readonly"
+                    v-on="on"
+                    @click="save"
+                  >
+                    <v-icon
+                      v-text="modified ? 'mdi-content-save-alert' : 'mdi-content-save'"
+                    />
+                  </v-btn>
+                </template>
+                <span>Save</span>
+              </v-tooltip>
+              <v-tooltip bottom>
+                <template #activator="{ on }">
+                  <v-btn
+                    icon
+                    color="secondary"
+                    :disabled="disableUndo"
+                    v-on="on"
+                    @click="undoChange"
+                  >
+                    <v-icon>
+                      mdi-undo
+                    </v-icon>
+                  </v-btn>
+                </template>
+                <span>Undo</span>
+              </v-tooltip>
+              <v-tooltip bottom>
+                <template #activator="{ on }">
+                  <v-btn
+                    icon
+                    color="secondary"
+                    :disabled="disableRedo"
+                    v-on="on"
+                    @click="redoChange"
+                  >
+                    <v-icon>
+                      mdi-redo
+                    </v-icon>
+                  </v-btn>
+                </template>
+                <span>Redo</span>
+              </v-tooltip>
+              <v-spacer />
+              <v-tooltip bottom>
+                <template #activator="{ on }">
+                  <v-btn
+                    icon
+                    v-on="on"
+                    @click="download"
+                  >
+                    <v-icon>
+                      mdi-download
+                    </v-icon>
+                  </v-btn>
+                </template>
+                <span>Download Metadata</span>
+              </v-tooltip>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+      </v-row>
+      <v-row class="px-2 justify-center">
+        <v-tabs
+          v-model="tab"
+          background-color="grey darken-2"
+          slider-color="highlight"
+          dark
+          show-arrows
+          align-with-title
         >
-          <v-badge
-            color="error"
-            dot
-            :value="!complexModelValidation[propKey]"
+          <v-tab
+            key="tab-0"
+            class="font-weight-medium text-caption ml-2"
           >
-            {{ getSchemaTitle(propKey) }}
-          </v-badge>
-        </v-tab>
-      </v-tabs>
-    </v-row>
-    <v-row>
-      <v-tabs-items
-        v-model="tab"
-        style="width: 100%;"
-      >
-        <v-tab-item
-          key="tab-0"
-          eager
-        >
-          <v-form
-            v-model="basicModelValid"
-            style="height: 70vh;"
-            class="px-7 py-5 overflow-y-auto"
-          >
-            <v-jsf
-              v-model="basicModel"
-              :schema="basicSchema"
-              :options="{...CommonVJSFOptions, hideReadOnly: true}"
-              @change="vjsfListener"
-            />
-          </v-form>
-        </v-tab-item>
-        <v-tab-item
-          v-for="(propKey, i) in fieldsToRender"
-          :key="`tab-${i+1}`"
-          eager
-        >
-          <v-card class="pa-2 px-1">
-            <v-form
-              v-model="complexModelValidation[propKey]"
-              class="px-7"
+            <v-badge
+              color="error"
+              dot
+              :value="!basicModelValid"
             >
-              <v-jsf-wrapper
-                :prop-key="propKey"
-                :options="CommonVJSFOptions"
-                :readonly="readonly"
+              General
+            </v-badge>
+          </v-tab>
+          <v-tab
+            v-for="(propKey, i) in fieldsToRender"
+            :key="`tab-${i+1}`"
+            class="font-weight-medium text-caption"
+          >
+            <v-badge
+              color="error"
+              dot
+              :value="!complexModelValidation[propKey]"
+            >
+              {{ getSchemaTitle(propKey) }}
+            </v-badge>
+          </v-tab>
+        </v-tabs>
+      </v-row>
+      <v-row>
+        <v-tabs-items
+          v-model="tab"
+          style="width: 100%;"
+        >
+          <v-tab-item
+            key="tab-0"
+            eager
+          >
+            <v-form
+              v-model="basicModelValid"
+              style="height: 70vh;"
+              class="px-7 py-5 overflow-y-auto"
+            >
+              <v-jsf
+                v-model="basicModel"
+                :schema="basicSchema"
+                :options="{...CommonVJSFOptions, hideReadOnly: true}"
+                @change="vjsfListener"
               />
             </v-form>
-          </v-card>
-        </v-tab-item>
-      </v-tabs-items>
-    </v-row>
-  </v-card>
+          </v-tab-item>
+          <v-tab-item
+            v-for="(propKey, i) in fieldsToRender"
+            :key="`tab-${i+1}`"
+            eager
+          >
+            <v-card class="pa-2 px-1">
+              <v-form
+                v-model="complexModelValidation[propKey]"
+                class="px-7"
+              >
+                <v-jsf-wrapper
+                  :prop-key="propKey"
+                  :options="CommonVJSFOptions"
+                  :readonly="readonly"
+                />
+              </v-form>
+            </v-card>
+          </v-tab-item>
+        </v-tabs-items>
+      </v-row>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script lang="ts">
@@ -245,7 +250,7 @@ import {
   getTransactionsLocalStorage,
 } from './localStorage';
 import VJsfWrapper from './VJsfWrapper.vue';
-import { editorInterface } from './state';
+import { editorInterface, open } from './state';
 
 function renderField(fieldSchema: JSONSchema7) {
   const { properties } = fieldSchema;
@@ -421,6 +426,7 @@ export default defineComponent({
       schema,
       model,
       readonly,
+      open,
 
       basicSchema,
       basicModel,

--- a/web/src/components/Meditor/state.ts
+++ b/web/src/components/Meditor/state.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { computed } from '@vue/composition-api';
+import { computed, ref } from '@vue/composition-api';
 import { EditorInterface } from './editor';
 
 // NOTE: it would be better to use a single ref here instead of seperate state/computed
@@ -28,6 +28,9 @@ const editorInterface = computed({
   },
 });
 
+const open = ref(false); // whether or not the Meditor is open
+
 export {
   editorInterface,
+  open,
 };

--- a/web/src/views/DandisetLandingView/DandisetActions.vue
+++ b/web/src/views/DandisetLandingView/DandisetActions.vue
@@ -87,28 +87,21 @@
           <v-spacer />
         </v-btn>
       </v-row>
-      <v-row no-gutters>
-        <v-dialog max-width="85vw">
-          <template #activator="{ on }">
-            <v-btn
-              id="view-edit-metadata"
-              outlined
-              block
-              v-on="on"
-            >
-              <v-icon
-                left
-                color="primary"
-              >
-                mdi-note-text
-              </v-icon>
-              <span>Metadata</span>
-              <v-spacer />
-            </v-btn>
-          </template>
-          <meditor />
-        </v-dialog>
-      </v-row>
+      <v-btn
+        id="view-edit-metadata"
+        outlined
+        block
+        @click="openMeditor = true"
+      >
+        <v-icon
+          left
+          color="primary"
+        >
+          mdi-note-text
+        </v-icon>
+        <span>Metadata</span>
+        <v-spacer />
+      </v-btn>
     </div>
 
     <div class="my-4">
@@ -154,7 +147,7 @@ import { Location } from 'vue-router';
 import { dandiRest } from '@/rest';
 import store from '@/store';
 
-import Meditor from '@/components/Meditor/Meditor.vue';
+import { open as openMeditor } from '@/components/Meditor/state';
 import DownloadDialog from './DownloadDialog.vue';
 import CiteAsDialog from './CiteAsDialog.vue';
 import ShareDialog from './ShareDialog.vue';
@@ -165,7 +158,6 @@ export default defineComponent({
     CiteAsDialog,
     DownloadDialog,
     ShareDialog,
-    Meditor,
   },
   setup() {
     const currentDandiset = computed(() => store.state.dandiset.dandiset);
@@ -198,6 +190,7 @@ export default defineComponent({
       currentVersion,
       fileBrowserLink,
       manifestLocation,
+      openMeditor,
     };
   },
 });

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <Meditor v-if="currentDandiset" />
     <v-toolbar class="grey darken-2 white--text">
       <DandisetSearchField />
     </v-toolbar>
@@ -46,6 +47,7 @@ import {
 import { NavigationGuardNext, RawLocation, Route } from 'vue-router';
 
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
+import Meditor from '@/components/Meditor/Meditor.vue';
 import store from '@/store';
 import { Version } from '@/types';
 import { draftVersion } from '@/utils/constants';
@@ -59,6 +61,7 @@ export default defineComponent({
     DandisetMain,
     DandisetSearchField,
     DandisetSidebar,
+    Meditor,
   },
   // This guards against "soft" page navigations, i.e. using the back/forward buttons or clicking a
   // link to navigate elsewhere in the SPA. The `beforeunload` event listener below handles


### PR DESCRIPTION
Fixes #915 

This basically just moves the `Meditor` to a higher level in the component tree. Before, the tree looked like this

```
<App>
  <router-view>
    <DandisetLandingView>
      <DandisetSidebar>
        <DandisetActions>
          <Meditor />
        </DandisetActions>
      </DandisetSidebar>
    </DandisetLandingView>
  </router-view>
</App>
```

Now, it looks like this
```
<App>
  <router-view>
    <DandisetLandingView>
      <Meditor />
    </DandisetLandingView>
  </router-view>
</App>
```