### PR TITLE
BF: provide custom commit message without token to skip the beat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          ~/auto shipit
+          ~/auto shipit --message="auto shipit - CHANGELOG.md etc"


### PR DESCRIPTION
this is a suspect for why we lacked deployment releases and possibly for
some commits off in the staging as well

ref: https://github.com/dandi/dandi-archive/issues/1100#issuecomment-1125119989 

