### PR TITLE
Remove `-s` and `-v` flags from CLI integration test invocation

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run dandi-api tests in dandi-cli
         run: |
-          python -m pytest -s -v --dandi-api \
+          python -m pytest --dandi-api \
             "$pythonLocation/lib/python${{ matrix.python }}/site-packages/dandi"
         env:
           DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"


### PR DESCRIPTION
The CLI tests have been flaky recently, and the large amount of log input makes it difficult to see what's going wrong. The `-s` flag in particular causes the output from _every_ test to be logged in realtime, while the default behavior of pytest is to only log output from failed tests at the conclusion of the test run.