### PR TITLE
Add YouTube channel to approved/registered emails

### DIFF
--- a/dandiapi/api/templates/api/mail/approved_user_message.txt
+++ b/dandiapi/api/templates/api/mail/approved_user_message.txt
@@ -8,6 +8,8 @@ Please use the following links to post any questions or issues.
 
 Discussions: https://github.com/dandi/helpdesk/discussions
 Issues: https://github.com/dandi/helpdesk/issues/new/choose
+YouTube: https://www.youtube.com/channel/UCsLLBNhtcV-wL8cCZWveDCA
+(please Subscribe)
 
 Thank you for choosing DANDI for your neurophysiology data needs.
 

--- a/dandiapi/api/templates/api/mail/registered_message.txt
+++ b/dandiapi/api/templates/api/mail/registered_message.txt
@@ -16,6 +16,8 @@ Please use the following links to post any questions or issues.
 
 Discussions: https://github.com/dandi/helpdesk/discussions
 Issues: https://github.com/dandi/helpdesk/issues/new/choose
+YouTube: https://www.youtube.com/channel/UCsLLBNhtcV-wL8cCZWveDCA
+(please Subscribe)
 
 Thank you for choosing DANDI for your neurophysiology data needs.
 


### PR DESCRIPTION
Would be useful for them and for us -- when we reach 100 subscribers, we would be able to get a shortcut name for the channel!