### PR TITLE
Optimize dandiset list endpoint

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -155,13 +155,6 @@ def test_dandiset_versions(
                 'status': 'Pending',
                 'created': TIMESTAMP_RE,
                 'modified': TIMESTAMP_RE,
-                'dandiset': {
-                    'identifier': dandiset.identifier,
-                    'created': TIMESTAMP_RE,
-                    'modified': TIMESTAMP_RE,
-                    'contact_person': contact_person,
-                    'embargo_status': 'OPEN',
-                },
             }
             if draft_version is not None
             else None,
@@ -173,13 +166,6 @@ def test_dandiset_versions(
                 'status': 'Pending',
                 'created': TIMESTAMP_RE,
                 'modified': TIMESTAMP_RE,
-                'dandiset': {
-                    'identifier': dandiset.identifier,
-                    'created': TIMESTAMP_RE,
-                    'modified': TIMESTAMP_RE,
-                    'contact_person': contact_person,
-                    'embargo_status': 'OPEN',
-                },
             }
             if published_version is not None
             else None,

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -161,7 +161,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         responses={200: DandisetListSerializer(many=True)},
     )
     def list(self, request, *args, **kwargs):
-        qs = self.get_queryset().annotate()
+        qs = self.get_queryset()
         dandisets = self.paginate_queryset(self.filter_queryset(qs))
 
         # Query versions, to supply num/count of assets.
@@ -187,7 +187,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         # see all drafts first, then any published. Once we have seen both one draft
         # and one published, we're done for that dandiset.
         dandisets_to_versions = {}
-        for version in versions:
+        for version in versions.iterator():
             version: Version
 
             if version.dandiset_id not in dandisets_to_versions:

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -5,7 +5,7 @@ from dandischema.models import Dandiset as PydanticDandiset
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Count, OuterRef, Subquery, Sum
+from django.db.models import Count, OuterRef, Subquery, Sum, F
 from django.db.models.functions import Coalesce
 from django.db.utils import IntegrityError
 from django.http import Http404
@@ -164,28 +164,39 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         qs = self.get_queryset()
         dandisets = self.paginate_queryset(self.filter_queryset(qs))
 
-        # Query versions, to supply num/count of assets.
-        # Ideally we'd use `distinct('dandiset_id')` to limit the
-        # amount of published versions returned, but we can't use that with `annotate`.
-        versions = (
+        # Query versions, to supply size/count of assets.
+        base_query = (
             Version.objects.select_related('dandiset')
             .annotate(
+                num_assets=Count('assets'),
                 total_size=(
                     Coalesce(Sum('assets__blob__size'), 0)
                     + Coalesce(Sum('assets__embargoed_blob__size'), 0)
                     + Coalesce(Sum('assets__zarr__size'), 0)
                 ),
-                num_assets=Count('assets'),
             )
             .filter(dandiset__in=dandisets)
             .order_by('-version', '-modified')
         )
 
-        # Determine draft and most recently published for each dandiset.
-        #
-        # Since ordering is version descending, then modified descending, we will
-        # see all drafts first, then any published. Once we have seen both one draft
-        # and one published, we're done for that dandiset.
+        latest_dandiset_version = (
+            Version.objects.exclude(version='draft')
+            .order_by('-version')
+            .filter(dandiset_id=OuterRef('dandiset_id'))
+            .values('version')[:1]
+        )
+        published = (
+            base_query.exclude(version='draft')
+            .alias(latest=Subquery(latest_dandiset_version))
+            .filter(version=F('latest'))
+        )
+        drafts = base_query.filter(version='draft')
+
+        # Union with drafts
+        versions = published.union(drafts).order_by('dandiset_id', '-version')
+
+        # Organize draft and most recently published for each dandiset.
+        # Because of above query, a max of 1 of each (per dandiset) will be present.
         dandisets_to_versions = {}
         for version in versions.iterator():
             version: Version

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -5,7 +5,7 @@ from dandischema.models import Dandiset as PydanticDandiset
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Count, OuterRef, Subquery, Sum, F
+from django.db.models import Count, F, OuterRef, Subquery, Sum
 from django.db.models.functions import Coalesce
 from django.db.utils import IntegrityError
 from django.http import Http404

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -114,6 +114,7 @@ class DandiMixin(ConfigMixin):
 class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
     # This makes pydantic model schema allow URLs with localhost in them.
     DANDI_ALLOW_LOCALHOST_URLS = True
+    SHELL_PLUS_PRINT_SQL_TRUNCATE = None
 
 
 class TestingConfiguration(DandiMixin, TestingBaseConfiguration):

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -49,7 +49,7 @@
 
           DANDI:<b>{{ item.dandiset.identifier }}</b>
           ·
-          Contact <b>{{ item.contact_person }}</b>
+          Contact <b>{{ item.dandiset.contact_person }}</b>
           ·
           Updated on <b>{{ formatDate(item.modified) }}</b>
           ·

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -96,6 +96,8 @@
 import {
   defineComponent, ref, computed, watch, Ref, watchEffect,
 } from '@vue/composition-api';
+
+import omit from 'lodash/omit';
 import DandisetList from '@/components/DandisetList.vue';
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
 import { dandiRest } from '@/rest';
@@ -176,7 +178,7 @@ export default defineComponent({
 
     const dandisets = computed(() => djangoDandisetRequest.value?.results.map((dandiset) => ({
       ...(dandiset.most_recent_published_version || dandiset.draft_version),
-      contact_person: dandiset.contact_person,
+      dandiset: omit(dandiset, 'most_recent_published_version', 'draft_version'),
     })));
 
     const pages = computed(() => {


### PR DESCRIPTION
Closes #1132

Previously, this endpoint was making heavy use of model properties in the `Dandiset` and `Version` models, in order to populate various computed / annotated fields. This caused many repeated queries (~900 SQL queries for ~350 dandisets, so around 2.5 queries per dandiset).

I've consolidated this aggregation into both a larger SQL query, and some manual aggregation in python. After this change, there are only 3 SQL queries being made by this endpoint (out of the 5 or 6 total queries you might see in the Django Debug Toolbar).

Looking back, much of this was caused by rampant use of Django model properties. I think in the future we should discourage this pattern, as it leads to lots of repeated queries (for not all that much abstraction).