### PR TITLE
Remove TODO about Django Sites

### DIFF
--- a/dandiapi/api/templates/api/mail/pending_users_message.txt
+++ b/dandiapi/api/templates/api/mail/pending_users_message.txt
@@ -3,6 +3,5 @@ The following new DANDI users are awaiting approval:
 {% for user in users %}
 Username: {{ user.username }}
 Joined: {{ user.date_joined }}
-{# TODO: use Django Sites here instead of hardcoding URL. #}
 Link to approve: {{ dandi_api_url }}{% url 'user-approval' username=user.username %}
 {% endfor %}


### PR DESCRIPTION
We're no longer planning to use Django Sites (#286), so this TODO is no longer valid.