### PR TITLE
Separate backend CI into separate jobs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-env: [lint, type, test, check-migrations]
     services:
       postgres:
         image: postgres:latest
@@ -45,7 +49,7 @@ jobs:
           pip install tox
       - name: Run tests
         run: |
-          tox
+          tox -e ${{ matrix.tox-env }}
         env:
           DJANGO_DATABASE_URL: postgres://postgres:postgres@localhost:5432/django
           DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000


### PR DESCRIPTION
IMO it's annoying to have to open the job logs and sift through the entire log output from flake8, mypy, pytest, and the migrations check just to figure out why one of them failed. Any objections to running these in separate jobs so it's easy to distinguish? This will make it easier to tell at-a-glance which one failed, and also declutter the log outputs.