### PR TITLE
Unpin minio docker image and update env var names

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -27,10 +27,10 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:2022.3.3
+        image: bitnami/minio:latest
         env:
-          MINIO_ACCESS_KEY: minioAccessKey
-          MINIO_SECRET_KEY: minioSecretKey
+          MINIO_ROOT_USER: minioAccessKey
+          MINIO_ROOT_PASSWORD: minioSecretKey
         ports:
           - 9000:9000
     steps:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -45,10 +45,10 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:2022.3.3
+        image: bitnami/minio:latest
         env:
-          MINIO_ACCESS_KEY: minioAccessKey
-          MINIO_SECRET_KEY: minioSecretKey
+          MINIO_ROOT_USER: minioAccessKey
+          MINIO_ROOT_PASSWORD: minioSecretKey
         ports:
           - 9000:9000
     env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
       - ${DOCKER_RABBITMQ_CONSOLE_PORT-15672}:15672
 
   minio:
-    image: minio/minio:RELEASE.2022-03-03T21-21-16Z
+    image: minio/minio:latest
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]
     environment:
-      MINIO_ACCESS_KEY: minioAccessKey
-      MINIO_SECRET_KEY: minioSecretKey
+      MINIO_ROOT_USER: minioAccessKey
+      MINIO_ROOT_PASSWORD: minioSecretKey
     ports:
       - ${DOCKER_MINIO_PORT-9000}:9000
       - ${DOCKER_MINIO_CONSOLE_PORT-9001}:9001


### PR DESCRIPTION
The latest minio docker image wasn't working for us because minio updated the names of the username/password env vars recently https://github.com/minio/minio/blob/master/docs/config/README.md#credentials. 