### PR TITLE
Fix asset unembargo method

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -261,18 +261,19 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
             # Assert files are equal
             assert resp.etag == self.embargoed_blob.etag
 
-            # Assign blob
+            # Assign blob (changing only blob)
             self.blob = AssetBlob(
-                blob_id=self.embargoed_blob.blob_id,
-                etag=resp.etag,
                 blob=resp.key,
+                blob_id=self.embargoed_blob.blob_id,
+                sha256=self.embargoed_blob.sha256,
+                etag=self.embargoed_blob.etag,
                 size=self.embargoed_blob.size,
             )
             self.blob.save()
 
         # Save updated blob field
         self.embargoed_blob = None
-        self.save(update_fields=['blob', 'embargoed_blob'])
+        self.save()
 
     def publish(self):
         """

--- a/dandiapi/api/tests/test_unembargo.py
+++ b/dandiapi/api/tests/test_unembargo.py
@@ -14,7 +14,12 @@ from dandiapi.api.models.dandiset import Dandiset
 
 
 @pytest.mark.django_db
-def test_asset_unembargo(asset_factory, embargoed_asset_blob_factory, draft_version):
+def test_asset_unembargo(
+    embargoed_storage, asset_factory, embargoed_asset_blob_factory, draft_version
+):
+    # Pretend like EmbargoedAssetBlob was defined with the given storage
+    EmbargoedAssetBlob.blob.field.storage = embargoed_storage
+
     embargoed_asset_blob: EmbargoedAssetBlob = embargoed_asset_blob_factory()
     embargoed_asset: Asset = asset_factory(embargoed_blob=embargoed_asset_blob, blob=None)
     draft_version.assets.add(embargoed_asset)

--- a/dandiapi/api/tests/test_unembargo.py
+++ b/dandiapi/api/tests/test_unembargo.py
@@ -13,6 +13,33 @@ from dandiapi.api.models import Asset, AssetBlob, EmbargoedAssetBlob, Version
 from dandiapi.api.models.dandiset import Dandiset
 
 
+@pytest.mark.django_db
+def test_asset_unembargo(asset_factory, embargoed_asset_blob_factory, draft_version):
+    embargoed_asset_blob: EmbargoedAssetBlob = embargoed_asset_blob_factory()
+    embargoed_asset: Asset = asset_factory(embargoed_blob=embargoed_asset_blob, blob=None)
+    draft_version.assets.add(embargoed_asset)
+
+    # Assert embargoed properties
+    embargoed_sha256 = embargoed_asset.sha256
+    embargoed_etag = embargoed_asset.embargoed_blob.etag
+    assert embargoed_asset.blob is None
+    assert embargoed_asset.embargoed_blob is not None
+    assert embargoed_asset.sha256 is not None
+    assert 'embargo' in embargoed_asset.metadata['contentUrl'][1]
+
+    # Unembargo
+    embargoed_asset.unembargo()
+    asset = embargoed_asset
+    asset.refresh_from_db()
+
+    # Assert unembargoed properties
+    assert asset.blob is not None
+    assert asset.embargoed_blob is None
+    assert asset.sha256 == embargoed_sha256
+    assert asset.blob.etag == embargoed_etag
+    assert 'embargo' not in asset.metadata['contentUrl'][1]
+
+
 @pytest.mark.parametrize(
     ('embargo_status', 'user_status', 'resp_code'),
     [


### PR DESCRIPTION
Closes #1264
Closes #1278 

There were a couple of things wrong with the asset unembargo method
1. The metadata wasn't saved, so the metadata remained out of date and incorrect
2. The sha256 value wasn't copied to the unembargoed asset blob, leaving that field null.

@yarikoptic I believe the latter is the cause of #1278.