### PR TITLE
Use `intuit/auto` to manage releases

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    "git-tag",
+    "all-contributors",
+    "conventional-commits",
+    "first-time-contributor",
+    "released"
+  ],
+  "owner": "dandi",
+  "repo": "dandi-archive",
+  "name": "dandibot",
+  "email": "dandibot@mit.edu",
+  "onlyPublishWithReleaseLabel": true
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # fetch history for all branches and tags
+
+      - name: Download latest auto
+        run: |
+          auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
+          wget -O- "$auto_download_url" | gunzip > ~/auto
+          chmod a+x ~/auto
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ~/auto shipit


### PR DESCRIPTION
Closes #968 

Summary of what this gets us -

- `auto` handles creating releases for us. To cut a release, simply tag a PR with the `release` label. 
- I've included the `conventional-commits` auto plugin, which lets us use the [conventional commits](https://intuit.github.io/auto/docs/generated/conventional-commits) format in commits to tell `auto` whether this is a MAJOR, MINOR, or PATCH release. Then, on the next release `auto` will bump the version number accordingly. 
	- `auto` defaults to a PATCH release if no "conventional commits" are in the PR.
- For every release, `auto` will attach the `released` label to any issues that were closed by a PR in that release. 
	- This functionality provided by the [`released`](https://intuit.github.io/auto/docs/generated/released) plugin.