### PR TITLE
Use QuerySet.iterator in asset paths endpoint

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -565,9 +565,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
 
         qs: QuerySet[Asset] = (
             self.get_queryset()
-            .select_related('blob')
-            .select_related('embargoed_blob')
-            .select_related('zarr')
+            .select_related('blob', 'embargoed_blob', 'zarr')
             .filter(path__startswith=path_prefix)
             .order_by('path')
         )

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -18,6 +18,7 @@ from urllib.parse import urlencode
 
 from django.core.paginator import EmptyPage, Page, Paginator
 from django.db import transaction
+from django.db.models import QuerySet
 from django.http import HttpResponseRedirect
 from django.http.response import Http404
 from django.urls import reverse
@@ -562,7 +563,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         page: int = query_serializer.validated_data['page']
         page_size: int = query_serializer.validated_data['page_size']
 
-        qs = (
+        qs: QuerySet[Asset] = (
             self.get_queryset()
             .select_related('blob')
             .select_related('embargoed_blob')
@@ -574,7 +575,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         folders: dict[str, dict] = {}
         files: dict[str, Asset] = {}
 
-        for asset in qs:
+        for asset in qs.iterator():
             # Get the remainder of the path after path_prefix
             base_path: str = asset.path[len(path_prefix) :].strip('/')
 


### PR DESCRIPTION
When iterating over large querysets, using `[QuerySet.iterator](https://docs.djangoproject.com/en/4.0/ref/models/querysets/#iterator)` is more memory-efficient. This may mitigate or solve the OOM errors with dandiset 26.