### PR TITLE
Fix zarr viewer

### DIFF
--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -94,5 +94,5 @@ export interface AssetFile extends AssetStats {
   asset_id: string,
   path: string,
   services: AssetServices[],
-  url: URL;
+  url: string;
 }

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -223,6 +223,7 @@ import {
 } from '@vue/composition-api';
 import { RawLocation } from 'vue-router';
 import filesize from 'filesize';
+import { trimEnd } from 'lodash';
 
 import { dandiRest } from '@/rest';
 import store from '@/store';
@@ -301,7 +302,7 @@ export default defineComponent({
           .test(name) && (asset.size || 0) <= service.maxsize)
         .map((service) => ({
           name: service.name,
-          url: `${service.endpoint}${asset.url}`,
+          url: `${service.endpoint}${trimEnd(asset.url, '/')}`,
         }));
     }
 


### PR DESCRIPTION
The vtk/itk js viewer (https://kitware.github.io/itk-vtk-viewer/app) used for zarr viewing automatically appends a trailing slash to the URL it is given. So, this PR changes the URL formation to automatically strip off a trailing slash if one exists.

Fixes #1235