### PR TITLE
Fix oauth client error

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
-    "@girder/oauth-client": "^0.7.7",
+    "@girder/oauth-client": "^0.8.0",
     "@koumoul/vjsf": "^2.5.2",
     "@sentry/integrations": "^7.13.0",
     "@sentry/tracing": "^7.13.0",

--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -24,7 +24,7 @@ let oauthClient: OAuthClient | null = null;
 try {
   if (process.env.VUE_APP_OAUTH_API_ROOT && process.env.VUE_APP_OAUTH_CLIENT_ID) {
     oauthClient = new OAuthClient(
-      process.env.VUE_APP_OAUTH_API_ROOT,
+      new URL(process.env.VUE_APP_OAUTH_API_ROOT),
       process.env.VUE_APP_OAUTH_CLIENT_ID,
     );
   }

--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -26,6 +26,7 @@ try {
     oauthClient = new OAuthClient(
       new URL(process.env.VUE_APP_OAUTH_API_ROOT),
       process.env.VUE_APP_OAUTH_CLIENT_ID,
+      { redirectUrl: new URL(window.location.origin) },
     );
   }
 } catch (e) {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -987,10 +987,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@girder/oauth-client@^0.7.7":
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/@girder/oauth-client/-/oauth-client-0.7.8.tgz#519970a1b3dc867e501e75b1770c088be53110cf"
-  integrity sha512-ZjniIA4Q1OIO2Ba3suAqClUw6ENUeBiLNTSRJ62fRCPUJDci5VmIb3WvhoELw44x5aR7lbVfCiUmfu3/xL3zGA==
+"@girder/oauth-client@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@girder/oauth-client/-/oauth-client-0.8.0.tgz#6bb6c85edd6cf7892c35ff2951076c49809b048c"
+  integrity sha512-uOEKyerB3BArN/t4UJxA2+L35ykidk60RNN+XwFXlVUVjZMuajaLFB6/r53Tr977/k8D1RJnBjosAfgl7oLTzg==
   dependencies:
     "@openid/appauth" "^1.3.0"
 


### PR DESCRIPTION
[The `girder-oauth-client` library defaults to `window.location` for the OAuth redirect URL](https://github.com/girder/girder-oauth-client/blob/master/src/oauth-client.ts#L22). That means when trying to log in from, for example, https://dandiarchive.org/dandiset/000108, the oauth client was sending `https://dandiarchive.org/dandiset/000108` as the redirect URL. 

Note that this approached worked fine before #997 since we were using "fake" hash-based URLs, but now that we're using history mode, `https://dandiarchive.org/dandiset/000108` != `https://dandiarchive.org/` for redirect URLs.

This PR updates our oauth client to always use the current URL's `origin` instead of the entire URL. Note, explicitly specifying the redirect URL was introduced in girder-oauth-client 0.8.0, so this PR also updates us to that version.

Fixes #1353