### PR TITLE
Add actions workflow to auto-add issues to beta project board

### DIFF
--- a/.github/workflows/auto-add-issues.yml
+++ b/.github/workflows/auto-add-issues.yml
@@ -1,0 +1,17 @@
+name: Add issues to beta project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.0.3
+        with:
+          project-url: https://github.com/orgs/dandi/projects/16
+          github-token: ${{ secrets.AUTO_ADD_ISSUES }}


### PR DESCRIPTION
See [the new action](https://github.com/marketplace/actions/add-to-github-projects-beta) for doing this.