### PR TITLE
Improve manifest file writing performance

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -9,5 +9,3 @@ web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi --timeout 25
 worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B
 # The checksum-worker calculates blob checksums and updates zarr checksum files
 checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256,ingest_zarr_archive
-# Manifests can be very memory intensive for large numbers of assets, so limit concurrency to 1
-manifest-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q write_manifest_files -c 1

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -57,17 +57,17 @@ def calculate_sha256(blob_id: int) -> None:
     transaction.on_commit(dispatch_validation)
 
 
-@shared_task(queue='write_manifest_files')
+@shared_task(soft_time_limit=40)
 @atomic
 def write_manifest_files(version_id: int) -> None:
     version: Version = Version.objects.get(id=version_id)
     logger.info('Writing manifests for version %s:%s', version.dandiset.identifier, version.version)
 
-    write_dandiset_yaml(version, logger=logger)
-    write_assets_yaml(version, logger=logger)
-    write_dandiset_jsonld(version, logger=logger)
-    write_assets_jsonld(version, logger=logger)
-    write_collection_jsonld(version, logger=logger)
+    write_dandiset_yaml(version)
+    write_assets_yaml(version)
+    write_dandiset_jsonld(version)
+    write_assets_jsonld(version)
+    write_collection_jsonld(version)
 
 
 def encode_pydantic_error(error) -> dict[str, str]:


### PR DESCRIPTION
This significantly speeds up and reduces the memory usage of the write_manifest_files task that takes place on publish.

The manifest files are now written in a streaming fashion, and the YAML output now uses the C implementation. Worst case time/memory usage went from ~2m20s and ~1gb ram to ~20s and ~25mb (constant time) memory usage.

As a result, I'm removing the manifest-worker since this task doesn't need to be treated differently than any others on the main worker.

Fixes #985 