### PR TITLE
Pin mypy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
 
 [testenv:type]
 deps =
-    mypy
+    mypy==0.982
 extras =
     dev
 commands =


### PR DESCRIPTION
The latest `mypy` release introduced new checks that cause our codebase to fail type-checking. This PR pins `mypy` to the previous release for now.