### PR TITLE
Add additional waits to account E2E test

### DIFF
--- a/web/test/src/tests/account.test.js
+++ b/web/test/src/tests/account.test.js
@@ -9,6 +9,7 @@ import {
   LOGIN_BUTTON_TEXT,
   LOGOUT_BUTTON_TEXT,
   TEST_USER_INITIALS,
+  waitForRequestsToFinish,
 } from '../util';
 
 describe('account management', () => {
@@ -16,8 +17,9 @@ describe('account management', () => {
     await registerNewUser();
 
     await expect(page).toClickXPath(vAvatar(TEST_USER_INITIALS));
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(500); // wait for vuetify animation to finish
     await expect(page).toClickXPath(vListItem(LOGOUT_BUTTON_TEXT, { action: vIcon('mdi-logout') }));
+    await waitForRequestsToFinish();
 
     // this text is only displayed when not logged in
     await expect(page).toMatch(LOGIN_BUTTON_TEXT);
@@ -28,10 +30,13 @@ describe('account management', () => {
 
     // Logout
     await expect(page).toClickXPath(vAvatar(TEST_USER_INITIALS));
+    await page.waitForTimeout(500); // wait for vuetify animation to finish
     await expect(page).toClickXPath(vListItem(LOGOUT_BUTTON_TEXT, { action: vIcon('mdi-logout') }));
+    await waitForRequestsToFinish();
 
     // Test logging in
     await expect(page).toClickXPath(vBtn(LOGIN_BUTTON_TEXT));
+    await waitForRequestsToFinish();
 
     // the user avatar contains the initials and is only rendered when logged in successfully
     await expect(page).toContainXPath(vAvatar(TEST_USER_INITIALS));


### PR DESCRIPTION
Since merging #1306, this particular test has been flaky in CI for me. I suspect it might be because we're running a much newer version of puppeteer than we were before. This PR adds additional calls to `waitForRequestsToFinish` to ensure background API calls are completed before the automated browser starts clicking things.