### PR TITLE
Upgrade django-composed-configuration

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -114,7 +114,6 @@ class DandiMixin(ConfigMixin):
 class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
     # This makes pydantic model schema allow URLs with localhost in them.
     DANDI_ALLOW_LOCALHOST_URLS = True
-    SHELL_PLUS_PRINT_SQL_TRUNCATE = None
 
 
 class TestingConfiguration(DandiMixin, TestingBaseConfiguration):

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'pydantic',
         'boto3[s3]',
         # Production-only
-        'django-composed-configuration[prod]>=0.20.1',
+        'django-composed-configuration[prod]>=0.22.0',
         'django-s3-file-field[boto3]==0.1.1',
         'django-storages[boto3]',
         'gunicorn',
@@ -67,7 +67,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            'django-composed-configuration[dev]>=0.20.1',
+            'django-composed-configuration[dev]>=0.22.0',
             'django-debug-toolbar',
             'django-s3-file-field[minio]',
             'ipython',


### PR DESCRIPTION
`SHELL_PLUS_PRINT_SQL_TRUNCATE` is automatically set in the newer version of composed config.