### PR TITLE
Remove unnecessary conditional check for schemaVersion

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -214,12 +214,11 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
             'contentSize': self.size,
             'digest': self.digest,
         }
-        if 'schemaVersion' in metadata:
-            schema_version = metadata['schemaVersion']
-            metadata['@context'] = (
-                'https://raw.githubusercontent.com/dandi/schema/master/releases/'
-                f'{schema_version}/context.json'
-            )
+        schema_version = metadata['schemaVersion']
+        metadata['@context'] = (
+            'https://raw.githubusercontent.com/dandi/schema/master/releases/'
+            f'{schema_version}/context.json'
+        )
         if self.is_zarr:
             metadata['encodingFormat'] = 'application/x-zarr'
         return metadata

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -27,10 +27,11 @@ def test_asset_no_blob_zarr():
 
 
 @pytest.mark.django_db
-def test_asset_blob_and_zarr(asset_blob, zarr_archive):
+def test_asset_blob_and_zarr(draft_asset, zarr_archive):
     # An integrity error is thrown by the constraint that both blob and zarr cannot both be defined
     with pytest.raises(IntegrityError):
-        Asset(blob=asset_blob, zarr=zarr_archive).save()
+        draft_asset.zarr = zarr_archive
+        draft_asset.save()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
It's not possible for this to return false anymore due to database constraints.