### PR TITLE
Turn off autoescaping for text/plain emails

### DIFF
--- a/dandiapi/api/templates/api/mail/added_message.txt
+++ b/dandiapi/api/templates/api/mail/added_message.txt
@@ -1,1 +1,3 @@
+{% autoescape off %}
 You have been made an owner of Dandiset "{{ dandiset_name }}".
+{% endautoescape %}

--- a/dandiapi/api/templates/api/mail/approved_user_message.txt
+++ b/dandiapi/api/templates/api/mail/approved_user_message.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 Dear {{ greeting_name }},
 
 Your DANDI account has been approved. You can go to {{ dandi_web_app_url }} and login with your GitHub account
@@ -13,3 +14,4 @@ Thank you for choosing DANDI for your neurophysiology data needs.
 Sincerely,
 
 The DANDI team
+{% endautoescape %}

--- a/dandiapi/api/templates/api/mail/new_user_message.txt
+++ b/dandiapi/api/templates/api/mail/new_user_message.txt
@@ -1,5 +1,7 @@
+{% autoescape off %}
 A new user ({{ username }}) has signed up for DANDI.
 
 Please proceed to the following URL to approve or reject their account:
 
 {{ dandi_api_url }}/dashboard/user/{{ username }}
+{% endautoescape %}

--- a/dandiapi/api/templates/api/mail/pending_users_message.txt
+++ b/dandiapi/api/templates/api/mail/pending_users_message.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 The following new DANDI users are awaiting approval:
 
 {% for user in users %}
@@ -5,3 +6,4 @@ Username: {{ user.username }}
 Joined: {{ user.date_joined }}
 Link to approve: {{ dandi_api_url }}{% url 'user-approval' username=user.username %}
 {% endfor %}
+{% endautoescape %}

--- a/dandiapi/api/templates/api/mail/registered_message.txt
+++ b/dandiapi/api/templates/api/mail/registered_message.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 Dear {{ greeting_name }},
 
 Welcome to DANDI.
@@ -21,3 +22,4 @@ Thank you for choosing DANDI for your neurophysiology data needs.
 Sincerely,
 
 The DANDI team
+{% endautoescape %}

--- a/dandiapi/api/templates/api/mail/rejected_user_message.txt
+++ b/dandiapi/api/templates/api/mail/rejected_user_message.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 Dear {{ greeting_name }},
 
 Your DANDI account has been denied approval.
@@ -11,3 +12,4 @@ If you would like to appeal this decision, please contact the DANDI admins at he
 Sincerely,
 
 The DANDI team
+{% endautoescape %}

--- a/dandiapi/api/templates/api/mail/removed_message.txt
+++ b/dandiapi/api/templates/api/mail/removed_message.txt
@@ -1,1 +1,3 @@
+{% autoescape off %}
 You have been removed as an owner of Dandiset "{{ dandiset_name }}".
+{% endautoescape %}


### PR DESCRIPTION
Fixes #1165.

We shouldn't be escaping html entities in plain text emails.