### PR TITLE
BF: add "needs" dependency within update-release-branch

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -21,6 +21,7 @@ jobs:
 
   production-deploy:
     runs-on: ubuntu-latest
+    needs: reset-release-branch
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
production-deploy relies on release branch update in reset-release-branch.
By default jobs run in parallel according to
https://docs.github.com/en/enterprise-server@3.3/actions/using-jobs/using-jobs-in-a-workflow
so such running out of order might be the reason for incorrect tags etc as reported
in https://github.com/dandi/dandi-archive/issues/1089 or even simply "missed"
main deployment as we have recently observed.

This is not a complete fix to #1089 since that one concerns also with
staging and this is only about release

requested review, but might not wait too long to try it by merging ;)