### PR TITLE
Add timeout to gunicorn in heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 release: ./manage.py migrate
-web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi
+web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi --timeout 25
 # celery-beat: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery beat --loglevel INFO
 # Rather than using a dedicated worker for Celery Beat, we simply use the -B option on the priority task worker.
 # This means that we cannot safely scale up the number of priority-workers without Celery Beat triggering multiple events.


### PR DESCRIPTION
Downstreaming https://github.com/girder/cookiecutter-girder-4/pull/190 from the cookiecutter.

This will help distinguish Heroku request timeouts from other errors that cause a `SystemExit` in sentry.