### PR TITLE
Disable pulling of all Docker images from Docker Hub

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -47,6 +47,7 @@ jobs:
           - master
     env:
       DANDI_ALLOW_LOCALHOST_URLS: 1
+      DANDI_TESTS_PULL_DOCKER_COMPOSE: 0
     steps:
       - name: Download Docker image tarball
         uses: actions/download-artifact@v3


### PR DESCRIPTION
See https://github.com/dandi/dandi-archive/issues/1336#issuecomment-1286926124 etc.; depends on https://github.com/dandi/dandi-cli/pull/1141.