### PR TITLE
Use standard collection types instead of deprecated ones from `typing`

### DIFF
--- a/dandiapi/api/copy.py
+++ b/dandiapi/api/copy.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import List
 
 import boto3
 from django.conf import settings
@@ -131,7 +130,7 @@ def _copy_object_multipart_s3(
     )['UploadId']
 
     # Perform concurrent copying of object parts
-    uploading_parts: List[Future[CopyPartResponse]] = []
+    uploading_parts: list[Future[CopyPartResponse]] = []
     with ThreadPoolExecutor(max_workers=settings.DANDI_MULTIPART_COPY_MAX_WORKERS) as executor:
         for part in parts:
             # Submit part copy for execution in thread pool

--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
@@ -19,7 +19,7 @@ BASE_RENDER_CONTEXT = {
 ADMIN_EMAIL = 'info@dandiarchive.org'
 
 
-def build_message(subject: str, message: str, to: List[str], html_message: Optional[str] = None):
+def build_message(subject: str, message: str, to: list[str], html_message: Optional[str] = None):
     message = mail.EmailMultiAlternatives(subject=subject, body=message, to=to)
     if html_message is not None:
         message.attach_alternative(html_message, 'text/html')
@@ -165,7 +165,7 @@ def send_rejected_user_message(user: User, socialaccount: SocialAccount):
         connection.send_messages(messages)
 
 
-def build_pending_users_message(users: Union[QuerySet, List[User]]):
+def build_pending_users_message(users: Union[QuerySet, list[User]]):
     render_context = {**BASE_RENDER_CONTEXT, 'users': users}
     return build_message(
         subject='DANDI: new user registrations to review',
@@ -174,7 +174,7 @@ def build_pending_users_message(users: Union[QuerySet, List[User]]):
     )
 
 
-def send_pending_users_message(users: Union[QuerySet, List[User]]):
+def send_pending_users_message(users: Union[QuerySet, list[User]]):
     logger.info(f'Sending pending users message to admins at {ADMIN_EMAIL}')
     messages = [build_pending_users_message(users)]
     with mail.get_connection() as connection:

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-from typing import Dict
 from urllib.parse import urlparse, urlunparse
 import uuid
 
@@ -50,7 +49,7 @@ class BaseAssetBlob(TimeStampedModel):
         return self.assets.count()
 
     @property
-    def digest(self) -> Dict[str, str]:
+    def digest(self) -> dict[str, str]:
         digest = {'dandi:dandi-etag': self.etag}
         if self.sha256:
             digest['dandi:sha2-256'] = self.sha256
@@ -173,7 +172,7 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
             return self.embargoed_blob.sha256
 
     @property
-    def digest(self) -> Dict[str, str]:
+    def digest(self) -> dict[str, str]:
         if self.is_blob:
             return self.blob.digest
         elif self.is_embargoed_blob:

--- a/dandiapi/api/multipart.py
+++ b/dandiapi/api/multipart.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterator
 from datetime import timedelta
-from typing import Iterator, Tuple
 
 from dandischema.digests.dandietag import PartGenerator
 from django.core.files.storage import Storage
@@ -16,7 +16,7 @@ class UnsupportedStorageError(Exception):
 
 class DandiMultipartMixin:
     @staticmethod
-    def _iter_part_sizes(file_size: int, part_size: int = None) -> Iterator[Tuple[int, int]]:
+    def _iter_part_sizes(file_size: int, part_size: int = None) -> Iterator[tuple[int, int]]:
         generator = PartGenerator.for_file_size(file_size)
         for part in generator:
             yield part.number, part.size

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 from celery import shared_task
 from celery.utils.log import get_task_logger
 import dandischema.exceptions
@@ -60,17 +58,17 @@ def write_manifest_files(version_id: int) -> None:
     write_collection_jsonld(version, logger=logger)
 
 
-def encode_pydantic_error(error) -> Dict[str, str]:
+def encode_pydantic_error(error) -> dict[str, str]:
     return {'field': error['loc'][0], 'message': error['msg']}
 
 
-def encode_jsonschema_error(error: jsonschema.exceptions.ValidationError) -> Dict[str, str]:
+def encode_jsonschema_error(error: jsonschema.exceptions.ValidationError) -> dict[str, str]:
     return {'field': '.'.join([str(p) for p in error.path]), 'message': error.message}
 
 
 def collect_validation_errors(
     error: dandischema.exceptions.ValidationError,
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     if type(error) is dandischema.exceptions.PydanticValidationError:
         encoder = encode_pydantic_error
     elif type(error) is dandischema.exceptions.JsonschemaValidationError:
@@ -165,7 +163,7 @@ def unembargo_dandiset(dandiset_id: int):
 
     # Only the draft version is needed, since embargoed dandisets can't be published
     draft_version: Version = dandiset.draft_version
-    embargoed_assets: List[Asset] = list(draft_version.assets.filter(embargoed_blob__isnull=False))
+    embargoed_assets: list[Asset] = list(draft_version.assets.filter(embargoed_blob__isnull=False))
 
     # Unembargo all assets
     for asset in embargoed_assets:

--- a/dandiapi/api/tests/conftest.py
+++ b/dandiapi/api/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 from botocore.exceptions import ClientError
 from django.conf import settings
@@ -187,6 +187,6 @@ def embargoed_storage(request) -> Storage:
     ],
     ids=['s3boto3', 'minio'],
 )
