### PR TITLE
Pin flake8 version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
-    flake8
+    flake8 < 5
     flake8-black >= 0.2.4
     flake8-bugbear
     flake8-docstrings


### PR DESCRIPTION
Flake8 v5 was just [released](https://pypi.org/project/flake8/#history), and causes flake8-isort to break. Pinning the version to < 5 fixes this for now.