### PR TITLE
Optimize version/zarr asset path ingestion

### DIFF
--- a/dandiapi/api/asset_paths.py
+++ b/dandiapi/api/asset_paths.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import os
 
-from django.db import transaction
-from django.db.models import Count, F, QuerySet
+from django.db.models import Count, F, QuerySet, Sum
+from django.db.models.functions import Coalesce
+from django.db.transaction import atomic
 
 from dandiapi.api.models import Asset, AssetPath, AssetPathRelation, Version
 from dandiapi.zarr.models import ZarrArchive
@@ -72,13 +74,12 @@ def search_asset_paths(query: str, version: Version) -> QuerySet[AssetPath] | No
     return get_path_children(path)
 
 
-# TODO: Make idempotent
-@transaction.atomic()
-def add_asset_paths(asset: Asset, version: Version):
+def insert_asset_paths(asset: Asset, version: Version):
+    """Add all intermediate paths from an asset and link them together."""
     # Get or create leaf path
     leaf, created = AssetPath.objects.get_or_create(path=asset.path, asset=asset, version=version)
     if not created:
-        return
+        return leaf
 
     # Create absolute paths (exclude leaf node)
     nodepaths = extract_paths(asset.path)[:-1]
@@ -105,69 +106,103 @@ def add_asset_paths(asset: Asset, version: Version):
     # Create objects
     AssetPathRelation.objects.bulk_create(links, ignore_conflicts=True)
 
-    # Get all relations (including leaf node)
-    parent_ids = (
-        AssetPathRelation.objects.filter(child=leaf)
-        .distinct('parent')
-        .values_list('parent', flat=True)
-    )
-
-    # Update size + file count
-    AssetPath.objects.filter(id__in=parent_ids).update(
-        aggregate_size=F('aggregate_size') + asset.size, aggregate_files=F('aggregate_files') + 1
-    )
+    return leaf
 
 
-@transaction.atomic()
-def delete_asset_paths(asset: Asset, version: Version):
-    leaf: AssetPath = AssetPath.objects.get(asset=asset, version=version)
+# TODO: Make idempotent
+def add_asset_paths(asset: Asset, version: Version, transaction=True):
+    with atomic() if transaction else contextlib.nullcontext():
+        # Insert leaf node and all required parent paths
+        leaf = insert_asset_paths(asset, version)
 
-    # Fetch parents
-    parent_ids = (
-        AssetPathRelation.objects.filter(child=leaf)
-        .distinct('parent')
-        .values_list('parent', flat=True)
-    )
-    parent_paths = AssetPath.objects.filter(id__in=parent_ids)
+        # Increment the size and file count of all parent paths.
+        # Get all relations (including leaf node)
+        parent_ids = (
+            AssetPathRelation.objects.filter(child=leaf)
+            .distinct('parent')
+            .values_list('parent', flat=True)
+        )
 
-    # Update parents
-    parent_paths.update(
-        aggregate_size=F('aggregate_size') - asset.size, aggregate_files=F('aggregate_files') - 1
-    )
-
-    # Ensure integrity
-    leaf.refresh_from_db()
-    assert leaf.aggregate_size == 0
-    assert leaf.aggregate_files == 0
-
-    # Delete leaf node and any other paths with no contained files
-    AssetPath.objects.filter(aggregate_files=0).delete()
+        # Update size + file count
+        AssetPath.objects.filter(id__in=parent_ids).update(
+            aggregate_size=F('aggregate_size') + leaf.asset.size,
+            aggregate_files=F('aggregate_files') + 1,
+        )
 
 
-@transaction.atomic()
+def delete_asset_paths(asset: Asset, version: Version, transaction=True):
+    with atomic() if transaction else contextlib.nullcontext():
+        leaf: AssetPath = AssetPath.objects.get(asset=asset, version=version)
+
+        # Fetch parents
+        parent_ids = (
+            AssetPathRelation.objects.filter(child=leaf)
+            .distinct('parent')
+            .values_list('parent', flat=True)
+        )
+        parent_paths = AssetPath.objects.filter(id__in=parent_ids)
+
+        # Update parents
+        parent_paths.update(
+            aggregate_size=F('aggregate_size') - asset.size,
+            aggregate_files=F('aggregate_files') - 1,
+        )
+
+        # Ensure integrity
+        leaf.refresh_from_db()
+        assert leaf.aggregate_size == 0
+        assert leaf.aggregate_files == 0
+
+        # Delete leaf node and any other paths with no contained files
+        AssetPath.objects.filter(aggregate_files=0).delete()
+
+
+@atomic()
 def update_asset_paths(old_asset: Asset, new_asset: Asset, version: Version):
-    delete_asset_paths(old_asset, version)
-    add_asset_paths(new_asset, version)
+    delete_asset_paths(old_asset, version, transaction=False)
+    add_asset_paths(new_asset, version, transaction=False)
 
 
-@transaction.atomic()
+@atomic()
 def add_version_asset_paths(version: Version):
     """Add every asset from a version."""
-    for asset in version.assets.iterator():
-        add_asset_paths(asset, version)
+    for asset in version.assets.all().iterator():
+        insert_asset_paths(asset, version)
+
+    # Compute aggregate file size + count for each non-leaf asset path, instead of when each asset
+    # is added. This is done because updating the same row many times within a transaction is slow.
+    # https://stackoverflow.com/a/60221875
+    nodes = AssetPath.objects.filter(version=version, asset__isnull=True)
+    for node in nodes:
+        child_link_ids = node.child_links.distinct('child_id').values_list('child_id', flat=True)
+        child_leaves = AssetPath.objects.filter(id__in=child_link_ids, asset__isnull=False).exclude(
+            id=node.id
+        )
+
+        # Get all aggregates
+        sizes = child_leaves.aggregate(
+            size=Coalesce(Sum('asset__blob__size'), 0),
+            esize=Coalesce(Sum('asset__embargoed_blob__size'), 0),
+            zsize=Coalesce(Sum('asset__zarr__size'), 0),
+        )
+
+        node.aggregate_files += child_leaves.count()
+        node.aggregate_size += sizes['size'] + sizes['esize'] + sizes['zsize']
 
 
+@atomic()
 def add_zarr_paths(zarr: ZarrArchive):
     """Add all asset paths that are associated with a zarr."""
     # Only act on draft assets/versions
     for asset in zarr.assets.filter(published=False).iterator():
         for version in asset.versions.filter(version='draft').iterator():
-            add_asset_paths(asset, version)
+            add_asset_paths(asset, version, transaction=False)
 
 
+@atomic()
 def delete_zarr_paths(zarr: ZarrArchive):
     """Remove all asset paths that are associated with a zarr."""
     # Only act on draft assets/versions
     for asset in zarr.assets.filter(published=False).iterator():
         for version in asset.versions.filter(version='draft').iterator():
-            delete_asset_paths(asset, version)
+            delete_asset_paths(asset, version, transaction=False)


### PR DESCRIPTION
This unblocks asset path ingestion in staging/prod. Previously, transactions were being used in such an inefficient way that ingestion would essentially halt.