### PR TITLE
Prefer social account data over direct user data

### DIFF
--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -27,7 +27,7 @@ class UserMetadataFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = UserMetadata
 
-    status = UserMetadata.Status.APPROVED
+    status = UserMetadata.Status.APPROVED.value
 
 
 class UserFactory(factory.django.DjangoModelFactory):
@@ -54,10 +54,20 @@ class SocialAccountFactory(factory.django.DjangoModelFactory):
         first_name = self.user.first_name
         last_name = self.user.last_name
         name = f'{first_name} {last_name}'
+
+        # Supply a fake created date at least 1 year before now
+        created = (
+            faker.Faker()
+            .date_time_between(end_date=datetime.datetime.now() - datetime.timedelta(days=365))
+            .isoformat()
+        )
+
+        # Supply different values from User object, since social account values maybe be different
         return {
-            'login': self.user.username,
+            'login': faker.Faker().user_name(),
             'name': name,
-            'email': self.user.username,
+            'email': faker.Faker().ascii_email(),
+            'created_at': created,
         }
 
 

--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -210,7 +210,9 @@ def test_user_search_limit_enforced(api_client, user, user_factory, social_accou
         '/api/users/search/?',
         {'username': 'odysseus'},
         format='json',
-    ).data == [serialize_social_account(social_account) for social_account in social_accounts[:10]]
+    ).json() == [
+        serialize_social_account(social_account) for social_account in social_accounts[:10]
+    ]
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def _get_user_status(user: User):
     try:
         return user.metadata.status
-    except ObjectDoesNotExist:
+    except UserMetadata.DoesNotExist:
         return UserMetadata.Status.INCOMPLETE.value
 
 

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -68,8 +68,8 @@ def serialize_user(user: User):
 
     # Prefer social account info if present
     if user.social_account_data is not None:
-        username = user.social_account_data.get('login') or username
-        name = user.social_account_data.get('name') or name
+        username = user.social_account_data.get('login', username)
+        name = user.social_account_data.get('name', name)
 
     return {
         'admin': user.is_superuser,

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -5,7 +5,6 @@ import re
 
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import OuterRef, Q, Subquery
 from django.http.response import HttpResponseBase
 from drf_yasg.utils import swagger_auto_schema


### PR DESCRIPTION
This fixes an unintentional behavior modification introduced in #1124, that caused user data to be displayed instead of any social account data.