### PR TITLE
ENH(DX): extend and harmonize any log message about task on a version

### DIFF
--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -239,8 +239,7 @@ def publish_task(version_id: int):
     transaction.on_commit(lambda: _create_doi(new_version.id))
 
 
-def _log_version_action(msg: str, version_id: int, version: Version) -> None:
+def _log_version_action(msg: str, version: Version) -> None:
     """Centralize/harmonize logging of operations over a Version."""
-    logger.info(
-        '%s for version %d %s:%s', msg, version_id, version.dandiset.identifier, version.version
-    )
+
+    logger.info(f'{msg} for version {version.id}, {version}')

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -239,8 +239,8 @@ def publish_task(version_id: int):
     transaction.on_commit(lambda: _create_doi(new_version.id))
 
 
-def _log_version_action(msg:str, version_id: int, version: Version) -> None:
-    """Helper to centralize/harmonize logging of operations over a Version
-    """
-    logger.info('%s for version %d %s:%s',
-                msg, version_id, version.dandiset.identifier, version.version)
+def _log_version_action(msg: str, version_id: int, version: Version) -> None:
+    """Centralize/harmonize logging of operations over a Version."""
+    logger.info(
+        '%s for version %d %s:%s', msg, version_id, version.dandiset.identifier, version.version
+    )

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -139,7 +139,7 @@ def validate_version_metadata(version_id: int) -> None:
 
         validate(metadata, schema_key='PublishedDandiset', json_validation=True)
     except dandischema.exceptions.ValidationError as e:
-        logger.info('Error while validating version %s', version_id)
+        _log_version_action('Error while validating dandiset metadata', version_id, version)
         version.status = Version.Status.INVALID
 
         validation_errors = collect_validation_errors(e)


### PR DESCRIPTION
I was looking at the logs and found that some log messages do present in
varying shapes - some reported version_id (good for looking up DB), some actual
dandiset id and version string. Since developer can not map version_id to
dandiset id in their minds I have decided to print them both out.