### PR TITLE
Fix incorrect fields in info endpoint

### DIFF
--- a/dandiapi/api/tests/test_info.py
+++ b/dandiapi/api/tests/test_info.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+import versioneer
+
+from dandiapi.api.views.info import schema_url
+
+
+def test_rest_info(api_client):
+    resp = api_client.get('/api/info/')
+    assert resp.status_code == 200
+    assert resp.json() == {
+        'schema_version': settings.DANDI_SCHEMA_VERSION,
+        'schema_url': schema_url,
+        'version': versioneer.get_version(),
+        'cli-minimal-version': '0.14.2',
+        'cli-bad-versions': [],
+        'services': {
+            'api': {'url': settings.DANDI_API_URL},
+            'webui': {'url': settings.DANDI_WEB_APP_URL},
+            'jupyterhub': {'url': settings.DANDI_JUPYTERHUB_URL},
+        },
+    }

--- a/dandiapi/api/tests/test_info.py
+++ b/dandiapi/api/tests/test_info.py
@@ -1,7 +1,7 @@
 from django.conf import settings
-import versioneer
 
 from dandiapi.api.views.info import schema_url
+import versioneer
 
 
 def test_rest_info(api_client):

--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -23,14 +23,23 @@ class ApiServicesSerializer(serializers.Serializer):
 
 
 class ApiInfoSerializer(serializers.Serializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Need to add fields here to allow for hyphens in name
+        self.fields.update(
+            {
+                'cli-minimal-version': serializers.CharField(),
+                'cli-bad-versions': serializers.ListField(child=serializers.CharField()),
+            }
+        )
+
     # Schema
     schema_version = serializers.CharField()
     schema_url = serializers.URLField()
 
     # Versions
     version = serializers.CharField()
-    cli_minimal_version = serializers.CharField()
-    cli_bad_versions = serializers.ListField(child=serializers.CharField())
 
     # Services
     services = ApiServicesSerializer()
@@ -48,8 +57,8 @@ def info_view(self):
             'schema_version': settings.DANDI_SCHEMA_VERSION,
             'schema_url': schema_url,
             'version': versioneer.get_version(),
-            'cli_minimal_version': '0.14.2',
-            'cli_bad_versions': [],
+            'cli-minimal-version': '0.14.2',
+            'cli-bad-versions': [],
             'services': {
                 'api': {'url': settings.DANDI_API_URL},
                 'webui': {'url': settings.DANDI_WEB_APP_URL},

--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -26,7 +26,9 @@ class ApiInfoSerializer(serializers.Serializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Need to add fields here to allow for hyphens in name
+        # Need to add fields here to allow for hyphens in name.
+        # dandi-cli expects these exact field names (with hyphens), so
+        # these fields must remain unchanged.
         self.fields.update(
             {
                 'cli-minimal-version': serializers.CharField(),

--- a/dev/.env.docker-compose
+++ b/dev/.env.docker-compose
@@ -10,4 +10,4 @@ DJANGO_DANDI_DANDISETS_BUCKET_NAME=dandi-dandisets
 DJANGO_DANDI_DANDISETS_EMBARGO_BUCKET_NAME=dandi-embargo-dandisets
 DJANGO_DANDI_WEB_APP_URL=http://localhost:8085
 DJANGO_DANDI_API_URL=http://localhost:8000
-DANDI_JUPYTERHUB_URL=https://hub.dandiarchive.org/
+DJANGO_DANDI_JUPYTERHUB_URL=https://hub.dandiarchive.org/

--- a/dev/.env.docker-compose-native
+++ b/dev/.env.docker-compose-native
@@ -9,4 +9,4 @@ DJANGO_DANDI_DANDISETS_BUCKET_NAME=dandi-dandisets
 DJANGO_DANDI_DANDISETS_EMBARGO_BUCKET_NAME=dandi-embargo-dandisets
 DJANGO_DANDI_WEB_APP_URL=http://localhost:8085
 DJANGO_DANDI_API_URL=http://localhost:8000
-DANDI_JUPYTERHUB_URL=https://hub.dandiarchive.org/
+DJANGO_DANDI_JUPYTERHUB_URL=https://hub.dandiarchive.org/


### PR DESCRIPTION
Closes #1044

The test is pretty barebones but will ensure tests fail if the endpoint structure is modified.

This also fixes a typo in the `DJANGO_DANDI_JUPYTERHUB_URL` env var in `dev/.env.docker-compose` and `dev/.env.docker-compose-native`.