### PR TITLE
Use `logging.info` for user errors instead of `logging.error`

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -227,7 +227,7 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
             except Exception:
                 # The assets summary aggregation may fail if any asset metadata is invalid.
                 # If so, just use the placeholder summary.
-                logger.error('Error calculating assetsSummary', exc_info=1)
+                logger.info('Error calculating assetsSummary', exc_info=1)
 
         # Import here to avoid dependency cycle
         from dandiapi.api.manifests import manifest_location

--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -198,7 +198,7 @@ class BaseZarrArchive(TimeStampedModel):
         except ValidationError:
             return EMPTY_CHECKSUM
         except pydantic.ValidationError as e:
-            logger.error(e, exc_info=True)
+            logger.info(e, exc_info=True)
             return None
 
     @property

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -99,7 +99,7 @@ def validate_asset_metadata(asset_id: int) -> None:
         metadata = asset.published_metadata()
         validate(metadata, schema_key='PublishedAsset', json_validation=True)
     except dandischema.exceptions.ValidationError as e:
-        logger.error('Error while validating asset %s', asset_id)
+        logger.info('Error while validating asset %s', asset_id)
         asset.status = Asset.Status.INVALID
 
         validation_errors = collect_validation_errors(e)
@@ -137,7 +137,7 @@ def validate_version_metadata(version_id: int) -> None:
 
         validate(metadata, schema_key='PublishedDandiset', json_validation=True)
     except dandischema.exceptions.ValidationError as e:
-        logger.error('Error while validating version %s', version_id)
+        logger.info('Error while validating version %s', version_id)
         version.status = Version.Status.INVALID
 
         validation_errors = collect_validation_errors(e)


### PR DESCRIPTION
Fixes #1151 

There's a couple places where logs indicating "errors" on the part of the client are logged as ERROR level, which are then reported as a sentry error. I think ERROR-level logging should be reserved for actual programming errors or abnormal system failures, not user "errors" like validation failures that are a normal part of the system. Any thoughts @AlmightyYakob @waxlamp?