### PR TITLE
Add force argument in `ingest_zarr_archive`

### DIFF
--- a/dandiapi/api/management/commands/ingest_dandiset_zarrs.py
+++ b/dandiapi/api/management/commands/ingest_dandiset_zarrs.py
@@ -8,6 +8,6 @@ from dandiapi.api.tasks.zarr import ingest_dandiset_zarrs as _ingest_dandiset_za
 @click.option('--no-checksum', help="Don't recompute checksums", is_flag=True)
 @click.option('--no-size', help="Don't recompute total size", is_flag=True)
 @click.option('--no-count', help="Don't recompute total file count", is_flag=True)
-@click.option('-f', '--force', help="Force re-ingestion", is_flag=True)
+@click.option('-f', '--force', help='Force re-ingestion', is_flag=True)
 def ingest_dandiset_zarrs(dandiset_id: str, **kwargs):
     _ingest_dandiset_zarrs(dandiset_id=int(dandiset_id.lstrip('0')), **kwargs)

--- a/dandiapi/api/management/commands/ingest_dandiset_zarrs.py
+++ b/dandiapi/api/management/commands/ingest_dandiset_zarrs.py
@@ -8,5 +8,6 @@ from dandiapi.api.tasks.zarr import ingest_dandiset_zarrs as _ingest_dandiset_za
 @click.option('--no-checksum', help="Don't recompute checksums", is_flag=True)
 @click.option('--no-size', help="Don't recompute total size", is_flag=True)
 @click.option('--no-count', help="Don't recompute total file count", is_flag=True)
+@click.option('-f', '--force', help="Force re-ingestion", is_flag=True)
 def ingest_dandiset_zarrs(dandiset_id: str, **kwargs):
     _ingest_dandiset_zarrs(dandiset_id=int(dandiset_id.lstrip('0')), **kwargs)

--- a/dandiapi/api/management/commands/ingest_zarr_archive.py
+++ b/dandiapi/api/management/commands/ingest_zarr_archive.py
@@ -8,6 +8,6 @@ from dandiapi.api.tasks.zarr import ingest_zarr_archive as _ingest_zarr_archive
 @click.option('--no-checksum', help="Don't recompute checksums", is_flag=True)
 @click.option('--no-size', help="Don't recompute total size", is_flag=True)
 @click.option('--no-count', help="Don't recompute total file count", is_flag=True)
-@click.option('-f', '--force', help="Force re-ingestion", is_flag=True)
+@click.option('-f', '--force', help='Force re-ingestion', is_flag=True)
 def ingest_zarr_archive(*args, **kwargs):
     _ingest_zarr_archive(*args, **kwargs)

--- a/dandiapi/api/management/commands/ingest_zarr_archive.py
+++ b/dandiapi/api/management/commands/ingest_zarr_archive.py
@@ -8,5 +8,6 @@ from dandiapi.api.tasks.zarr import ingest_zarr_archive as _ingest_zarr_archive
 @click.option('--no-checksum', help="Don't recompute checksums", is_flag=True)
 @click.option('--no-size', help="Don't recompute total size", is_flag=True)
 @click.option('--no-count', help="Don't recompute total file count", is_flag=True)
+@click.option('-f', '--force', help="Force re-ingestion", is_flag=True)
 def ingest_zarr_archive(*args, **kwargs):
     _ingest_zarr_archive(*args, **kwargs)

--- a/dandiapi/api/tasks/zarr.py
+++ b/dandiapi/api/tasks/zarr.py
@@ -144,12 +144,16 @@ class SessionZarrChecksumUpdater(ZarrChecksumUpdater):
 
 @shared_task(queue='ingest_zarr_archive')
 def ingest_zarr_archive(
-    zarr_id: str, no_checksum: bool = False, no_size: bool = False, no_count: bool = False
+    zarr_id: str,
+    no_checksum: bool = False,
+    no_size: bool = False,
+    no_count: bool = False,
+    force: bool = False,
 ):
     # Ensure zarr is in pending state before proceeding
     with transaction.atomic():
         zarr: ZarrArchive = ZarrArchive.objects.select_for_update().get(zarr_id=zarr_id)
