### PR TITLE
Use `exact` prop consistently

### DIFF
--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -24,7 +24,6 @@
             >
               <v-list-item-content
                 v-if="!navItem.external"
-                exact
                 text
                 class="text-md"
               >

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -12,6 +12,7 @@
         params: { identifier: item.dandiset.identifier, origin },
         query: { ...$route.query, pos: getPos(index) },
       }"
+      exact
     >
       <v-list-item-content>
         <v-list-item-title class="wrap-text text-h6 grey--text text--darken-3 pb-1">

--- a/web/src/views/DandisetLandingView/DandisetActions.vue
+++ b/web/src/views/DandisetLandingView/DandisetActions.vue
@@ -74,6 +74,7 @@
           block
           :disabled="currentDandiset.dandiset.embargo_status === 'UNEMBARGOING'"
           :to="fileBrowserLink"
+          exact
         >
           <v-icon
             left

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -61,6 +61,7 @@
               />
               <router-link
                 :to="{ name: 'fileBrowser', query: { location: rootDirectory } }"
+                exact
                 style="text-decoration: none;"
                 class="mx-2"
               >
@@ -73,6 +74,7 @@
                   <router-link
                     :key="part"
                     :to="{ name: 'fileBrowser', query: { location: locationSlice(i) } }"
+                    exact
                     style="text-decoration: none;"
                     class="mx-2"
                   >


### PR DESCRIPTION
Closes #792

Reviewers, please especially look at f4790be63307f95296e467cb0b0968e61923a6f0 and tell me if that `exact` is actually supposed to be there in some other capacity (it has no corresponding `:to`, and doesn't look like it's supposed to).