### PR TITLE
Use an ordered QuerySet in Zarr viewset

### DIFF
--- a/dandiapi/api/views/zarr.py
+++ b/dandiapi/api/views/zarr.py
@@ -100,7 +100,7 @@ class ZarrViewSet(ReadOnlyModelViewSet):
     serializer_class = ZarrSerializer
     pagination_class = DandiPagination
 
-    queryset = ZarrArchive.objects.all()
+    queryset = ZarrArchive.objects.all().order_by('created')
     lookup_field = 'zarr_id'
     lookup_value_regex = ZarrArchive.UUID_REGEX
 


### PR DESCRIPTION
This orders ZarrArchive models by created time in the Zarr viewset, eliminating some warnings in the logs.

Closes #1136.