### PR TITLE
Pin django-oauth-toolkit to 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'django-extensions',
         'django-filter',
         'django-guardian',
-        'django-oauth-toolkit',
+        'django-oauth-toolkit>=1.7,<2',
         'djangorestframework',
         'djangorestframework-yaml',
         'drf-extensions',


### PR DESCRIPTION
The upgrade to 2.0.0 caused the check-migrations test to fail since one of the breaking changes was to change the DB schema. I'm pinning this to 1.x now to prevent breakage in production, but this opens up two issues:
1. If we're pinning this to major versions, we should pin all our dependencies to major versions as well.
2. If we do *that*, then we need to discuss a procedure for keeping up on major version changes so that we can do the work of upgrading when warranted.

Thoughts on the above welcome.