### PR TITLE
Configure mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,0 @@
-[mypy]
-plugins =
-    mypy_django_plugin.main
-
-[mypy.plugins.django-stubs]
-django_settings_module = "dandiapi.settings"
-
-[mypy-celery.*]
-ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,25 @@ line_length = 100
 force_sort_within_sections = true
 # Combines "as" imports on the same line
 combine_as_imports = true
+
+[tool.mypy]
+ignore_missing_imports = true
+show_error_codes = true
+disable_error_code = ["attr-defined", "var-annotated"]
+follow_imports = "skip" # Don't follow imports into other files. This should be removed once all type errors have been resolved.
+exclude = [
+    "^dandiapi/api/admin.py",
+    "^dandiapi/api/mail.py",
+    "^dandiapi/api/tests/",
+    "^dandiapi/api/management/",
+    "^dandiapi/api/migrations/",
+    "^dandiapi/api/models/",
+    "^dandiapi/api/tasks/",
+    "^dandiapi/api/views/",
+]
+
+# Re-enable these when https://github.com/typeddjango/django-stubs/issues/417 is fixed.
+# plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
+
+# [tool.django-stubs]
+# django_settings_module = "dandiapi.settings"

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,9 @@ setup(
             'ipython',
             'tox',
             'boto3-stubs[s3]',
+            'django-stubs',
+            'djangorestframework-stubs',
+            'types-setuptools',
             'memray',
         ],
         'test': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     lint,
+    type,
     test,
     check-migrations,
 
@@ -19,14 +20,12 @@ commands =
     flake8 --config=tox.ini {posargs:.}
 
 [testenv:type]
-skipsdist = true
-skip_install = true
 deps =
     mypy
-    django-stubs
-    djangorestframework-stubs
+extras =
+    dev
 commands =
-    mypy {posargs:.}
+    mypy {posargs:dandiapi/}
 
 [testenv:format]
 skipsdist = true


### PR DESCRIPTION
Closes #1232.

This makes the necessary changes to `tox.ini` to enable `mypy` static type-checking locally and in CI. Type-checking can be run via `tox -e type`.