### PR TITLE
Fix vuetify console error on DLP

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -82,13 +82,13 @@
                 v-model="showPublishChecklistDialog"
                 width="900"
               >
-                <template #activator>
+                <template #activator="{ on: onNested }">
                   <v-btn
                     block
                     :color="showPublishWarning ? 'error' : 'success'"
                     depressed
                     :disabled="publishButtonDisabled"
-                    @click="showPublishChecklistDialog = true"
+                    v-on="onNested"
                   >
                     Publish
                     <v-spacer />


### PR DESCRIPTION
Fixes the `[Vuetify] The activator slot must be bound, try '<template v-slot:activator="{ on }"><v-btn v-on="on">'` console error that happens on the DLP currently.

This issue was that we were manually setting the `v-model` for the publish checklist `v-dialog` instead of letting Vuetify do it with slots (which is the correct way).