### PR TITLE
Fix bug in `import_dandisets` script

### DIFF
--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -90,7 +90,7 @@ def import_versions_from_response(
                 assets = requests.get(
                     urljoin(
                         api_url,
-                        f'/api/dandisets/{dandiset.identifier}/versions'
+                        f'/api/dandisets/{result["dandiset"]["identifier"]}/versions'
                         f'/{result["version"]}/assets/',
                     )
                 ).json()


### PR DESCRIPTION
The user can specify a new identifier for the cloned dandiset, so using the identifier from the newly created `Dandiset` is not correct. Instead, use the identifier from the dandiset API response.

Fixes https://sentry.io/organizations/dandiarchive/issues/3453536368/