### PR TITLE
Fix disabled Heroku Github integration for staging and production deployment

### DIFF
--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -1,0 +1,19 @@
+name: Trigger production deploy of backend server on push to release
+
+on:
+  push:
+    branches:
+      - release
+    paths-ignore:
+      - "web/**"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "dandi-api"
+          heroku_email: ${{secrets.HEROKU_EMAIL}}

--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -1,0 +1,19 @@
+name: Trigger staging deploy of backend server on push to master
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "web/**"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "dandi-api-staging"
+          heroku_email: ${{secrets.HEROKU_EMAIL}}


### PR DESCRIPTION
This is a temporary fix to address a recent [Heroku Incident](https://status.heroku.com/incidents/2413), which resulted in Heroku disabled Heroku Github integration for all Heroku applications. This requires us to temporarily add back a Heroku CLI based deployment mechanism, until Github integration is restored.