### PR TITLE
Allow for using django core exceptions with DRF 

### DIFF
--- a/dandiapi/drf_utils.py
+++ b/dandiapi/drf_utils.py
@@ -1,0 +1,30 @@
+from django.core.exceptions import (
+    PermissionDenied as DjangoPermissionDenied,
+    ValidationError as DjangoValidationError,
+)
+from django.http import Http404
+from rest_framework import exceptions as drf_exceptions
+from rest_framework.response import Response
+from rest_framework.serializers import as_serializer_error
+from rest_framework.views import exception_handler
+
+
+def rewrap_django_core_exceptions(exc: Exception, ctx: dict) -> Response | None:
+    """
+    Rewraps core Django exceptions and re-raises them as the DRF equivalent.
+
+    This is useful for allowing internal APIs to throw Django validation errors
+    and be used from DRF endpoints.
+    """
+    if isinstance(exc, DjangoValidationError):
+        exc = drf_exceptions.ValidationError(as_serializer_error(exc))
+
+    if isinstance(exc, Http404):
+        exc = drf_exceptions.NotFound()
+
+    if isinstance(exc, DjangoPermissionDenied):
+        exc = drf_exceptions.PermissionDenied()
+
+    response = exception_handler(exc, ctx)
+
+    return response

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -61,6 +61,10 @@ class DandiMixin(ConfigMixin):
             'DEFAULT_PAGINATION_CLASS'
         ] = 'dandiapi.api.views.common.DandiPagination'
 
+        configuration.REST_FRAMEWORK[
+            'EXCEPTION_HANDLER'
+        ] = 'dandiapi.drf_utils.rewrap_django_core_exceptions'
+
         # If this environment variable is set, the pydantic model will allow URLs with localhost
         # in them. This is important for development and testing environments, where URLs will
         # frequently point to localhost.

--- a/dandiapi/zarr/views/__init__.py
+++ b/dandiapi/zarr/views/__init__.py
@@ -4,7 +4,6 @@ import logging
 from pathlib import Path
 
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError, transaction
 from django.db.models import Exists, OuterRef
 from django.db.models.query import QuerySet
@@ -14,7 +13,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import no_body, swagger_auto_schema
 from rest_framework import serializers, status
 from rest_framework.decorators import action, api_view
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ setup(
         'django-filter',
         'django-guardian',
         'django-oauth-toolkit>=1.7,<2',
-        'djangorestframework',
+        # DRF 3.14 is incompatible with drf-yasg, see
+        # https://github.com/axnsan12/drf-yasg/issues/810
+        'djangorestframework<3.14',
         'djangorestframework-yaml',
         'drf-extensions',
         'drf-yasg',


### PR DESCRIPTION
This creates a custom exception handler for DRF which will properly handle core django exceptions (like `ValidationError`and `PermissionDenied`) and raise them as the DRF versions. I think we should still explicitly the context specific exceptions when we can (e.g. in DRF views) - but this will allow internal APIs that aren't context aware to raise the builtin django exceptions.