### PR TITLE
Update frontend to use new query parameter for version listing endpoint

### DIFF
--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -161,7 +161,7 @@ const dandiRest = new Vue({
     },
     async mostRecentVersion(identifier: string) {
       // Look up the last version using page filters
-      const versions = await this.versions(identifier, { page_size: 1, ordering: '-created' });
+      const versions = await this.versions(identifier, { page_size: 1, order: '-created' });
       if (versions === null) {
         return null;
       }


### PR DESCRIPTION
When I merged #1308 I didn't realize the frontend made use of that query param :facepalm: 