### PR TITLE
Extend docs with information about devel env

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,7 +54,7 @@ but allows developers to run Python code on their native system.
    2. `./manage.py runserver`
 3. Run in a separate terminal:
    1. `source ./dev/export-env.sh`
-   2. `celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat -Q celery,calculate_sha256 -B`
+   2. `celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat -Q celery,calculate_sha256,ingest_zarr_archive -B`
 4. When finished, run `docker-compose stop`
 
 ## Remap Service Ports (optional)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,6 +103,11 @@ Useful sub-commands include:
 To automatically reformat all code to comply with
 some (but not all) of the style checks, run `tox -e format`.
 
+## dandiarchive.org WEB Interface
+
+This repository now also contains sources for the web interface under [web/](./web/) folder.
+If you would like to develop it locally, please see [web/README.md](./web/README.md) file for instructions.
+
 ## API Authentication
 Read-only API endpoints (i.e. `GET`, `HEAD`) do not require any
 authentication. All other endpoints require token authentication

--- a/web/README.md
+++ b/web/README.md
@@ -12,6 +12,9 @@ yarn install
 yarn run serve
 ```
 
+**Note**: on Debian systems `yarn` command is from unrelated `cmdtest` package.
+Install and use (instead of `yarn`) `yarnpkg` instead.
+
 The web app will be served at `http://localhost:8085/`.
 
 This app requires a server component to be useful, which you can run locally; see the [instructions](https://github.com/dandi/dandi-archive/#dandi-archive)) for doing so.


### PR DESCRIPTION
From my experience while trying to make it running locally
on my Debian OS laptop

Minimal changes. If anyone wants to expand -- please suggest the diffs. 