### PR TITLE
Revert "Pin flake8 version"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
-    flake8 < 5
+    flake8
     flake8-black >= 0.2.4
     flake8-bugbear
     flake8-docstrings


### PR DESCRIPTION
Reverts dandi/dandi-archive#1226

The issue causing this (https://github.com/gforcada/flake8-isort/issues/115) has been resolved upstream. 