### PR TITLE
Fix search bar overflowing offscreen

### DIFF
--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -1,6 +1,6 @@
 <template>
   <v-form
-    style="width: 100vw;"
+    style="width: 100%;"
     @submit="performSearch"
   >
     <v-text-field


### PR DESCRIPTION
Closes #936.

This PR changes the search bar styling to use a percentage-based width instead of viewport-size based width, which prevents it from extending offscreen on the homepage.