-def storage_tuple(request) -> Tuple[Storage, Storage]:
+def storage_tuple(request) -> tuple[Storage, Storage]:
     storage_factory, embargoed_storage_factory = request.param
     return (storage_factory(), embargoed_storage_factory())

--- a/dandiapi/api/tests/test_ingest_zarr_archive.py
+++ b/dandiapi/api/tests/test_ingest_zarr_archive.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from dandischema.digests.zarr import EMPTY_CHECKSUM
 import pytest
 
@@ -21,11 +19,11 @@ def test_ingest_zarr_archive(zarr_upload_file_factory, zarr_archive_factory, fak
     zarr: ZarrArchive = zarr_archive_factory()
 
     # Generate > 1000 files, since the page size from S3 is 1000 items
-    foo_bar_files: List[ZarrUploadFile] = [
+    foo_bar_files: list[ZarrUploadFile] = [
         zarr_upload_file_factory(zarr_archive=zarr, path='foo/bar/a'),
         zarr_upload_file_factory(zarr_archive=zarr, path='foo/bar/b'),
     ]
-    foo_baz_files: List[ZarrUploadFile] = [
+    foo_baz_files: list[ZarrUploadFile] = [
         zarr_upload_file_factory(zarr_archive=zarr, path=f'foo/baz/{faker.pystr()}')
         for _ in range(1005)
     ]

--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
@@ -282,7 +282,7 @@ def test_user_status(
 )
 def test_user_questionnaire_view(
     admin_client: Client,
-    questions: List[Dict[str, Any]],
+    questions: list[dict[str, Any]],
     querystring: str,
     expected_status_code: int,
 ):

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import List
 
 from django.db import transaction
 from django.http.response import Http404, HttpResponseBase
@@ -59,7 +58,7 @@ class PartCompletionRequestSerializer(serializers.Serializer):
 class UploadCompletionRequestSerializer(serializers.Serializer):
     parts = PartCompletionRequestSerializer(many=True, allow_empty=False)
 
-    def create(self, validated_data) -> List[TransferredPart]:
+    def create(self, validated_data) -> list[TransferredPart]:
         return [
             TransferredPart(**part)
             for part in sorted(validated_data.pop('parts'), key=lambda part: part['part_number'])
@@ -191,7 +190,7 @@ def upload_complete_view(request: Request, upload_id: str) -> HttpResponseBase:
     """
     request_serializer = UploadCompletionRequestSerializer(data=request.data)
     request_serializer.is_valid(raise_exception=True)
-    parts: List[TransferredPart] = request_serializer.save()
+    parts: list[TransferredPart] = request_serializer.save()
 
     try:
         upload = Upload.objects.get(upload_id=upload_id)

--- a/dandiapi/api/zarr_checksums.py
+++ b/dandiapi/api/zarr_checksums.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
 from django.core.files.base import ContentFile
@@ -98,19 +98,19 @@ class ZarrChecksumFileUpdater(AbstractContextManager):
         storage = self.zarr_archive.storage
         storage.delete(self.checksum_file_path)
 
-    def add_file_checksums(self, checksums: List[ZarrChecksum]):
+    def add_file_checksums(self, checksums: list[ZarrChecksum]):
         """Add a list of file checksums to the listing."""
         if self._checksums is None:
             raise ValueError('This method is only valid when used by a context manager')
         self._checksums.add_file_checksums(checksums)
 
-    def add_directory_checksums(self, checksums: List[ZarrChecksum]):
+    def add_directory_checksums(self, checksums: list[ZarrChecksum]):
         """Add a list of directory checksums to the listing."""
         if self._checksums is None:
             raise ValueError('This method is only valid when used by a context manager')
         self._checksums.add_directory_checksums(checksums)
 
-    def remove_checksums(self, paths: List[str]):
+    def remove_checksums(self, paths: list[str]):
         """Remove a list of paths from the listing."""
         if self._checksums is None:
             raise ValueError('This method is only valid when used by a context manager')


### PR DESCRIPTION
Following up on the python version change in #958 - apparently collection types from the `typing` module are deprecated as of Python 3.9 (see [PEP-585](https://peps.python.org/pep-0585/)).

While we don't do any python type checking currently, I think it's still good to move away from using deprecated types.