### PR TITLE
Prevent deletion of dandisets currently being published

### DIFF
--- a/dandiapi/api/services/dandiset/__init__.py
+++ b/dandiapi/api/services/dandiset/__init__.py
@@ -54,5 +54,7 @@ def delete_dandiset(*, user, dandiset: Dandiset) -> None:
 
     if dandiset.versions.exclude(version='draft').exists():
         raise PermissionDenied('Cannot delete dandisets with published versions.')
+    if dandiset.versions.filter(status=Version.Status.PUBLISHING).exists():
+        raise PermissionDenied('Cannot delete dandisets that are currently being published.')
 
     dandiset.delete()


### PR DESCRIPTION
This fixes the underlying issue causing these two sentry errors
https://sentry.io/organizations/dandiarchive/issues/3650822437/?project=5266078&query=is%3Aunresolved
https://sentry.io/organizations/dandiarchive/issues/3650556448/?project=5266078&query=is%3Aunresolved

Both of them are from an attempt to publish dandiset 204774 in staging, which doesn't exist. I'm guessing what happened is the user
1) created the dandiset
2) uploaded assets
3) clicked publish
4) deleted the dandiset.

There's a potential race condition in there between 3 and 4 where the queue is backed up with so many tasks that the publish task doesn't get kicked off until much later, potentially after the user has deleted the dandiset. In production we have dedicated queues for long-running tasks like checksumming and zarr ingestion, so the chances of a publish task getting stuck waiting to be picked up from the queue are low. However in staging we only have a single celery worker, which is what caused this to surface.