### PR TITLE
Fix race condition in sha256 calculation

### DIFF
--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -45,11 +45,11 @@ def calculate_sha256(blob_id: int) -> None:
     # The newly calculated sha256 digest will be included in the metadata, so we need to revalidate
     # Note, we use `.iterator` here and delay each validation as a new task in order to keep memory
     # usage down.
-    for asset in asset_blob.assets.values('id').iterator():
+    for asset_id in asset_blob.assets.values_list('id', flat=True).iterator():
         # Note: while asset metadata is fairly lightweight compute-wise, memory-wise it can become
         # an issue during serialization/deserialization of the JSON blob by pydantic. Therefore,
         # we delay each validation to its own task.
-        transaction.on_commit(lambda: validate_asset_metadata.delay(asset['id']))
+        transaction.on_commit(lambda: validate_asset_metadata.delay(asset_id))
 
 
 @shared_task(queue='write_manifest_files')

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -45,11 +45,15 @@ def calculate_sha256(blob_id: int) -> None:
     # The newly calculated sha256 digest will be included in the metadata, so we need to revalidate
     # Note, we use `.iterator` here and delay each validation as a new task in order to keep memory
     # usage down.
-    for asset_id in asset_blob.assets.values_list('id', flat=True).iterator():
-        # Note: while asset metadata is fairly lightweight compute-wise, memory-wise it can become
-        # an issue during serialization/deserialization of the JSON blob by pydantic. Therefore,
-        # we delay each validation to its own task.
-        transaction.on_commit(lambda: validate_asset_metadata.delay(asset_id))
+    def dispatch_validation():
+        for asset_id in asset_blob.assets.values_list('id', flat=True).iterator():
+            # Note: while asset metadata is fairly lightweight compute-wise, memory-wise it can
+            # become an issue during serialization/deserialization of the JSON blob by pydantic.
+            # Therefore, we delay each validation to its own task.
+            validate_asset_metadata.delay(asset_id)
+
+    # Run on transaction commit
+    transaction.on_commit(dispatch_validation)
 
 
 @shared_task(queue='write_manifest_files')


### PR DESCRIPTION
Waits until the current transaction is commited before running asset validation. 

As part of the asset validation process, the sha256 checksum is injected into the metadata. The recent changes to delay asset validation to a new task after checksumming means that there is a good chance it will run before the sha256 checksum has been commited to the database. This PR uses the `transaction.on_commit` hook to avoid this. I also made a small memory optimization by changing a `queryset.values` to a `queryset.values_list`.

Fixes #1156