### PR TITLE
BF DOC(incomplete): /zarr/.../ingest has 204 not 200 response

### DIFF
--- a/dandiapi/api/views/zarr.py
+++ b/dandiapi/api/views/zarr.py
@@ -261,7 +261,8 @@ class ZarrViewSet(ReadOnlyModelViewSet):
         method='POST',
         request_body=no_body,
         responses={
-            200: ZarrSerializer(many=True),
+            # Note: Having proper None results in no documentation in /swagger
+            204: 'None - expected normal return without any content',
             400: ZarrArchive.INGEST_ERROR_MSG,
         },
         operation_summary='Ingest a zarr archive, calculating checksums, size and file count.',


### PR DESCRIPTION
Unfortunately it is no a complete fix, since for 400 there could be 2
possible responses, but only one is documented.  I did not find a way to
document both as possible valid choices, but may be it should be a different
from 400 for upload_in_progress anyways?

Also for 204 -- not sure what was motivation for using that reponse
instead of 200 with some message such as "Dispatched ingestion" to inform user
that all is good etc.  But probably such discussion is worth another issue/PR