### PR TITLE
Revert "[gh-actions](deps): Bump actions/add-to-project from 0.0.3 to 0.3.0"

### DIFF
--- a/.github/workflows/auto-add-issues.yml
+++ b/.github/workflows/auto-add-issues.yml
@@ -11,7 +11,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@v0.0.3
         with:
           project-url: https://github.com/orgs/dandi/projects/16
           github-token: ${{ secrets.AUTO_ADD_ISSUES }}


### PR DESCRIPTION
Reverts dandi/dandi-archive#1325

Adding issues to the project board fails after merging this https://github.com/dandi/dandi-archive/actions/runs/3238087336. i guess there are some changes needed here, reverting for now so we don't miss any issues