### PR TITLE
Fix asset update/deletion when associated with zarr

### DIFF
--- a/dandiapi/api/asset_paths.py
+++ b/dandiapi/api/asset_paths.py
@@ -160,14 +160,14 @@ def add_version_asset_paths(version: Version):
 def add_zarr_paths(zarr: ZarrArchive):
     """Add all asset paths that are associated with a zarr."""
     # Only act on draft assets/versions
-    for asset in zarr.assets.filter(published=False):
-        for version in asset.versions.filter(version='draft'):
+    for asset in zarr.assets.filter(published=False).iterator():
+        for version in asset.versions.filter(version='draft').iterator():
             add_asset_paths(asset, version)
 
 
 def delete_zarr_paths(zarr: ZarrArchive):
     """Remove all asset paths that are associated with a zarr."""
     # Only act on draft assets/versions
-    for asset in zarr.assets.filter(published=False):
-        for version in asset.versions.filter(version='draft'):
+    for asset in zarr.assets.filter(published=False).iterator():
+        for version in asset.versions.filter(version='draft').iterator():
             delete_asset_paths(asset, version)

--- a/dandiapi/api/asset_paths.py
+++ b/dandiapi/api/asset_paths.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from django.db.models import Count, F, QuerySet
 
 from dandiapi.api.models import Asset, AssetPath, AssetPathRelation, Version
+from dandiapi.zarr.models import ZarrArchive
 
 ####################################################################
 # Dandiset and version deletion will cascade to asset path deletion.
@@ -154,3 +155,19 @@ def add_version_asset_paths(version: Version):
     """Add every asset from a version."""
     for asset in version.assets.iterator():
         add_asset_paths(asset, version)
+
+
+def add_zarr_paths(zarr: ZarrArchive):
+    """Add all asset paths that are associated with a zarr."""
+    # Only act on draft assets/versions
+    for asset in zarr.assets.filter(published=False):
+        for version in asset.versions.filter(version='draft'):
+            add_asset_paths(asset, version)
+
+
+def delete_zarr_paths(zarr: ZarrArchive):
+    """Remove all asset paths that are associated with a zarr."""
+    # Only act on draft assets/versions
+    for asset in zarr.assets.filter(published=False):
+        for version in asset.versions.filter(version='draft'):
+            delete_asset_paths(asset, version)


### PR DESCRIPTION
Closes #1336 

The reported issue was caused by the following:

* When a zarr is created and associated to an asset (but not ingested) it initially has a size of zero
* Ingest can then be performed, giving it a non-zero size
* If the containing asset is then updated / deleted, all parent paths are updated, decrementing the size of the asset. However, now that size is non-zero, and was never updated, so a possibly zero value is being decremented by a non-zero value, causing the value to be negative, and throwing an integrity error.

This PR updates the `ingest_zarr_archive` task to delete all asset paths that are associated with the zarr, and then re-add them after the ingestion is finished. This is essentially the same process as updating an asset path (path deletion and immediate addition), but with zarr ingestion in the middle.