### PR TITLE
Add support for glob/regex filtering on `NestedAsset` list endpoint

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -1305,3 +1305,15 @@ def test_asset_rest_regex_invalid(api_client, version):
     )
 
     assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_asset_rest_glob_regex_together(api_client, version):
+    """Test that including both a glob and regex returns a 400 error."""
+    resp = api_client.get(
+        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/assets/',
+        {'regex': '[0-9].txt', 'glob': '*.txt'},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json() == {'glob': ['Cannot specify both glob and regex']}

--- a/dandiapi/api/views/common.py
+++ b/dandiapi/api/views/common.py
@@ -40,6 +40,13 @@ ASSET_GLOB_PARAM = openapi.Parameter(
     description='Glob pattern to filter asset paths with.',
 )
 
+ASSET_REGEX_PARAM = openapi.Parameter(
+    'regex',
+    openapi.IN_QUERY,
+    type=openapi.TYPE_STRING,
+    description='Regex pattern to filter asset paths with.',
+)
+
 VERSION_PARAM = openapi.Parameter(
     'version',
     openapi.IN_PATH,

--- a/dandiapi/api/views/common.py
+++ b/dandiapi/api/views/common.py
@@ -33,6 +33,13 @@ DANDISET_PK_PARAM = openapi.Parameter(
 
 PATH_PREFIX_PARAM = openapi.Parameter('path_prefix', openapi.IN_QUERY, type=openapi.TYPE_STRING)
 
+ASSET_GLOB_PARAM = openapi.Parameter(
+    'glob',
+    openapi.IN_QUERY,
+    type=openapi.TYPE_STRING,
+    description='Glob pattern to filter asset paths with.',
+)
+
 VERSION_PARAM = openapi.Parameter(
     'version',
     openapi.IN_PATH,

--- a/dandiapi/api/views/common.py
+++ b/dandiapi/api/views/common.py
@@ -33,20 +33,6 @@ DANDISET_PK_PARAM = openapi.Parameter(
 
 PATH_PREFIX_PARAM = openapi.Parameter('path_prefix', openapi.IN_QUERY, type=openapi.TYPE_STRING)
 
-ASSET_GLOB_PARAM = openapi.Parameter(
-    'glob',
-    openapi.IN_QUERY,
-    type=openapi.TYPE_STRING,
-    description='Glob pattern to filter asset paths with.',
-)
-
-ASSET_REGEX_PARAM = openapi.Parameter(
-    'regex',
-    openapi.IN_QUERY,
-    type=openapi.TYPE_STRING,
-    description='Regex pattern to filter asset paths with.',
-)
-
 VERSION_PARAM = openapi.Parameter(
     'version',
     openapi.IN_PATH,

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -197,3 +197,8 @@ class AssetPathsQueryParameterSerializer(serializers.Serializer):
     path_prefix = serializers.CharField(default='')
     page = serializers.IntegerField(default=1)
     page_size = serializers.IntegerField(default=DandiPagination.page_size)
+
+
+class AssetListSerializer(serializers.Serializer):
+    glob = serializers.CharField(required=False)
+    regex = serializers.CharField(required=False)

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -202,3 +202,10 @@ class AssetPathsQueryParameterSerializer(serializers.Serializer):
 class AssetListSerializer(serializers.Serializer):
     glob = serializers.CharField(required=False)
     regex = serializers.CharField(required=False)
+
+    def validate(self, attrs):
+        if 'glob' in attrs and 'regex' in attrs:
+            raise serializers.ValidationError(
+                {'glob': 'Cannot specify both glob and regex'},
+            )
+        return super().validate(attrs)


### PR DESCRIPTION
Closes #1002.

Note that Postgres doesn't support querying with globs, but it does support querying with a regex. So, the approach I've taken to support globbing here is to convert the glob pattern to a regex pattern and then use that in the query. Python has a built-in function (`fnmatch.translate`) that converts a glob expression to a regex, but the regex syntax it uses is incompatible with Postgres's regex syntax. I found [this 81-line library](https://github.com/Salamek/glob2regex) that does work with Postgres, so I've used that here.