### PR TITLE
Increase asset validation celery task timeout

### DIFF
--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -83,7 +83,7 @@ def collect_validation_errors(
     return [encoder(error) for error in error.errors]
 
 
-@shared_task(soft_time_limit=10)
+@shared_task(soft_time_limit=60)
 @atomic
 def validate_asset_metadata(asset_id: int) -> None:
     logger.info('Validating asset metadata for asset %s', asset_id)


### PR DESCRIPTION
Now that we're also saving every associated version, this might take longer than 10 seconds.

The main contributor to the potentially long validation time is the fact that we loop over every `Asset` in a `Version` when it's being saved https://github.com/dandi/dandi-archive/blob/master/dandiapi/api/models/version.py#L237-L242.