### PR TITLE
RF: sort long listings of keys in metadata records

### DIFF
--- a/dandiapi/api/manifests.py
+++ b/dandiapi/api/manifests.py
@@ -127,9 +127,9 @@ def write_collection_jsonld(version: Version):
             .render(
                 {
                     '@context': version.metadata['@context'],
-                    'id': version.metadata['id'],
                     '@type': 'prov:Collection',
                     'hasMember': list(version.assets.values_list('metadata__id', flat=True)),
+                    'id': version.metadata['id'],
                 },
             )
             .decode()

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -262,12 +262,12 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
 
         metadata = {
             **self.metadata,
-            'id': f'dandiasset:{self.asset_id}',
-            'path': self.path,
-            'identifier': str(self.asset_id),
-            'contentUrl': [download_url, s3_url],
             'contentSize': self.size,
+            'contentUrl': [download_url, s3_url],
             'digest': self.digest,
+            'id': f'dandiasset:{self.asset_id}',
+            'identifier': str(self.asset_id),
+            'path': self.path,
         }
         schema_version = metadata['schemaVersion']
         metadata['@context'] = (
@@ -307,13 +307,13 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
     def strip_metadata(cls, metadata):
         """Strip away computed fields from a metadata dict."""
         computed_fields = [
-            'id',
-            'path',
-            'identifier',
-            'contentUrl',
             'contentSize',
-            'digest',
+            'contentUrl',
             'datePublished',
+            'digest',
+            'id',
+            'identifier',
+            'path',
             'publishedBy',
         ]
         return {key: metadata[key] for key in metadata if key not in computed_fields}

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -200,18 +200,18 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
     def strip_metadata(cls, metadata):
         """Strip away computed fields from a metadata dict."""
         computed_fields = [
-            'name',
-            'identifier',
-            'version',
-            'id',
-            'url',
             'assetsSummary',
             'citation',
-            'doi',
             'dateCreated',
             'datePublished',
-            'publishedBy',
+            'doi',
+            'id',
+            'identifier',
             'manifestLocation',
+            'name',
+            'publishedBy',
+            'url',
+            'version',
         ]
         return {key: metadata[key] for key in metadata if key not in computed_fields}
 
@@ -251,14 +251,14 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
         metadata = {
             **self.metadata,
             'manifestLocation': manifest_location(self),
-            'name': self.name,
-            'identifier': f'DANDI:{self.dandiset.identifier}',
-            'version': self.version,
-            'id': f'DANDI:{self.dandiset.identifier}/{self.version}',
-            'repository': settings.DANDI_WEB_APP_URL,
-            'url': f'{settings.DANDI_WEB_APP_URL}/dandiset/{self.dandiset.identifier}/{self.version}',  # noqa
             'assetsSummary': summary,
             'dateCreated': self.dandiset.created.isoformat(),
+            'id': f'DANDI:{self.dandiset.identifier}/{self.version}',
+            'identifier': f'DANDI:{self.dandiset.identifier}',
+            'name': self.name,
+            'repository': settings.DANDI_WEB_APP_URL,
+            'url': f'{settings.DANDI_WEB_APP_URL}/dandiset/{self.dandiset.identifier}/{self.version}',  # noqa
+            'version': self.version,
         }
         if self.doi:
             metadata['doi'] = self.doi

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -178,13 +178,13 @@ def test_asset_populate_metadata(draft_asset_factory):
     blob_url = asset.blob.s3_url
     assert asset.metadata == {
         **raw_metadata,
-        'id': f'dandiasset:{asset.asset_id}',
-        'path': asset.path,
-        'identifier': str(asset.asset_id),
-        'contentUrl': [download_url, blob_url],
-        'contentSize': asset.blob.size,
-        'digest': asset.blob.digest,
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+        'contentSize': asset.blob.size,
+        'contentUrl': [download_url, blob_url],
+        'digest': asset.blob.digest,
+        'id': f'dandiasset:{asset.asset_id}',
+        'identifier': str(asset.asset_id),
+        'path': asset.path,
     }
 
 
@@ -205,15 +205,15 @@ def test_asset_populate_metadata_zarr(draft_asset_factory, zarr_archive):
     s3_url = f'http://{settings.MINIO_STORAGE_ENDPOINT}/test-dandiapi-dandisets/test-prefix/test-zarr/{zarr_archive.zarr_id}/'  # noqa: E501
     assert asset.metadata == {
         **raw_metadata,
-        'id': f'dandiasset:{asset.asset_id}',
-        'path': asset.path,
-        'identifier': str(asset.asset_id),
-        'contentUrl': [download_url, s3_url],
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'contentSize': asset.size,
+        'contentUrl': [download_url, s3_url],
         'digest': asset.digest,
         # This should be injected on all zarr assets
         'encodingFormat': 'application/x-zarr',
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+        'id': f'dandiasset:{asset.asset_id}',
+        'identifier': str(asset.asset_id),
+        'path': asset.path,
     }
 
 


### PR DESCRIPTION
Originally suggested as a part of the
https://github.com/dandi/dandi-archive/pull/1103

Consistent sorted order improves DX by not needing to do linear search
for a specific field and simplifying matching of listings (e.g. to see if
specific field is lacking from needing to be considered autogenerated etc).