-        if zarr.status != ZarrArchive.Status.PENDING:
+        if not force and zarr.status != ZarrArchive.Status.PENDING:
             logger.info(f'{ZarrArchive.INGEST_ERROR_MSG}. Exiting...')
             return
 

--- a/dandiapi/api/tests/test_ingest_zarr_archive.py
+++ b/dandiapi/api/tests/test_ingest_zarr_archive.py
@@ -1,3 +1,4 @@
+import time
 from dandischema.digests.zarr import EMPTY_CHECKSUM
 from guardian.shortcuts import assign_perm
 import pytest
@@ -121,6 +122,32 @@ def test_ingest_zarr_archive(zarr_upload_file_factory, zarr_archive_factory, fak
     zarr.refresh_from_db()
     assert zarr.size == total_size
     assert zarr.file_count == total_file_count
+
+
+@pytest.mark.django_db
+def test_ingest_zarr_archive_force(zarr_upload_file_factory, zarr_archive_factory, faker):
+    zarr: ZarrArchive = zarr_archive_factory()
+    zarr_upload_file_factory(zarr_archive=zarr, path=f'foo/bar/baz.txt')
+
+    # Perform initial ingest
+    ingest_zarr_archive(str(zarr.zarr_id))
+    checksum_updater = ZarrChecksumFileUpdater(zarr, '')
+    checksum = checksum_updater.read_checksum_file()
+    checksum_last_modified = zarr.storage.modified_time(checksum_updater.checksum_file_path)
+    assert checksum is not None
+
+    # Last modified time only has second precision, so sleep for 1 second
+    time.sleep(1)
+
+    # Perform redundant ingest, ensure checksum hasn't changed
+    ingest_zarr_archive(str(zarr.zarr_id))
+    assert checksum_updater.read_checksum_file() == checksum
+    assert zarr.storage.modified_time(checksum_updater.checksum_file_path) == checksum_last_modified
+
+    # Perform ingest with force flag, assert updated
+    ingest_zarr_archive(str(zarr.zarr_id), force=True)
+    assert checksum_updater.read_checksum_file() == checksum
+    assert zarr.storage.modified_time(checksum_updater.checksum_file_path) != checksum_last_modified
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_ingest_zarr_archive.py
+++ b/dandiapi/api/tests/test_ingest_zarr_archive.py
@@ -1,4 +1,5 @@
 import time
+
 from dandischema.digests.zarr import EMPTY_CHECKSUM
 from guardian.shortcuts import assign_perm
 import pytest
@@ -127,7 +128,7 @@ def test_ingest_zarr_archive(zarr_upload_file_factory, zarr_archive_factory, fak
 @pytest.mark.django_db
 def test_ingest_zarr_archive_force(zarr_upload_file_factory, zarr_archive_factory, faker):
     zarr: ZarrArchive = zarr_archive_factory()
-    zarr_upload_file_factory(zarr_archive=zarr, path=f'foo/bar/baz.txt')
+    zarr_upload_file_factory(zarr_archive=zarr, path='foo/bar/baz.txt')
 
     # Perform initial ingest
     ingest_zarr_archive(str(zarr.zarr_id))


### PR DESCRIPTION
Addresses underlying cause of #1004.

@dchiquito Right now, the management command defaults to `force=False`. I'd think most of the time we're using the management command, we'd want to use `force=True`. Do you think we should default `force=True` in the management command? I'm leaning towards yes.

I'm also wondering how we can improve the process of checksum updates. That is, if there is ever a need again to update the checksum format, it'd be good to have some automated process around this, rather than someone needing to manually run a management command. I get the feeling that any automated solution would be overly costly in the average case of not needing to update. @dchiquito any thoughts?