### PR TITLE
Navigation buttons on landing page

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -4,13 +4,13 @@
     subheader
   >
     <v-list-item
-      v-for="item in dandisets"
+      v-for="(item, index) in dandisets"
       :key="item.dandiset.identifier"
       selectable
       :to="{
         name: 'dandisetLanding',
         params: { identifier: item.dandiset.identifier, origin },
-        query: $route.query,
+        query: { ...$route.query, pos: getPos(index) },
       }"
     >
       <v-list-item-content>
@@ -83,6 +83,7 @@ import moment from 'moment';
 import filesize from 'filesize';
 
 import { Version } from '@/types';
+import { DANDISETS_PER_PAGE } from '@/utils/constants';
 
 export default defineComponent({
   name: 'DandisetList',
@@ -101,7 +102,10 @@ export default defineComponent({
       const { name, params, query } = route;
       return { name, params, query };
     });
-
+    // current position in search result set = items on prev pages + position on current page
+    function getPos(index: number) {
+      return (Number(ctx.root.$route.query.page || 1) - 1) * DANDISETS_PER_PAGE + (index + 1);
+    }
     function formatDate(date: string) {
       return moment(date).format('LL');
     }
@@ -109,7 +113,7 @@ export default defineComponent({
     return {
       origin,
       formatDate,
-
+      getPos,
       // Returned imports
       filesize,
     };

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -9,7 +9,8 @@
       selectable
       :to="{
         name: 'dandisetLanding',
-        params: { identifier: item.dandiset.identifier, origin }
+        params: { identifier: item.dandiset.identifier, origin },
+        query: $route.query,
       }"
     >
       <v-list-item-content>

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -100,27 +100,9 @@ import DandisetList from '@/components/DandisetList.vue';
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
 import { dandiRest } from '@/rest';
 import { Dandiset, Paginated } from '@/types';
+import { sortingOptions } from '@/utils/constants';
 
 const DANDISETS_PER_PAGE = 8;
-
-const sortingOptions = [
-  {
-    name: 'Modified',
-    djangoField: 'modified',
-  },
-  {
-    name: 'Identifier',
-    djangoField: 'id',
-  },
-  {
-    name: 'Name',
-    djangoField: 'name',
-  },
-  {
-    name: 'Size',
-    djangoField: 'size',
-  },
-];
 
 export default defineComponent({
   name: 'DandisetsPage',
@@ -159,6 +141,8 @@ export default defineComponent({
 
     const djangoDandisetRequest: Ref<Paginated<Dandiset> | null> = ref(null);
     watchEffect(async () => {
+      // console.log('page', ctx.root.$route);
+
       const ordering = ((sortDir.value === -1) ? '-' : '') + sortField.value;
       const response = await dandiRest.dandisets({
         page: page.value,

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -100,9 +100,7 @@ import DandisetList from '@/components/DandisetList.vue';
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
 import { dandiRest } from '@/rest';
 import { Dandiset, Paginated } from '@/types';
-import { sortingOptions } from '@/utils/constants';
-
-const DANDISETS_PER_PAGE = 8;
+import { sortingOptions, DANDISETS_PER_PAGE } from '@/utils/constants';
 
 export default defineComponent({
   name: 'DandisetsPage',
@@ -141,8 +139,6 @@ export default defineComponent({
 
     const djangoDandisetRequest: Ref<Paginated<Dandiset> | null> = ref(null);
     watchEffect(async () => {
-      // console.log('page', ctx.root.$route);
-
       const ordering = ((sortDir.value === -1) ? '-' : '') + sortField.value;
       const response = await dandiRest.dandisets({
         page: page.value,

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -172,6 +172,8 @@ export default defineComponent({
       page: String(page.value),
       sortOption: String(sortOption.value),
       sortDir: String(sortDir.value),
+      showDrafts: String(showDrafts.value),
+      showEmpty: String(showEmpty.value),
     }));
     watch(queryParams, (params) => {
       ctx.root.$router.replace({

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -46,6 +46,8 @@ const sortingOptions = [
   },
 ];
 
+const DANDISETS_PER_PAGE = 8;
+
 export {
   dandiUrl,
   dandiAboutUrl,
@@ -55,4 +57,5 @@ export {
   dandiHelpUrl,
   VALIDATION_ICONS,
   sortingOptions,
+  DANDISETS_PER_PAGE,
 };

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -27,6 +27,25 @@ const VALIDATION_ICONS = {
   DEFAULT: 'mdi-alert',
 };
 
+const sortingOptions = [
+  {
+    name: 'Modified',
+    djangoField: 'modified',
+  },
+  {
+    name: 'Identifier',
+    djangoField: 'id',
+  },
+  {
+    name: 'Name',
+    djangoField: 'name',
+  },
+  {
+    name: 'Size',
+    djangoField: 'size',
+  },
+];
+
 export {
   dandiUrl,
   dandiAboutUrl,
@@ -35,4 +54,5 @@ export {
   draftVersion,
   dandiHelpUrl,
   VALIDATION_ICONS,
+  sortingOptions,
 };

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -150,7 +150,6 @@ export default defineComponent({
     const pages = ref(1);
     const nextDandiset : Ref<any[]> = ref([]);
 
-    const djangoDandisetRequest: Ref<Paginated<Dandiset> | null> = ref(null);
     async function fetchNextPage() {
       const sortOption = Number(ctx.root.$route.query.sortOption) || 0;
       const sortDir = Number(ctx.root.$route.query.sortDir || -1);
@@ -164,10 +163,9 @@ export default defineComponent({
         draft: true,
         empty: true,
       });
-      djangoDandisetRequest.value = response.data;
 
-      pages.value = (djangoDandisetRequest.value?.count) ? djangoDandisetRequest.value?.count : 1;
-      nextDandiset.value = djangoDandisetRequest.value?.results.map((dandiset) => ({
+      pages.value = (response.data?.count) ? response.data?.count : 1;
+      nextDandiset.value = response.data?.results.map((dandiset) => ({
         ...(dandiset.most_recent_published_version || dandiset.draft_version),
         contact_person: dandiset.contact_person,
         identifier: dandiset.identifier,

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -47,7 +47,7 @@
 
 <script lang="ts">
 import {
-  defineComponent, computed, watchEffect, watch, onMounted, Ref, ref,
+  defineComponent, computed, watch, onMounted, Ref, ref,
 } from '@vue/composition-api';
 import { NavigationGuardNext, RawLocation, Route } from 'vue-router';
 

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -160,8 +160,8 @@ export default defineComponent({
         page_size: 1,
         ordering,
         search: ctx.root.$route.query.search,
-        draft: true,
-        empty: true,
+        draft: ctx.root.$route.query.showDrafts || true,
+        empty: ctx.root.$route.query.showEmpty,
       });
 
       pages.value = (response.data?.count) ? response.data?.count : 1;

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -54,7 +54,7 @@ import { NavigationGuardNext, RawLocation, Route } from 'vue-router';
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
 import Meditor from '@/components/Meditor/Meditor.vue';
 import store from '@/store';
-import { Version, Dandiset, Paginated } from '@/types';
+import { Version } from '@/types';
 import { draftVersion, sortingOptions } from '@/utils/constants';
 import { editorInterface } from '@/components/Meditor/state';
 import { dandiRest } from '@/rest';


### PR DESCRIPTION
### **Issue [775](https://github.com/dandi/dandi-archive/issues/775)**

**Proposed Solution:**
We add prev and next buttons on the top right within the search toolbar as indicated in the screenshot below:
![Screenshot from 2022-07-08 17-20-33](https://user-images.githubusercontent.com/9425902/178071985-07d68a7a-4417-49b7-92f3-9b618e936408.png)

- The search parameters (query, sorting) would be inherited from the list page as query params
- Implemented using `<v-pagination>` with a page size of 1
- Any navigation event would trigger a new fetch request with a page size of 1 and page number = position of the current item. The position is calculated wrt the entire result set i.e. `page number * no of items per page + position on current page`

**Limitations**
- Query parameters may not be persisted on directly opening a DLP


**TODO**

- [x] Fix the sorting order (not being inherited from the list page)
- [x] Remove unnecessary props/ duplicate code
- [x] Check if this interferes with the existing watch methods for `version` and `identifier` as they also lead to page navigation 