### PR TITLE
Remove `management/` directory from excluded mypy files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ exclude = [
     "^dandiapi/api/admin.py",
     "^dandiapi/api/mail.py",
     "^dandiapi/api/tests/",
-    "^dandiapi/api/management/",
     "^dandiapi/api/views/",
 ]
 


### PR DESCRIPTION
`mypy` reports no errors for the management scripts as-is, so this PR just removes it from the excluded list for type-checking.