### PR TITLE
Use PAT when checking out repo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch history for all branches and tags
+          token: ${{ secrets.GH_TOKEN }} # use PAT with permissions to push to master
 
       - name: Download latest auto
         run: |


### PR DESCRIPTION
This will hopefully allow the GH Actions runner to push directly to `master`.