### PR TITLE
Make checksum_worker responsible for zarr ingest

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -7,6 +7,7 @@ web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi
 # but we may need to switch back to a dedicated worker in the future.
 # The queue `celery` is the default queue.
 worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B
-checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256
+# The checksum-worker calculates blob checksums and updates zarr checksum files
+checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256,ingest_zarr_archive
 # Manifests can be very memory intensive for large numbers of assets, so limit concurrency to 1
 manifest-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q write_manifest_files -c 1

--- a/dandiapi/api/tasks/zarr.py
+++ b/dandiapi/api/tasks/zarr.py
@@ -142,7 +142,7 @@ class SessionZarrChecksumUpdater(ZarrChecksumUpdater):
         return file_updater
 
 
-@shared_task
+@shared_task(queue='ingest_zarr_archive')
 def ingest_zarr_archive(
     zarr_id: str, no_checksum: bool = False, no_size: bool = False, no_count: bool = False
 ):

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,7 +27,7 @@ services:
       "worker",
       "--loglevel", "INFO",
       "--without-heartbeat",
-      "-Q", "celery,calculate_sha256,manifest-worker",
+      "-Q", "celery,calculate_sha256,ingest_zarr_archive,manifest-worker",
       "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors


### PR DESCRIPTION
Currently zarr ingestion runs on the main task queue, which blocks other
shorter tasks from running. Instead, have a separate
`ingest_zarr_archive` queue which is consumed by the existing
`checksum-worker`.

Having a separate worker for blob checksums and zarr checksums seems
like overkill to me, since we will almost never have a spike in both at
the same time, and even if we did, the solution is to scale the number
of `checksum-worker`s even higher.