### PR TITLE
Add metadata flag for asset listing

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -329,6 +329,28 @@ def test_asset_rest_list(api_client, version, asset, asset_factory):
     }
 
 
+@pytest.mark.django_db
+def test_asset_rest_list_include_metadata(api_client, version, asset, asset_factory):
+    version.assets.add(asset)
+
+    # Create an extra asset so that there are multiple assets to filter down
+    asset_factory()
+
+    # Assert false has no effect
+    r = api_client.get(
+        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/assets/',
+        {'metadata': False},
+    )
+    assert 'metadata' not in r.json()['results'][0]
+
+    # Test positive case
+    r = api_client.get(
+        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/assets/',
+        {'metadata': True},
+    )
+    assert r.json()['results'][0]['metadata'] == asset.metadata
+
+
 @pytest.mark.parametrize(
     'path,result_indices',
     [

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -533,13 +533,14 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
             glob_pattern = re.escape(glob_pattern)
             queryset = queryset.filter(path__iregex=glob_pattern.replace('\\*', '.*'))
 
-        # Paginate if necessary
+        # Paginate and return
         page = self.paginate_queryset(queryset)
         if page is not None:
-            queryset = page
+            serializer = self.get_serializer(page, many=True, metadata=include_metadata)
+            return self.get_paginated_response(serializer.data)
 
         serializer = self.get_serializer(queryset, many=True, metadata=include_metadata)
-        return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
     @swagger_auto_schema(
         manual_parameters=[PATH_PREFIX_PARAM],

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -517,7 +517,9 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         serializer.is_valid(raise_exception=True)
 
         # Don't include metadata field if not asked for
-        queryset: QuerySet[Asset] = self.filter_queryset(self.get_queryset().select_related('blob'))
+        queryset: QuerySet[Asset] = self.filter_queryset(
+            self.get_queryset().select_related('blob', 'embargoed_blob', 'zarr')
+        )
         include_metadata = serializer.validated_data['metadata']
         if not include_metadata:
             queryset = queryset.defer('metadata')

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -511,14 +511,18 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
 
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
-    @swagger_auto_schema(query_serializer=AssetListSerializer)
+    @swagger_auto_schema(query_serializer=AssetListSerializer, responses={200: AssetSerializer()})
     def list(self, request, *args, **kwargs):
         serializer = AssetListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
 
-        queryset = self.filter_queryset(self.get_queryset())
-        glob_pattern: str | None = serializer.validated_data.get('glob')
+        # Don't include metadata field if not asked for
+        queryset: QuerySet[Asset] = self.filter_queryset(self.get_queryset().select_related('blob'))
+        include_metadata = serializer.validated_data['metadata']
+        if not include_metadata:
+            queryset = queryset.defer('metadata')
 
+        glob_pattern: str | None = serializer.validated_data.get('glob')
         if glob_pattern is not None:
             # Escape special characters in the glob pattern. This is a security precaution taken
             # since we are using postgres' regex search. A malicious user who knows this could
@@ -527,13 +531,13 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
             glob_pattern = re.escape(glob_pattern)
             queryset = queryset.filter(path__iregex=glob_pattern.replace('\\*', '.*'))
 
+        # Paginate if necessary
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
+            queryset = page
 
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
+        serializer = self.get_serializer(queryset, many=True, metadata=include_metadata)
+        return self.get_paginated_response(serializer.data)
 
     @swagger_auto_schema(
         manual_parameters=[PATH_PREFIX_PARAM],

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -516,10 +516,12 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         serializer = AssetListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
 
-        # Don't include metadata field if not asked for
+        # Fetch initial queryset
         queryset: QuerySet[Asset] = self.filter_queryset(
             self.get_queryset().select_related('blob', 'embargoed_blob', 'zarr')
         )
+
+        # Don't include metadata field if not asked for
         include_metadata = serializer.validated_data['metadata']
         if not include_metadata:
             queryset = queryset.defer('metadata')

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -226,11 +226,20 @@ class AssetSerializer(serializers.ModelSerializer):
             'size',
             'created',
             'modified',
+            'metadata',
         ]
         read_only_fields = ['created']
 
     blob = EmbargoedSlugRelatedField(slug_field='blob_id', read_only=True)
     zarr = serializers.SlugRelatedField(slug_field='zarr_id', read_only=True)
+
+    def __init__(self, *args, metadata=True, **kwargs):
+        # Instantiate the superclass normally
+        super().__init__(*args, **kwargs)
+
+        # Don't include metadata unless specified
+        if not metadata:
+            self.fields.pop('metadata')
 
 
 class AssetDetailSerializer(AssetSerializer):
@@ -258,3 +267,4 @@ class AssetPathsQueryParameterSerializer(serializers.Serializer):
 
 class AssetListSerializer(serializers.Serializer):
     glob = serializers.CharField(required=False)
+    metadata = serializers.BooleanField(required=False, default=False)


### PR DESCRIPTION
Closes #1217.

Addresses in part #397.

This specifically addresses the metadata flag for the asset list endpoint. If we want to address other aspects of that issue, they should be filed as their own respective issues.