### PR TITLE
Handle validation errors when fetching zarr checksums

### DIFF
--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -20,8 +20,8 @@ from dandiapi.api.multipart import UnsupportedStorageError
 from dandiapi.api.storage import get_embargo_storage, get_storage
 from dandiapi.api.zarr_checksums import ZarrChecksum, ZarrChecksumFileUpdater
 
-
 logger = logging.Logger(name=__name__)
+
 
 class ZarrUploadFileManager(models.Manager):
     def create_zarr_upload_file(

--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import logging
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
@@ -10,6 +12,7 @@ from django.conf import settings
 from django.core.validators import RegexValidator
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
+import pydantic
 from rest_framework.exceptions import ValidationError
 
 from dandiapi.api.models import Dandiset
@@ -17,6 +20,8 @@ from dandiapi.api.multipart import UnsupportedStorageError
 from dandiapi.api.storage import get_embargo_storage, get_storage
 from dandiapi.api.zarr_checksums import ZarrChecksum, ZarrChecksumFileUpdater
 
+
+logger = logging.Logger(name=__name__)
 
 class ZarrUploadFileManager(models.Manager):
     def create_zarr_upload_file(
@@ -188,11 +193,14 @@ class BaseZarrArchive(TimeStampedModel):
         return self.active_uploads.exists()
 
     @property
-    def checksum(self) -> str:
+    def checksum(self) -> Optional[str]:
         try:
             return self.get_checksum()
         except ValidationError:
             return EMPTY_CHECKSUM
+        except pydantic.ValidationError as e:
+            logger.error(e, exc_info=True)
+            return None
 
     @property
     def digest(self) -> dict[str, str]:

--- a/dandiapi/api/tests/test_zarr.py
+++ b/dandiapi/api/tests/test_zarr.py
@@ -162,7 +162,12 @@ def test_zarr_rest_get_invalid_checksum_file(authenticated_api_client, zarr_arch
     content_file = ContentFile('invalid content'.encode('utf-8'))
     # save() will never overwrite an existing file, it simply appends some garbage to ensure
     # uniqueness. _save() is an internal storage API that will overwite existing files.
-    storage._save(ZarrChecksumFileUpdater(zarr_archive=zarr_archive, zarr_directory_path='').checksum_file_path, content_file)
+    storage._save(
+        ZarrChecksumFileUpdater(
+            zarr_archive=zarr_archive, zarr_directory_path=''
+        ).checksum_file_path,
+        content_file,
+    )
 
     resp = authenticated_api_client.get(f'/api/zarr/{zarr_archive.zarr_id}/')
     assert resp.status_code == 200

--- a/dandiapi/api/tests/test_zarr.py
+++ b/dandiapi/api/tests/test_zarr.py
@@ -1,5 +1,6 @@
 from dandischema.digests.zarr import EMPTY_CHECKSUM
 from django.conf import settings
+from django.core.files.base import ContentFile
 from guardian.shortcuts import assign_perm
 import pytest
 
@@ -148,6 +149,29 @@ def test_zarr_rest_get_empty(authenticated_api_client, zarr_archive: ZarrArchive
         'dandiset': zarr_archive.dandiset.identifier,
         'status': ZarrArchive.Status.PENDING,
         'checksum': zarr_archive.checksum,
+        'upload_in_progress': False,
+        'file_count': 0,
+        'size': 0,
+    }
+
+
+@pytest.mark.django_db
+def test_zarr_rest_get_invalid_checksum_file(authenticated_api_client, zarr_archive: ZarrArchive):
+    # Write some invalid content into the .checksum file
+    storage = zarr_archive.storage
+    content_file = ContentFile('invalid content'.encode('utf-8'))
+    # save() will never overwrite an existing file, it simply appends some garbage to ensure
+    # uniqueness. _save() is an internal storage API that will overwite existing files.
+    storage._save(ZarrChecksumFileUpdater(zarr_archive=zarr_archive, zarr_directory_path='').checksum_file_path, content_file)
+
+    resp = authenticated_api_client.get(f'/api/zarr/{zarr_archive.zarr_id}/')
+    assert resp.status_code == 200
+    assert resp.json() == {
+        'name': zarr_archive.name,
+        'zarr_id': zarr_archive.zarr_id,
+        'dandiset': zarr_archive.dandiset.identifier,
+        'status': ZarrArchive.Status.PENDING,
+        'checksum': None,
         'upload_in_progress': False,
         'file_count': 0,
         'size': 0,

--- a/dandiapi/api/zarr_checksums.py
+++ b/dandiapi/api/zarr_checksums.py
@@ -226,8 +226,9 @@ class ZarrChecksumUpdater:
     def update_file_checksums(self, checksums: Mapping[str, ZarrChecksum]):
         """
         Update the given checksums.
-        
-        checksums: a mapping of path to the new checksum for that path."""
+
+        checksums: a mapping of path to the new checksum for that path.
+        """
         modifications = ZarrChecksumModificationQueue()
         for path, checksum in checksums.items():
             modifications.queue_file_update(Path(path).parent, checksum)


### PR DESCRIPTION
Currently, if the `.checksum` file is malformed, any API request that
requires the checksum (like `GET /zarr/` or `GET /zarr/{zarr_id}/`)
throws an error 500 because of the validation error. That should be
handled gracefully and `None` returned instead.

Should fix #1004 