### PR TITLE
Remove flake8 linting rule

### DIFF
--- a/dandiapi/api/migrations/0006_default_oauth_application.py
+++ b/dandiapi/api/migrations/0006_default_oauth_application.py
@@ -1,5 +1,3 @@
-# flake8: noqa N806
-
 from django.db import migrations
 from django.db.models import Q
 

--- a/dandiapi/api/migrations/0016_remove_metadata_tables.py
+++ b/dandiapi/api/migrations/0016_remove_metadata_tables.py
@@ -5,10 +5,10 @@ from django.db import migrations, models
 
 
 def migrate_metadata(apps, schema_editor):
-    Version = apps.get_model('api', 'Version')  # noqa: N806
-    VersionMetadata = apps.get_model('api', 'VersionMetadata')  # noqa: N806
-    Asset = apps.get_model('api', 'Asset')  # noqa: N806
-    AssetMetadata = apps.get_model('api', 'AssetMetadata')  # noqa: N806
+    Version = apps.get_model('api', 'Version')
+    VersionMetadata = apps.get_model('api', 'VersionMetadata')
+    Asset = apps.get_model('api', 'Asset')
+    AssetMetadata = apps.get_model('api', 'AssetMetadata')
 
     moved_metadata = VersionMetadata.objects.filter(id=models.OuterRef('old_metadata')).values_list(
         'metadata'

--- a/dandiapi/api/migrations/0022_upload_dandiset_alter_stagingapplication_user.py
+++ b/dandiapi/api/migrations/0022_upload_dandiset_alter_stagingapplication_user.py
@@ -6,8 +6,8 @@ import django.db.models.deletion
 
 def set_default_upload_dandiset(apps, schema_editor):
     """Set the dandiset field for all existing uploads to the first dandiset."""
-    Dandiset = apps.get_model('api', 'Dandiset')  # noqa: N806
-    Upload = apps.get_model('api', 'Upload')  # noqa: N806
+    Dandiset = apps.get_model('api', 'Dandiset')
+    Upload = apps.get_model('api', 'Upload')
     # noqa: E501 Fresh installations will have no dandisets, but also no uploads, so initialize this inside the loop
     first_dandiset = None
     uploads = list(Upload.objects.filter(dandiset=None).all())

--- a/dandiapi/api/migrations/0025_zarrarchive_dandiset.py
+++ b/dandiapi/api/migrations/0025_zarrarchive_dandiset.py
@@ -6,8 +6,8 @@ import django.db.models.deletion
 
 def set_default_zarrarchive_dandiset(apps, schema_editor):
     """Set the dandiset field for all existing uploads to the first dandiset."""
-    Dandiset = apps.get_model('api', 'Dandiset')  # noqa: N806
-    ZarrArchive = apps.get_model('api', 'ZarrArchive')  # noqa: N806
+    Dandiset = apps.get_model('api', 'Dandiset')
+    ZarrArchive = apps.get_model('api', 'ZarrArchive')
     # noqa: E501 Fresh installations will have no dandisets, but also no zarr_archives, so initialize this inside the loop
     first_dandiset = None
     zarr_archives = list(ZarrArchive.objects.filter(dandiset=None).all())

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -129,7 +129,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
             new_version.save()
             # Bulk create the join table rows to optimize linking assets to new_version
-            AssetVersions = Version.assets.through  # noqa: N806
+            AssetVersions = Version.assets.through
 
             # Add a new many-to-many association directly to any already published assets
             already_published_assets = old_version.assets.filter(published=True)

--- a/tox.ini
+++ b/tox.ini
@@ -130,6 +130,8 @@ ignore =
     W503,
     # Missing docstring in *
     D10,
+    # variables should be lowercased
+    N806,
 extend-exclude =
     build,
     dist,


### PR DESCRIPTION
IME this rule rarely catches problems and regularly frustrates in the cases where uppercase variable names are often necessary e.g. migrations.