### PR TITLE
Add Dandi exception classes

### DIFF
--- a/dandiapi/api/services/dandiset/exceptions.py
+++ b/dandiapi/api/services/dandiset/exceptions.py
@@ -1,0 +1,7 @@
+from rest_framework import status
+
+from dandiapi.api.services.exceptions import DandiException
+
+
+class DandisetAlreadyExists(DandiException):
+    http_status_code = status.HTTP_400_BAD_REQUEST

--- a/dandiapi/api/services/exceptions.py
+++ b/dandiapi/api/services/exceptions.py
@@ -1,0 +1,23 @@
+from rest_framework import status
+
+
+class DandiException(Exception):
+    message: str | None
+    http_status_code: int | None
+
+    def __init__(
+        self, message: str | None = None, http_status_code: int | None = None, *args: object
+    ) -> None:
+        self.message = message or self.message
+        self.http_status_code = http_status_code or self.http_status_code
+
+        super().__init__(*args)
+
+
+class NotAllowed(DandiException):
+    message = 'Action not allowed'
+    http_status_code = status.HTTP_403_FORBIDDEN
+
+
+class AdminOnlyOperation(DandiException):
+    pass

--- a/dandiapi/drf_utils.py
+++ b/dandiapi/drf_utils.py
@@ -8,6 +8,8 @@ from rest_framework.response import Response
 from rest_framework.serializers import as_serializer_error
 from rest_framework.views import exception_handler
 
+from dandiapi.api.services.exceptions import DandiException
+
 
 def rewrap_django_core_exceptions(exc: Exception, ctx: dict) -> Response | None:
     """
@@ -23,6 +25,8 @@ def rewrap_django_core_exceptions(exc: Exception, ctx: dict) -> Response | None:
             return Response(exc.error_list[0].message, status=status.HTTP_400_BAD_REQUEST)
         else:
             exc = drf_exceptions.ValidationError(as_serializer_error(exc))
+    elif isinstance(exc, DandiException):
+        return Response(exc.message, status=exc.http_status_code or status.HTTP_400_BAD_REQUEST)
 
     if isinstance(exc, Http404):
         exc = drf_exceptions.NotFound()

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,8 @@ ignore =
     D10,
     # variables should be lowercased
     N806,
+    # exceptions need Error in their name
+    N818
 extend-exclude =
     build,
     dist,


### PR DESCRIPTION
This adds specific exceptions that the services module is going to start making use of. This is part of an effort to let our different contexts (celery, drf, cli, etc) catch errors and handle them appropriately.

I'm marking this as draft for the moment because I'd like to try it out on one or two subsequent PRs.