### PR TITLE
Fix missing package error when first using docker-compose setup

### DIFF
--- a/dandiapi/__init__.py
+++ b/dandiapi/__init__.py
@@ -1,8 +1,8 @@
+from importlib.metadata import version
+
 # This project module is imported for us when Django starts. To ensure that Celery app is always
 # defined prior to any shared_task definitions (so those tasks will bind to the app), import
 # the Celery module here for side effects.
-from pkg_resources import get_distribution
-
 from .celery import app as _celery_app  # noqa: F401
 
-__version__ = get_distribution('dandiapi').version
+__version__ = version('dandiapi')

--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -19,7 +19,10 @@ COPY ./setup.py /opt/django-project/setup.py
 # Copy git folder for setuptools_scm
 COPY ./.git/ /opt/django-project/.git/
 
-RUN pip install --editable /opt/django-project[dev]
+# Don't install as editable, so that when the directory is mounted over with docker-compose, the
+# installation still exists (otherwise the dandiapi.egg-info/ directory would be overwritten, and
+# the installation would no longer exist)
+RUN pip install /opt/django-project[dev]
 
 # Use a directory name which will never be an import name, as isort considers this as first-party.
 WORKDIR /opt/django-project


### PR DESCRIPTION
~~Due to the following line~~

https://github.com/dandi/dandi-archive/blob/5d721709ad06041debbee93ca592ad470dd719ab/dandiapi/__init__.py#L8

~~The existing dev docker setup doesn't work as it's described in the `README.md`, as the `dandiapi` folder isn't copied into the container at the time of pip install, causing the `dandiapi` package to not be found. This wasn't an issue before, since we didn't rely on pip actually having knowledge of our `dandiapi` package to run django. However, due to our current versioning setup, any time our app is run, it runs the above line, to determine the current version. At that point, it finds that the `dandiapi` package isn't installed, causing an error.~~

~~We can't just copy the `dandiapi` directory into the container before pip install is run, since when we overwrite the current directory with our `docker-compose` setup, that folder will be gone, leaving us with the same problem. There's then two solutions:~~

~~1. Copy the `dandiapi` folder into the container at build time, before pip install. Then instead of mounting the entire directory with `docker-compose`, mount only the files/folders we need, so that the `.egg-info` folder isn't overwritten.~~
~~2. Add a step in the README to run pip install, which will then place a `.egg-info` folder in the cloned repo _outside_ of the container. After that, it will always get mounted into the container when docker-compose is run, and behave normally.~~

~~This PR takes the latter approach, since imo maintaining an exhaustive list of all files needed in the container could lead to all kinds of issues, which would likely not be caught since the dev setup isn't tested.~~

---

My initial report was a red herring, this PR has been updated to address the real cause, outlined in https://github.com/dandi/dandi-archive/pull/1158#issuecomment-1194641157.


