### PR TITLE
Fix type errors in `tasks`

### DIFF
--- a/dandiapi/api/tasks/zarr.py
+++ b/dandiapi/api/tasks/zarr.py
@@ -116,7 +116,7 @@ def ingest_zarr_archive(
 
     # Zarr is in correct state, lock until ingestion finishes
     with transaction.atomic():
-        zarr: ZarrArchive = ZarrArchive.objects.select_for_update().get(zarr_id=zarr_id)
+        zarr = ZarrArchive.objects.select_for_update().get(zarr_id=zarr_id)
 
         # Reset before compute
         if not no_size:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ exclude = [
     "^dandiapi/api/management/",
     "^dandiapi/api/migrations/",
     "^dandiapi/api/models/",
-    "^dandiapi/api/tasks/",
     "^dandiapi/api/views/",
 ]
 


### PR DESCRIPTION
Removes `dandiapi/api/tasks` from the excluded files list in mypy, and fixes all type errors reported by it.