### PR TITLE
Remove `migrations/` from excluded mypy files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ exclude = [
     "^dandiapi/api/mail.py",
     "^dandiapi/api/tests/",
     "^dandiapi/api/management/",
-    "^dandiapi/api/migrations/",
     "^dandiapi/api/views/",
 ]
 


### PR DESCRIPTION
`mypy` doesn't actually report any type errors in the migrations, so this PR just removes that directory from the excluded list.