### PR TITLE
Fix link to download help handbook page

### DIFF
--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -19,7 +19,7 @@
         <v-tooltip right>
           <template #activator="{ on }">
             <v-btn
-              href="https://www.dandiarchive.org/handbook/10_using_dandi/#downloading-from-dandi"
+              href="https://www.dandiarchive.org/handbook/12_download/"
               target="_blank"
               rel="noopener"
               text


### PR DESCRIPTION
The current link in the "Download" dropdown on the DLP is invalid.