### PR TITLE
Fix type errors in `models`

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -255,7 +255,7 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
                 source_key=self.embargoed_blob.blob.name,
                 dest_bucket=settings.DANDI_DANDISETS_BUCKET_NAME,
                 dest_key=Upload.object_key(
-                    self.embargoed_blob.blob_id, self.embargoed_blob.dandiset
+                    self.embargoed_blob.blob_id, dandiset=self.embargoed_blob.dandiset
                 ),
             )
 

--- a/dandiapi/api/models/dandiset.py
+++ b/dandiapi/api/models/dandiset.py
@@ -53,7 +53,7 @@ class Dandiset(TimeStampedModel):
         permissions = [('owner', 'Owns the dandiset')]
 
     @property
-    def identifier(self) -> str | None:
+    def identifier(self) -> str:
         # Compare against None, to allow id 0
         return f'{self.id:06}' if self.id is not None else ''
 

--- a/dandiapi/api/models/upload.py
+++ b/dandiapi/api/models/upload.py
@@ -41,13 +41,13 @@ class BaseUpload(TimeStampedModel):
 
     @staticmethod
     @abstractmethod
-    def object_key(upload_id, dandiset: Dandiset | None = None):  # noqa: N805
+    def object_key(upload_id, *, dandiset: Dandiset):  # noqa: N805
         pass
 
     @classmethod
     def initialize_multipart_upload(cls, etag, size, dandiset: Dandiset):
         upload_id = uuid4()
-        object_key = cls.object_key(upload_id, dandiset)
+        object_key = cls.object_key(upload_id, dandiset=dandiset)
         multipart_initialization = cls.blob.field.storage.multipart_manager.initialize_upload(
             object_key, size
         )
@@ -78,7 +78,7 @@ class Upload(BaseUpload):
     dandiset = models.ForeignKey(Dandiset, related_name='uploads', on_delete=models.CASCADE)
 
     @staticmethod
-    def object_key(upload_id, dandiset: Dandiset | None = None):
+    def object_key(upload_id, *, dandiset: Dandiset | None = None):
         upload_id = str(upload_id)
         return (
             f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}'
@@ -104,7 +104,7 @@ class EmbargoedUpload(BaseUpload):
     )
 
     @staticmethod
-    def object_key(upload_id, dandiset: Dandiset):
+    def object_key(upload_id, *, dandiset: Dandiset):
         upload_id = str(upload_id)
         return (
             f'{settings.DANDI_DANDISETS_EMBARGO_BUCKET_PREFIX}'

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -242,7 +242,7 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
             except Exception:
                 # The assets summary aggregation may fail if any asset metadata is invalid.
                 # If so, just use the placeholder summary.
-                logger.info('Error calculating assetsSummary', exc_info=1)
+                logger.info('Error calculating assetsSummary', exc_info=True)
 
         # Import here to avoid dependency cycle
         from dandiapi.api.manifests import manifest_location

--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -50,10 +50,10 @@ class BaseZarrUploadFile(TimeStampedModel):
 
     objects = ZarrUploadFileManager()
 
-    path: str = models.CharField(max_length=512)
+    path = models.CharField(max_length=512)
     """The path relative to the zarr root"""
 
-    etag: str = models.CharField(max_length=40, validators=[RegexValidator(f'^{ETAG_REGEX}$')])
+    etag = models.CharField(max_length=40, validators=[RegexValidator(f'^{ETAG_REGEX}$')])
 
     @property
     def upload_url(self) -> str:
@@ -73,7 +73,7 @@ class ZarrUploadFile(BaseZarrUploadFile):
     blob = models.FileField(blank=True, storage=get_storage, max_length=1_000)
     """The fully qualified S3 object key"""
 
-    zarr_archive: ZarrArchive = models.ForeignKey(
+    zarr_archive = models.ForeignKey(
         'ZarrArchive',
         related_name='active_uploads',
         on_delete=models.CASCADE,
@@ -84,7 +84,7 @@ class EmbargoedZarrUploadFile(BaseZarrUploadFile):
     blob = models.FileField(blank=True, storage=get_embargo_storage, max_length=1_000)
     """The fully qualified S3 object key"""
 
-    zarr_archive: EmbargoedZarrArchive = models.ForeignKey(
+    zarr_archive = models.ForeignKey(
         'EmbargoedZarrArchive',
         related_name='active_uploads',
         on_delete=models.CASCADE,

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -176,7 +176,7 @@ class EmbargoedAssetBlobFactory(AssetBlobFactory):
     def blob(self):
         return django_files.File(
             file=django_files.base.ContentFile(faker.Faker().binary(self.size)).file,
-            name=EmbargoedUpload.object_key(self.blob_id, self.dandiset),
+            name=EmbargoedUpload.object_key(self.blob_id, dandiset=self.dandiset),
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ exclude = [
     "^dandiapi/api/tests/",
     "^dandiapi/api/management/",
     "^dandiapi/api/migrations/",
-    "^dandiapi/api/models/",
     "^dandiapi/api/views/",
 ]
 


### PR DESCRIPTION
Removes `dandiapi/api/models` from the excluded files list in mypy, and fixes all type errors reported by it.