### PR TITLE
Select all underlying asset storage fields in asset paths endpoint

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -527,6 +527,8 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         qs = (
             self.get_queryset()
             .select_related('blob')
+            .select_related('embargoed_blob')
+            .select_related('zarr')
             .filter(path__startswith=path_prefix)
             .order_by('path')
         )


### PR DESCRIPTION
This addresses the unnecessarily slow behavior that's partially to blame for this issue: https://github.com/dandi/dandi-api-webshots-tools/issues/14.

Zarr and embargoed asset blobs weren't being selected along with the asset itself for the paths queryset. This resulted in sequential database calls for each asset, drastically increasing request time.