### PR TITLE
Disable APPROVE button if user is already approved

### DIFF
--- a/dandiapi/api/templates/dashboard/user_approval.html
+++ b/dandiapi/api/templates/dashboard/user_approval.html
@@ -80,7 +80,11 @@
         <form method="POST">
           {% csrf_token %}
           <input type="hidden" name="status" value="REJECTED">
-          <button class="waves-effect waves-light btn-large red accent-5 mb-5" type="submit">
+          <button
+            {% if user.metadata.status == 'REJECTED' %}
+              disabled
+            {% endif %}
+            class="waves-effect waves-light btn-large red accent-5 mb-5" type="submit">
             <span>REJECT</span>
           </button>
           <br /><br /><br />

--- a/dandiapi/api/templates/dashboard/user_approval.html
+++ b/dandiapi/api/templates/dashboard/user_approval.html
@@ -66,7 +66,11 @@
         <form method="POST">
           {% csrf_token %}
           <input type="hidden" name="status" value="APPROVED">
-          <button class="waves-effect waves-light btn-large green accent-5" type="submit">
+          <button
+            {% if user.metadata.status == 'APPROVED' %}
+              disabled
+            {% endif %}
+            class="waves-effect waves-light btn-large green accent-5" type="submit">
             <span>APPROVE</span>
           </button>
         </form>


### PR DESCRIPTION
This conditionally disables the approve button when a user's status is `APPROVED`.

The `REJECT` button remains enabled in case we need to revoke approval from a user for some reason (attn: @satra, is this correct?)

Closes #1341.