### PR TITLE
Use `whitenoise.storage.CompressedStaticFilesStorage` for `STATICFILES_STORAGE`

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -25,6 +25,8 @@ class DandiMixin(ConfigMixin):
 
     DANDI_ALLOW_LOCALHOST_URLS = False
 
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
+
     @staticmethod
     def mutate_configuration(configuration: Type[ComposedConfiguration]):
         # Install local apps first, to ensure any overridden resources are found first

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -25,6 +25,8 @@ class DandiMixin(ConfigMixin):
 
     DANDI_ALLOW_LOCALHOST_URLS = False
 
+    # Workaround for static file storage to work correctly on Django 4.
+    # Taken from https://github.com/axnsan12/drf-yasg/issues/761#issuecomment-1031381674
     STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
     @staticmethod


### PR DESCRIPTION
This fixes the heroku deployment error that started happening after #958 was merged.