### PR TITLE
Add manifest-worker to Celery in dev environment

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,7 +27,7 @@ services:
       "worker",
       "--loglevel", "INFO",
       "--without-heartbeat",
-      "-Q", "celery,calculate_sha256",
+      "-Q", "celery,calculate_sha256,manifest-worker",
       "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors


### PR DESCRIPTION
I added the `manifest-worker` to the `Procfile` Heroku uses in
staging/production, but I forgot to add it to the development
configuration.