### PR TITLE
Wait until after publish transaction commits to create DOI

### DIFF
--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -226,6 +226,10 @@ def publish_task(version_id: int):
 
     # Write updated manifest files and create DOI after published version has been committed to DB.
     transaction.on_commit(lambda: write_manifest_files.delay(new_version.id))
-    transaction.on_commit(
-        lambda: Version.objects.filter(id=new_version.id).update(doi=doi.create_doi(new_version))
-    )
+
+    def _create_doi(version_id: int):
+        version = Version.objects.get(id=version_id)
+        version.doi = doi.create_doi(version)
+        version.save()
+
+    transaction.on_commit(lambda: _create_doi(new_version.id))

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -252,6 +252,7 @@ def test_publish_task(
     draft_asset_factory,
     published_asset_factory,
     draft_version_factory,
+    django_capture_on_commit_callbacks,
 ):
     # Create a draft_version in PUBLISHING state
     draft_version: Version = draft_version_factory(status=Version.Status.PUBLISHING)
@@ -270,7 +271,10 @@ def test_publish_task(
 
     # Ensure that the number of versions increases by 1 after publishing
     starting_version_count = draft_version.dandiset.versions.count()
-    tasks.publish_task(draft_version.id)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        tasks.publish_task(draft_version.id)
+
     assert draft_version.dandiset.versions.count() == starting_version_count + 1
 
     draft_version.refresh_from_db()


### PR DESCRIPTION
Following up on https://github.com/dandi/dandi-archive/pull/1006#discussion_r976903612