### PR TITLE
Properly include "data packages" in project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 readme_file = Path(__file__).parent / 'README.md'
 if readme_file.exists():
@@ -35,7 +35,7 @@ setup(
         'Programming Language :: Python',
     ],
     python_requires='>=3.9',
-    packages=find_packages(),
+    packages=find_namespace_packages(include=["dandiapi*"]),
     include_package_data=True,
     install_requires=[
         'celery',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'Programming Language :: Python',
     ],
     python_requires='>=3.9',
-    packages=find_namespace_packages(include=["dandiapi*"]),
+    packages=find_namespace_packages(include=['dandiapi*']),
     include_package_data=True,
     install_requires=[
         'celery',


### PR DESCRIPTION
There are several folders in `dandiapi/` that contain data files but no Python source code, and we want these to be included when dandiapi is installed.  Currently, these folders are automatically included by the combination of `graft dandiapi` in `MANIFEST.in` and `include_package_data=True` in `setup.py`, but because we set `packages` in `setup.py` to `find_packages()` instead of `find_namespace_packages()`, the folders themselves are not recognized by setuptools as packages.  [This combination of settings is deprecated](https://github.com/pypa/setuptools/issues/3340), and the setuptools developers recommend using `find_namespace_packages()` instead of `find_packages()` for such situations.