### PR TITLE
Bump dandischema to 0.6.0

### DIFF
--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -134,7 +134,7 @@ class BaseZarrUploadFile(TimeStampedModel):
         raise UnsupportedStorageError('Unsupported storage provider.')
 
     def to_checksum(self) -> ZarrChecksum:
-        return ZarrChecksum(path=self.path, md5=self.etag)
+        return ZarrChecksum(name=Path(self.path).name, digest=self.etag, size=self.size())
 
 
 class ZarrUploadFile(BaseZarrUploadFile):
@@ -209,7 +209,7 @@ class BaseZarrArchive(TimeStampedModel):
     def get_checksum(self, path: str | Path = ''):
         listing = ZarrChecksumFileUpdater(self, path).read_checksum_file()
         if listing is not None:
-            return listing.md5
+            return listing.digest
         else:
             zarr_file = self.upload_file_class.objects.create_zarr_upload_file(
                 zarr_archive=self, path=path

--- a/dandiapi/api/tasks/zarr.py
+++ b/dandiapi/api/tasks/zarr.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import boto3
@@ -182,13 +183,14 @@ def ingest_zarr_archive(
             # Update checksums
             if not no_checksum:
                 updater.update_file_checksums(
-                    [
-                        ZarrChecksum(
-                            md5=file['ETag'].strip('"'),
-                            path=file['Key'].replace(zarr.s3_path(''), ''),
+                    {
+                        file['Key'].replace(zarr.s3_path(''), ''): ZarrChecksum(
+                            digest=file['ETag'].strip('"'),
+                            name=Path(file['Key'].replace(zarr.s3_path(''), '')).name,
+                            size=file['Size'],
                         )
                         for file in files
-                    ]
+                    }
                 )
 
         # If no files were actually yielded, remove all checksum files

--- a/dandiapi/api/zarr_checksums.py
+++ b/dandiapi/api/zarr_checksums.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Optional
+from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
 from django.core.files.base import ContentFile
@@ -223,6 +224,10 @@ class ZarrChecksumUpdater:
                     )
 
     def update_file_checksums(self, checksums: Mapping[str, ZarrChecksum]):
+        """
+        Update the given checksums.
+        
+        checksums: a mapping of path to the new checksum for that path."""
         modifications = ZarrChecksumModificationQueue()
         for path, checksum in checksums.items():
             modifications.queue_file_update(Path(path).parent, checksum)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'dandischema==0.5.3',
+        'dandischema==0.6.0',
         'django>=4.0.3',
         'django-admin-display',
         'django-allauth',


### PR DESCRIPTION
https://github.com/dandi/dandischema/pull/120 made some changes to the zarr API:
* Add `size` of files/directories to the serialization
* Only record the name of the file/directory in the .checksum file instead of the entire path relative to the zarr root.
* Add suffix `-{file_count}--{file_size}` to directory digests
* ZarrChecksum.md5 -> ZarrChecksum.digest, since directories are no longer technically just an MD5
* ZarrChecksum.path -> ZarrChecksum.name, since only the name is stored rather than the whole path.

A depressingly large number of changes are required to enact this change.

Fixes #925 