### PR TITLE
Add configuration for deploy previews to `netlify.toml`

### DIFF
--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -11,6 +11,15 @@ VUE_APP_DANDI_API_ROOT = "https://api-staging.dandiarchive.org/api/"
 VUE_APP_SENTRY_DSN = "https://425b9a012300493d867e97785fae7b88@o308436.ingest.sentry.io/5196549"
 VUE_APP_SENTRY_ENVIRONMENT = "staging"
 
+# Deploy previews
+[context.deploy-preview.environment]
+NODE_VERSION = "16" # Netlify defaults to node.js 10, but @types/node requires a more recent version
+VUE_APP_OAUTH_API_ROOT = "https://api-staging.dandiarchive.org/oauth/"
+VUE_APP_OAUTH_CLIENT_ID = "Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl"
+VUE_APP_DANDI_API_ROOT = "https://api-staging.dandiarchive.org/api/"
+VUE_APP_SENTRY_DSN = "https://425b9a012300493d867e97785fae7b88@o308436.ingest.sentry.io/5196549"
+VUE_APP_SENTRY_ENVIRONMENT = "staging"
+
 # Production
 [context.release.environment]
 NODE_VERSION = "16" # Netlify defaults to node.js 10, but @types/node requires a more recent version


### PR DESCRIPTION
Deploy previews are currently failing because their environment variables are not being set properly. https://app.netlify.com/sites/gui-staging-dandiarchive-org/deploys/6260642d8016f900092a15b1

I've created a seperate entry in `netlify.toml` for deploy previews like they have [in the docs](https://docs.netlify.com/configure-builds/file-based-configuration/)