### PR TITLE
Fix file browser bug

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -338,7 +338,7 @@ export default defineComponent({
     const store = useDandisetStore();
 
     const location = ref(rootDirectory);
-    const items: Ref<ExtendedAssetPath[]> = ref([]);
+    const items: Ref<ExtendedAssetPath[] | null> = ref(null);
 
     // Value is the asset id of the item to delete
     const itemToDelete: Ref<AssetPath | null> = ref(null);


### PR DESCRIPTION
After merging #1311, the "no files found" error message is displayed when the list of files is being fetched. This PR tweaks the list of files so that it is initially `null` instead of an empty array. `null` indicates the data hasn't been fetched yet, while an empty array would indicate the fetch occured but there was no files at the given path.