### PR TITLE
Bump `django-composed-configuration` and remove STATICFILES_STORAGE workaround

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -25,10 +25,6 @@ class DandiMixin(ConfigMixin):
 
     DANDI_ALLOW_LOCALHOST_URLS = False
 
-    # Workaround for static file storage to work correctly on Django 4.
-    # Taken from https://github.com/axnsan12/drf-yasg/issues/761#issuecomment-1031381674
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
-
     @staticmethod
     def mutate_configuration(configuration: Type[ComposedConfiguration]):
         # Install local apps first, to ensure any overridden resources are found first

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'pydantic',
         'boto3[s3]',
         # Production-only
-        'django-composed-configuration[prod]>=0.20.0',
+        'django-composed-configuration[prod]>=0.20.1',
         'django-s3-file-field[boto3]==0.1.1',
         'django-storages[boto3]',
         'gunicorn',
@@ -69,7 +69,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            'django-composed-configuration[dev]>=0.20.0',
+            'django-composed-configuration[dev]>=0.20.1',
             'django-debug-toolbar',
             'django-s3-file-field[minio]',
             'ipython',


### PR DESCRIPTION
The `STATICFILES_STORAGE` bug has been fixed upstream in `django-composed-configuration`, so this PR bumps it to the latest version and removes the workaround.