### PR TITLE
Add "/server-info" frontend endpoint in development builds

### DIFF
--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -34,7 +34,19 @@ module.exports = {
   devServer: {
     // The default port 8080 conflicts with Girder
     port: 8085,
+
+    // This proxy emulates the Netlify redirect to the backend (on the staging
+    // and production deploys).
+    proxy: {
+      '^/server-info/$': {
+        target: process.env.VUE_APP_DANDI_API_ROOT,
+        pathRewrite: {
+          '/server-info': '/info',
+        },
+      },
+    },
   },
+
   chainWebpack: (config) => {
     config
       .plugin('moment-locales')


### PR DESCRIPTION
This PR adds an "endpoint" to the frontend that proxies to the backend server info endpoint, emulating the mechanism in place on the Netlify-controlled deploys.

This works but only if you ask for the path complete with trailing slash, and I'm not sure why. Reviewers, perhaps you can recommend a better way to make this work so that the trailing slash is not required.

Closes #1108.