### PR TITLE
Improved pagination design in file browser

### DIFF
--- a/web/src/components/FileBrowser/FileBrowserPagination.vue
+++ b/web/src/components/FileBrowser/FileBrowserPagination.vue
@@ -77,5 +77,10 @@ const emit = defineEmits(['changePage']);
 const pageInput = ref(props.page.toString());
 
 watch(() => props.page, (newPage) => { pageInput.value = newPage.toString(); });
-watch(pageInput, (newPage) => emit('changePage', Number(newPage)));
+watch(pageInput, (newPage) => {
+  const page = Number(newPage);
+  if (page > 0 && page <= props.pageCount) {
+    emit('changePage', page);
+  }
+});
 </script>

--- a/web/src/components/FileBrowser/FileBrowserPagination.vue
+++ b/web/src/components/FileBrowser/FileBrowserPagination.vue
@@ -32,6 +32,7 @@
       :maxlength="pageCount"
       :rules="[pageIsValid]"
     />
+    <span>of {{ pageCount }}</span>
     <v-btn
       class="mx-2"
       color="white"

--- a/web/src/components/FileBrowser/FileBrowserPagination.vue
+++ b/web/src/components/FileBrowser/FileBrowserPagination.vue
@@ -1,0 +1,80 @@
+<template>
+  <div
+    class="d-flex justify-center align-center text-center"
+  >
+    <v-btn
+      class="mx-2"
+      color="white"
+      :disabled="page === 1 || !pageIsValid(page)"
+      @click="emit('changePage', 1)"
+    >
+      <v-icon>mdi-chevron-double-left</v-icon>
+    </v-btn>
+    <v-btn
+      class="mx-2"
+      color="white"
+      :disabled="page === 1 || !pageIsValid(page)"
+      @click="emit('changePage', page - 1)"
+    >
+      <v-icon>mdi-chevron-left</v-icon>
+    </v-btn>
+    <v-text-field
+      v-model="pageInput"
+      hide-details
+      single-line
+      type="number"
+      dense
+      style="max-width: 5%;"
+      class="pa-0 mx-2 my-0"
+      filled
+      min="1"
+      :max="pageCount"
+      :maxlength="pageCount"
+      :rules="[pageIsValid]"
+    />
+    <v-btn
+      class="mx-2"
+      color="white"
+      :disabled="page === pageCount || !pageIsValid(page)"
+      @click="emit('changePage', page + 1)"
+    >
+      <v-icon>mdi-chevron-right</v-icon>
+    </v-btn>
+    <v-btn
+      class="mx-2"
+      color="white"
+      :disabled="page === pageCount || !pageIsValid(page)"
+      @click="emit('changePage', pageCount)"
+    >
+      <v-icon>mdi-chevron-double-right</v-icon>
+    </v-btn>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+  page: {
+    type: Number,
+    required: true,
+  },
+  pageCount: {
+    type: Number,
+    required: true,
+  },
+});
+
+function pageIsValid(page: number): boolean {
+  return page > 0 && page <= props.pageCount;
+}
+
+const emit = defineEmits(['changePage']);
+
+// Note: the v-textfield `v-model` returns a string value despite its type being 'number', so
+// we have to handle converting back and forth below.
+const pageInput = ref(props.page.toString());
+
+watch(() => props.page, (newPage) => { pageInput.value = newPage.toString(); });
+watch(pageInput, (newPage) => emit('changePage', Number(newPage)));
+</script>

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -225,9 +225,10 @@
           </v-card>
         </v-col>
       </v-row>
-      <v-pagination
-        v-model="page"
-        :length="pages"
+      <FileBrowserPagination
+        :page="page"
+        :page-count="pages"
+        @changePage="page = $event;"
       />
     </v-container>
   </div>
@@ -245,6 +246,7 @@ import { trimEnd } from 'lodash';
 import { dandiRest } from '@/rest';
 import { useDandisetStore } from '@/stores/dandiset';
 import { AssetFile, AssetPath } from '@/types';
+import FileBrowserPagination from '@/components/FileBrowser/FileBrowserPagination.vue';
 
 const rootDirectory = '';
 const FILES_PER_PAGE = 15;
@@ -314,6 +316,7 @@ type Service = typeof EXTERNAL_SERVICES[0];
 
 export default defineComponent({
   name: 'FileBrowser',
+  components: { FileBrowserPagination },
   props: {
     identifier: {
       type: String,


### PR DESCRIPTION
Fixes #725.

I implemented Jared's design from #725, and also added an error message when an invalid path is entered by the user. 
Previously, a user would only run into this error if they manually edited the query params in the browser URL bar, so our very basic solution was to just kick the user back to the root directory of the dandiset if that happened. But now that there's an input to specify the page number, it's much easier for a user to enter something invalid. So, I've changed this behavior to display an error message instead of kicking them back to the root. 
I still think the UX here could use some significant improvement, but for the purposes of this PR I think it's sufficient.