### PR TITLE
ENH: increase page size from 25 to 100

### DIFF
--- a/dandiapi/api/views/common.py
+++ b/dandiapi/api/views/common.py
@@ -5,7 +5,7 @@ max_page_size = 1000
 
 
 class DandiPagination(PageNumberPagination):
-    page_size = 25
+    page_size = 100
     max_page_size = max_page_size
     page_size_query_param = 'page_size'
 


### PR DESCRIPTION
Should result in x4 fold reduction of logs from such requests,
speed up client interactions etc.

Motivation: https://github.com/dandi/dandi-cli/issues/1018

edit 1: possible "visible" side effect is 100 assets to be displayed per page in file navigator per dandiset. Might be considered pros or cons