### PR TITLE
Fix excessive memory usage in asset summary calculation

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -203,7 +203,7 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
         ]
         return {key: metadata[key] for key in metadata if key not in computed_fields}
 
-    def _populate_metadata(self, version_with_assets: Version = None):
+    def _populate_metadata(self, version_with_assets: Version | None = None):
 
         # When validating a draft version, we create a published version without saving it,
         # calculate it's metadata, and validate that metadata. However, assetsSummary is computed

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+from typing import TYPE_CHECKING
 
 from dandischema.metadata import aggregate_assets_summary
 from django.conf import settings
@@ -13,6 +14,9 @@ from django_extensions.db.models import TimeStampedModel
 from dandiapi.api.models.metadata import PublishableMetadataMixin
 
 from .dandiset import Dandiset
+
+if TYPE_CHECKING:
+    from .asset import Asset
 
 logger = logging.getLogger(__name__)
 
@@ -221,8 +225,12 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
         }
         if version_with_assets.id:
             try:
+                assets: models.QuerySet[Asset] = version_with_assets.assets
                 summary = aggregate_assets_summary(
-                    [asset['metadata'] for asset in version_with_assets.assets.values('metadata')]
+                    # There is no limit to how many assets a dandiset can have, so use
+                    # `values_list` and `iterator` here to keep the memory footprint
+                    # of this list low.
+                    assets.values_list('metadata', flat=True).iterator()
                 )
             except Exception:
                 # The assets summary aggregation may fail if any asset metadata is invalid.


### PR DESCRIPTION
This line [https://github.com/dandi/dandi-archive/blob/master/dandiapi/api/models/version.py#L224-L226](https://github.com/dandi/dandi-archive/blob/master/dandiapi/api/models/version.py?rgh-link-date=2022-06-30T20%3A20%3A35Z#L224-L226) loads metadata of every Asset into memory as a dict using .values, and then coerces it into a list. This means that we're essentially storing two copies of the asset metadata in memory for every Asset in the Version being validated. So for dandisets like [dandiarchive.org/dandiset/000026](https://dandiarchive.org/dandiset/000026), it appears that we're loading 80,000 JSON blobs into memory at once.

This PR changes this line to 

1) Use `QuerySet.values_list(..., flat=True)` to convert the queryset directly into a list of asset metadata JSON blobs, instead using .values and then recreating the list from scratch.
2) Use `QuerySet.iterator()` to produce a generator from the previous `values_list` queryset to avoid loading every asset metadata into memory at once. Note that the dandi-schema `aggregate_assets_summary` function takes any `Iterable` as an argument, so it's okay to pass a generator instead of a list here.


Fixes #1149 