### PR TITLE
Add *ZarrArchive sizes into total_size

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -298,11 +298,15 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
     @classmethod
     def total_size(cls):
         # delayed import to avoid present imports circularity
-        from .zarr import ZarrArchive, EmbargoedZarrArchive
+        from .zarr import ZarrArchive
+
         return sum(
             cls.objects.filter(assets__versions__isnull=False)
             .distinct()
             .aggregate(size=models.Sum('size'))['size']
             or 0
-            for cls in (AssetBlob, EmbargoedAssetBlob, ZarrArchive, EmbargoedZarrArchive)
+            for cls in (AssetBlob, EmbargoedAssetBlob, ZarrArchive)
+            # adding of Zarrs to embargoed dandisets is not supported
+            # so no point of adding EmbargoedZarr here since would also result in error
+            # TODO: add EmbagoedZarr whenever supported
         )

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -297,14 +297,10 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
 
     @classmethod
     def total_size(cls):
-        return (
-            AssetBlob.objects.filter(assets__versions__isnull=False)
+        return sum(
+            cls.objects.filter(assets__versions__isnull=False)
             .distinct()
             .aggregate(size=models.Sum('size'))['size']
             or 0
-        ) + (
-            EmbargoedAssetBlob.objects.filter(assets__versions__isnull=False)
-            .distinct()
-            .aggregate(size=models.Sum('size'))['size']
-            or 0
+            for cls in (AssetBlob, EmbargoedAssetBlob)
         )

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -297,10 +297,12 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
 
     @classmethod
     def total_size(cls):
+        # delayed import to avoid present imports circularity
+        from .zarr import ZarrArchive, EmbargoedZarrArchive
         return sum(
             cls.objects.filter(assets__versions__isnull=False)
             .distinct()
             .aggregate(size=models.Sum('size'))['size']
             or 0
-            for cls in (AssetBlob, EmbargoedAssetBlob)
+            for cls in (AssetBlob, EmbargoedAssetBlob, ZarrArchive, EmbargoedZarrArchive)
         )

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -231,13 +231,16 @@ def test_asset_total_size(
     zarr_archive = zarr_archive_factory()
     # give it some size
     zarr_archive.size = 100
-    zarr_archive.save() # save adjusted .size into DB
+    zarr_archive.save()  # save adjusted .size into DB
 
     # adding of an asset with zarr should be reflected
     asset3 = asset_factory(zarr=zarr_archive, blob=None)
     version2.assets.add(asset3)
 
     assert Asset.total_size() == asset_blob.size + zarr_archive.size
+
+    # TODO: add testing for embargoed zar added, whenever embargoed zarrs
+    # supported, ATM they are not and tested by test_zarr_rest_create_embargoed_dandiset
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
If is completed, Closes #1076 

- first commit is a basic RF, worth adopting if the rest not
- follow up commit implements tentative solution
- last commit provides an attempt at establishing a test but I am not sure how to augment draft asset factory so it would allow for assetblob **or** zarrfile

TODOs
- [x] fixup/extend testing