### PR TITLE
Use custom github token for auto release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
 
       - name: Create Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_GITHUB_TOKEN }}
         run: |
           ~/auto shipit


### PR DESCRIPTION
The default GITHUB_TOKEN doesn't have permission to push to `master`. See https://intuit.github.io/auto/docs/build-platforms/github-actions#running-with-branch-protection