### PR TITLE
Fix dandiset deletion when containing zarrs

### DIFF
--- a/dandiapi/api/services/dandiset/__init__.py
+++ b/dandiapi/api/services/dandiset/__init__.py
@@ -57,4 +57,7 @@ def delete_dandiset(*, user, dandiset: Dandiset) -> None:
     if dandiset.versions.filter(status=Version.Status.PUBLISHING).exists():
         raise PermissionDenied('Cannot delete dandisets that are currently being published.')
 
+    # Delete all versions first, so that AssetPath deletion is cascaded
+    # through versions, rather than through zarrs directly
+    dandiset.versions.all().delete()
     dandiset.delete()


### PR DESCRIPTION
Closes #1344 

This bug was due to the fact that zarrs are directly associated with a dandiset, and it so happened that their deletion was cascaded before the deletion of any dandiset versions. Since direct asset deletion is [protected](https://github.com/dandi/dandi-archive/blob/7c153de02726c89beddc35526e93a0c7d317f880/dandiapi/api/models/asset_paths.py#L12-L15) (to avoid desync), this caused an exception.