### PR TITLE
BF: populate repository field for asset + strip for asset and version

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -191,12 +191,12 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
             s3_url = self.embargoed_blob.s3_url
         else:
             s3_url = self.zarr.s3_url
-
         metadata = {
             **self.metadata,
             'id': f'dandiasset:{self.asset_id}',
             'path': self.path,
             'identifier': str(self.asset_id),
+            'repository': settings.DANDI_WEB_APP_URL,
             'contentUrl': [download_url, s3_url],
             'contentSize': self.size,
             'digest': self.digest,
@@ -289,6 +289,7 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
             'digest',
             'datePublished',
             'publishedBy',
+            'repository',
         ]
         return {key: metadata[key] for key in metadata if key not in computed_fields}
 

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -193,13 +193,13 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
             s3_url = self.zarr.s3_url
         metadata = {
             **self.metadata,
-            'id': f'dandiasset:{self.asset_id}',
-            'path': self.path,
-            'identifier': str(self.asset_id),
-            'repository': settings.DANDI_WEB_APP_URL,
-            'contentUrl': [download_url, s3_url],
             'contentSize': self.size,
+            'contentUrl': [download_url, s3_url],
             'digest': self.digest,
+            'id': f'dandiasset:{self.asset_id}',
+            'identifier': str(self.asset_id),
+            'path': self.path,
+            'repository': settings.DANDI_WEB_APP_URL,
         }
         if 'schemaVersion' in metadata:
             schema_version = metadata['schemaVersion']
@@ -281,13 +281,13 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
     def strip_metadata(cls, metadata):
         """Strip away computed fields from a metadata dict."""
         computed_fields = [
-            'id',
-            'path',
-            'identifier',
-            'contentUrl',
             'contentSize',
-            'digest',
+            'contentUrl',
             'datePublished',
+            'digest',
+            'id',
+            'identifier',
+            'path',
             'publishedBy',
             'repository',
         ]

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -188,19 +188,19 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
     def strip_metadata(cls, metadata):
         """Strip away computed fields from a metadata dict."""
         computed_fields = [
-            'name',
-            'identifier',
-            'version',
-            'id',
-            'url',
             'assetsSummary',
             'citation',
-            'doi',
             'dateCreated',
             'datePublished',
-            'publishedBy',
+            'doi',
+            'id',
+            'identifier',
             'manifestLocation',
-            'repository'
+            'name',
+            'publishedBy',
+            'repository',
+            'url',
+            'version',
         ]
         return {key: metadata[key] for key in metadata if key not in computed_fields}
 
@@ -235,15 +235,15 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
 
         metadata = {
             **self.metadata,
-            'manifestLocation': manifest_location(self),
-            'name': self.name,
-            'identifier': f'DANDI:{self.dandiset.identifier}',
-            'version': self.version,
-            'id': f'DANDI:{self.dandiset.identifier}/{self.version}',
-            'repository': settings.DANDI_WEB_APP_URL,
-            'url': f'{settings.DANDI_WEB_APP_URL}/dandiset/{self.dandiset.identifier}/{self.version}',  # noqa
             'assetsSummary': summary,
             'dateCreated': self.dandiset.created.isoformat(),
+            'id': f'DANDI:{self.dandiset.identifier}/{self.version}',
+            'identifier': f'DANDI:{self.dandiset.identifier}',
+            'manifestLocation': manifest_location(self),
+            'name': self.name,
+            'repository': settings.DANDI_WEB_APP_URL,
+            'url': f'{settings.DANDI_WEB_APP_URL}/dandiset/{self.dandiset.identifier}/{self.version}',  # noqa
+            'version': self.version,
         }
         if self.doi:
             metadata['doi'] = self.doi

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -200,6 +200,7 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
             'datePublished',
             'publishedBy',
             'manifestLocation',
+            'repository'
         ]
         return {key: metadata[key] for key in metadata if key not in computed_fields}
 

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -260,13 +260,13 @@ def test_asset_populate_metadata(draft_asset_factory):
     blob_url = asset.blob.s3_url
     assert asset.metadata == {
         **raw_metadata,
-        'id': f'dandiasset:{asset.asset_id}',
-        'path': asset.path,
-        'identifier': str(asset.asset_id),
-        'contentUrl': [download_url, blob_url],
-        'contentSize': asset.blob.size,
-        'digest': asset.blob.digest,
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+        'contentSize': asset.blob.size,
+        'contentUrl': [download_url, blob_url],
+        'digest': asset.blob.digest,
+        'id': f'dandiasset:{asset.asset_id}',
+        'identifier': str(asset.asset_id),
+        'path': asset.path,
         'repository': settings.DANDI_WEB_APP_URL,
     }
 
@@ -288,15 +288,15 @@ def test_asset_populate_metadata_zarr(draft_asset_factory, zarr_archive):
     s3_url = f'http://{settings.MINIO_STORAGE_ENDPOINT}/test-dandiapi-dandisets/test-prefix/test-zarr/{zarr_archive.zarr_id}/'  # noqa: E501
     assert asset.metadata == {
         **raw_metadata,
-        'id': f'dandiasset:{asset.asset_id}',
-        'path': asset.path,
-        'identifier': str(asset.asset_id),
-        'contentUrl': [download_url, s3_url],
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'contentSize': asset.size,
+        'contentUrl': [download_url, s3_url],
         'digest': asset.digest,
         # This should be injected on all zarr assets
         'encodingFormat': 'application/x-zarr',
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+        'id': f'dandiasset:{asset.asset_id}',
+        'identifier': str(asset.asset_id),
+        'path': asset.path,
         'repository': settings.DANDI_WEB_APP_URL,
     }
 

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -267,6 +267,7 @@ def test_asset_populate_metadata(draft_asset_factory):
         'contentSize': asset.blob.size,
         'digest': asset.blob.digest,
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+        'repository': settings.DANDI_WEB_APP_URL,
     }
 
 
@@ -296,6 +297,7 @@ def test_asset_populate_metadata_zarr(draft_asset_factory, zarr_archive):
         # This should be injected on all zarr assets
         'encodingFormat': 'application/x-zarr',
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+        'repository': settings.DANDI_WEB_APP_URL,
     }
 
 


### PR DESCRIPTION
Since that field is "computed" (or populated) lets make it explicitly
populated and stripped.  dandimodel does default atm to one
which should correspond but it seems might fail.

Hopefully this fixes #1081 . First I will try to reproduce on current staging, and then see if this addresses it...