### PR TITLE
Optimize loop in checksum task

### DIFF
--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -42,6 +42,8 @@ def calculate_sha256(blob_id: int) -> None:
     asset_blob.save()
 
     # The newly calculated sha256 digest will be included in the metadata, so we need to revalidate
+    # Note, we use `.iterator` here and delay each validation as a new task in order to keep memory
+    # usage down.
     for asset in asset_blob.assets.values('id').iterator():
         # Note: while asset metadata is fairly lightweight compute-wise, memory-wise it can become
         # an issue during serialization/deserialization of the JSON blob by pydantic. Therefore,

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -42,9 +42,9 @@ def calculate_sha256(blob_id: int) -> None:
     asset_blob.save()
 
     # The newly calculated sha256 digest will be included in the metadata, so we need to revalidate
-    for asset in asset_blob.assets.all():
+    for asset in asset_blob.assets.values('id').iterator():
         # validate_asset_metadata runs very quickly, no need to delay it
-        validate_asset_metadata(asset.id)
+        validate_asset_metadata(asset['id'])
 
 
 @shared_task(queue='write_manifest_files')

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -43,8 +43,10 @@ def calculate_sha256(blob_id: int) -> None:
 
     # The newly calculated sha256 digest will be included in the metadata, so we need to revalidate
     for asset in asset_blob.assets.values('id').iterator():
-        # validate_asset_metadata runs very quickly, no need to delay it
-        validate_asset_metadata(asset['id'])
+        # Note: while asset metadata is fairly lightweight compute-wise, memory-wise it can become
+        # an issue during serialization/deserialization of the JSON blob by pydantic. Therefore,
+        # we delay each validation to its own task.
+        validate_asset_metadata.delay(asset['id'])
 
 
 @shared_task(queue='write_manifest_files')


### PR DESCRIPTION
Fixes #1095 

- Uses `QuerySet.iterator()` to avoid loading every asset into memory at once
- Uses `QuerySet.values()` to load only each asset's id into memory, instead of the entire `Asset` object
- Delays the asset validation task instead of running it in the same thread as the checksum calculation