### PR TITLE
Fix missing zarr_id in `cancel_zarr_upload`

### DIFF
--- a/dandiapi/api/tests/test_unembargo.py
+++ b/dandiapi/api/tests/test_unembargo.py
@@ -29,9 +29,17 @@ from dandiapi.api.models.dandiset import Dandiset
 )
 @pytest.mark.django_db
 def test_dandiset_rest_unembargo(
-    api_client, dandiset_factory, user_factory, embargo_status, user_status, resp_code
+    api_client,
+    dandiset_factory,
+    draft_version_factory,
+    user_factory,
+    embargo_status,
+    user_status,
+    resp_code,
 ):
     dandiset: Dandiset = dandiset_factory(embargo_status=embargo_status)
+    draft_version_factory(dandiset=dandiset)
+
     if user_status == 'anonymous':
         user = AnonymousUser
     else:

--- a/dandiapi/api/tests/test_zarr_upload.py
+++ b/dandiapi/api/tests/test_zarr_upload.py
@@ -194,9 +194,9 @@ def test_zarr_rest_upload_cancel(
     resp = authenticated_api_client.delete(f'/api/zarr/{zarr_archive.zarr_id}/upload/')
     assert resp.status_code == 204
 
-    # The task was delayed but has not yet started, so nothing has changed
-    assert zarr_upload_file.blob.field.storage.exists(zarr_upload_file.blob.name)
-    assert zarr_archive.upload_in_progress
+    # Check that no uploads are in progress (tasks run synchronously in testing)
+    assert not zarr_archive.upload_in_progress
+    assert not zarr_upload_file.blob.field.storage.exists(zarr_upload_file.blob.name)
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/zarr.py
+++ b/dandiapi/api/views/zarr.py
@@ -227,7 +227,7 @@ class ZarrViewSet(ReadOnlyModelViewSet):
             raise ValidationError('No upload to cancel.')
         # Cancelling involves deleting any data uploaded to S3, which involves a batch of S3 API
         # requests. These are done in a task to avoid Heroku request timeouts.
-        cancel_zarr_upload.delay()
+        cancel_zarr_upload.delay(zarr_id)
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     @swagger_auto_schema(

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -129,6 +129,7 @@ class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
     DANDI_ALLOW_LOCALHOST_URLS = True
 
     # Ensure celery tasks run synchronously
+    CELERY_TASK_EAGER_PROPAGATES = True
     CELERY_TASK_ALWAYS_EAGER = True
 
 


### PR DESCRIPTION
I believe this is the root cause of https://github.com/dandi/dandi-cli/issues/1028, it seems that zarr upload cancelling has never worked from the API.

This was never caught, as while the function did result in an exception being raised, celery didn't propagate the exception up to the test function, and so all seemed good. To mitigate anything like this happening in the future, I've added the `CELERY_TASK_EAGER_PROPAGATES` setting to our testing configuration. This allows exceptions to propagate up.

Adding that setting also caused an error in the `test_dandiset_rest_unembargo` function to show up, which this PR fixes.