### PR TITLE
Add manifest queue+worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -5,6 +5,8 @@ web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi
 # This means that we cannot safely scale up the number of priority-workers without Celery Beat triggering multiple events.
 # This is OK for now because of how lightweight all high priority tasks currently are,
 # but we may need to switch back to a dedicated worker in the future.
-# The queue `celery` is the default queue. Right now the only named queue is `calculate_sha256`.
+# The queue `celery` is the default queue.
 worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B
 checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256
+# Manifests can be very memory intensive for large numbers of assets, so limit concurrency to 1
+manifest-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q write_manifest_files -c 1

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -47,7 +47,7 @@ def calculate_sha256(blob_id: int) -> None:
         validate_asset_metadata(asset.id)
 
 
-@shared_task
+@shared_task(queue='write_manifest_files')
 @atomic
 def write_manifest_files(version_id: int) -> None:
     version: Version = Version.objects.get(id=version_id)


### PR DESCRIPTION
The `write_manifest_files` has proven to be far from instantaneous, which means it's time for it to have it's own queue and worker.

Add a new queue `write_manifest_files` and a new worker `manifest-worker` which only has a single thread to avoid running out of memory. 