### PR TITLE
Fix opening Meditor when clicking on "Fix Issues" in the list of dandiset metadata issues

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -421,18 +421,6 @@ export default defineComponent({
       () => !!(!publishButtonDisabled.value && user.value?.admin && !isOwner.value),
     );
 
-    const meditorLink: ComputedRef<Location|null> = computed(() => {
-      if (!currentDandiset.value) {
-        return null;
-      }
-      const version: string = currentVersion.value;
-      const { identifier } = currentDandiset.value.dandiset;
-      return {
-        name: 'metadata',
-        params: { identifier, version },
-      } as Location;
-    });
-
     const showPublishWarningDialog = ref(false);
 
     function formatDate(date: string): string {
@@ -489,7 +477,6 @@ export default defineComponent({
       publishDisabledMessage,
       publishButtonDisabled,
       publishButtonHidden,
-      meditorLink,
       getValidationErrorIcon,
       publish,
       draftVersion,

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -168,7 +168,7 @@
           <v-btn
             v-if="isOwner"
             color="primary"
-            :to="meditorLink"
+            @click="openMeditor = true"
           >
             Fix issues
           </v-btn>
@@ -318,6 +318,7 @@ import { User, Version } from '@/types';
 
 import { draftVersion, VALIDATION_ICONS } from '@/utils/constants';
 import { Location, RawLocation } from 'vue-router';
+import { open as openMeditor } from '@/components/Meditor/state';
 
 function getValidationErrorIcon(errorField: string): string {
   const icons = Object.keys(VALIDATION_ICONS).filter((field) => errorField.includes(field));
@@ -495,6 +496,7 @@ export default defineComponent({
       showPublishWarning,
       showPublishWarningDialog,
       isOwner,
+      openMeditor,
     };
   },
 });

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -317,7 +317,7 @@ import router from '@/router';
 import { User, Version } from '@/types';
 
 import { draftVersion, VALIDATION_ICONS } from '@/utils/constants';
-import { Location, RawLocation } from 'vue-router';
+import { RawLocation } from 'vue-router';
 import { open as openMeditor } from '@/components/Meditor/state';
 
 function getValidationErrorIcon(errorField: string): string {


### PR DESCRIPTION
opening Meditor when clinging "FIX ISSUES".
fixes #950

@yarikoptic - see if this is what you wanted. I used `openMeditor` instead of `meditorLink`. I'm pretty sure there was soe idea behind it, so don't know if I should remove it completely