### PR TITLE
Allow github login with GET request

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -137,6 +137,10 @@ class HerokuProductionConfiguration(DandiMixin, HerokuProductionBaseConfiguratio
     # All login attempts in production should go straight to GitHub
     LOGIN_URL = '/accounts/github/login/'
 
+    # Don't require a POST request to initiate a GitHub login
+    # https://github.com/pennersr/django-allauth/blob/HEAD/ChangeLog.rst#backwards-incompatible-changes-2
+    SOCIALACCOUNT_LOGIN_ON_GET = True
+
     # Don't automatically approve users in production. Instead they must be
     # manually approved by an admin.
     AUTO_APPROVE_USERS = False


### PR DESCRIPTION
[django-allauth introduced a breaking change in a recent release](https://github.com/pennersr/django-allauth/blob/HEAD/ChangeLog.rst#backwards-incompatible-changes-2) that disallows signing into a 3rd party oauth service via a GET request. 

Apparently there are some security issues that come with doing this - https://github.com/pennersr/django-allauth/blob/HEAD/ChangeLog.rst#security-notice, which we probably want to think about @waxlamp @dchiquito @AlmightyYakob . For now though, I'm just going to merge this because we've been doing it this way up to this point anyways, and new user signup is currently in a broken state without it.

Closes #996