### PR TITLE
Move metadata validation tasks into the service layer

### DIFF
--- a/dandiapi/api/management/commands/create_dev_dandiset.py
+++ b/dandiapi/api/management/commands/create_dev_dandiset.py
@@ -8,7 +8,8 @@ import djclick as click
 from dandiapi.api.models import AssetBlob
 from dandiapi.api.services.asset import add_asset_to_version
 from dandiapi.api.services.dandiset import create_dandiset
-from dandiapi.api.tasks import calculate_sha256, validate_asset_metadata, validate_version_metadata
+from dandiapi.api.services.metadata import validate_asset_metadata, validate_version_metadata
+from dandiapi.api.tasks import calculate_sha256
 
 
 @click.command()
@@ -48,5 +49,5 @@ def create_dev_dandiset(name: str, owner: str):
     )
 
     calculate_sha256(blob_id=asset_blob.blob_id)
-    validate_asset_metadata(asset_id=asset.id)
-    validate_version_metadata(version_id=draft_version.id)
+    validate_asset_metadata(asset=asset)
+    validate_version_metadata(version=draft_version)

--- a/dandiapi/api/management/commands/revalidate.py
+++ b/dandiapi/api/management/commands/revalidate.py
@@ -1,7 +1,7 @@
 import djclick as click
 
 from dandiapi.api.models import Asset, Version
-from dandiapi.api.tasks import validate_asset_metadata, validate_version_metadata
+from dandiapi.api.services.metadata import validate_asset_metadata, validate_version_metadata
 
 
 @click.command()
@@ -21,8 +21,8 @@ def revalidate(assets: bool, versions: bool, revalidate_all: bool, dry_run: bool
             asset_qs = asset_qs.filter(status=Asset.Status.INVALID)
         click.echo(f'Revalidating {asset_qs.count()} assets')
         if not dry_run:
-            for asset in asset_qs.values('id'):
-                validate_asset_metadata(asset['id'])
+            for asset in asset_qs.iterator():
+                validate_asset_metadata(asset=asset)
 
     if versions:
         # Only revalidate draft versions
@@ -33,5 +33,5 @@ def revalidate(assets: bool, versions: bool, revalidate_all: bool, dry_run: bool
             )
         click.echo(f'Revalidating {version_qs.count()} versions')
         if not dry_run:
-            for version in version_qs.values('id'):
-                validate_version_metadata(version['id'])
+            for version in version_qs.iterator():
+                validate_version_metadata(version=version)

--- a/dandiapi/api/services/asset/metadata.py
+++ b/dandiapi/api/services/asset/metadata.py
@@ -2,7 +2,7 @@ from django.db import transaction
 from django.db.models.query import QuerySet
 
 from dandiapi.api.models.asset import Asset
-from dandiapi.api.tasks import validate_asset_metadata
+from dandiapi.api.services.metadata import validate_asset_metadata
 
 
 def _maybe_validate_asset_metadata(asset: Asset):
@@ -25,7 +25,7 @@ def _maybe_validate_asset_metadata(asset: Asset):
 
     # If the blob already has a sha256, then the asset metadata is ready to validate.
     # We do not bother to delay it because it should run very quickly.
-    validate_asset_metadata(asset.id)
+    validate_asset_metadata(asset=asset)
 
 
 def bulk_recalculate_asset_metadata(*, assets: QuerySet[Asset]):

--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -1,0 +1,107 @@
+from celery.utils.log import get_task_logger
+import dandischema.exceptions
+from dandischema.metadata import validate
+from django.db import transaction
+from django.utils import timezone
+import jsonschema.exceptions
+
+from dandiapi.api.models import Asset, Version
+from dandiapi.api.services.metadata.exceptions import AssetHasBeenPublished, VersionHasBeenPublished
+
+logger = get_task_logger(__name__)
+
+
+def _encode_pydantic_error(error) -> dict[str, str]:
+    return {'field': error['loc'][0], 'message': error['msg']}
+
+
+def _encode_jsonschema_error(error: jsonschema.exceptions.ValidationError) -> dict[str, str]:
+    return {'field': '.'.join([str(p) for p in error.path]), 'message': error.message}
+
+
+def _collect_validation_errors(
+    error: dandischema.exceptions.ValidationError,
+) -> list[dict[str, str]]:
+    if type(error) is dandischema.exceptions.PydanticValidationError:
+        encoder = _encode_pydantic_error
+    elif type(error) is dandischema.exceptions.JsonschemaValidationError:
+        encoder = _encode_jsonschema_error
+    else:
+        raise error
+    return [encoder(error) for error in error.errors]
+
+
+def validate_asset_metadata(*, asset: Asset) -> None:
+    logger.info('Validating asset metadata for asset %s', asset.id)
+
+    # Published assets are immutable
+    if asset.published:
+        raise AssetHasBeenPublished()
+
+    with transaction.atomic():
+        asset.status = Asset.Status.VALIDATING
+        asset.save()
+
+        try:
+            metadata = asset.published_metadata()
+            validate(metadata, schema_key='PublishedAsset', json_validation=True)
+            logger.info('Successfully validated asset %s', asset.id)
+            asset.status = Asset.Status.VALID
+            asset.validation_errors = []
+        except dandischema.exceptions.ValidationError as e:
+            logger.info('Error while validating asset %s', asset.id)
+            asset.status = Asset.Status.INVALID
+
+            validation_errors = _collect_validation_errors(e)
+            asset.validation_errors = validation_errors
+        except ValueError as e:
+            # A bare ValueError is thrown when dandischema generates its own exceptions, like a
+            # mismatched schemaVersion.
+            asset.status = Asset.Status.INVALID
+            asset.validation_errors = [{'field': '', 'message': str(e)}]
+
+        # Save asset
+        asset.save()
+
+        # Update modified timestamps on all draft versions this asset belongs to
+        asset.versions.filter(version='draft').update(modified=timezone.now())
+
+
+def validate_version_metadata(*, version: Version) -> None:
+    logger.info('Validating dandiset metadata for version %s', version.id)
+
+    # Published versions are immutable
+    if version.version != 'draft':
+        raise VersionHasBeenPublished()
+
+    with transaction.atomic():
+        version.status = Version.Status.VALIDATING
+        version.save()
+
+        try:
+            publish_version = version.publish_version
+            metadata = publish_version.metadata
+
+            # Inject a dummy DOI so the metadata is valid
+            metadata['doi'] = '10.80507/dandi.123456/0.123456.1234'
+
+            validate(metadata, schema_key='PublishedDandiset', json_validation=True)
+        except dandischema.exceptions.ValidationError as e:
+            logger.info('Error while validating version %s', version.id)
+            version.status = Version.Status.INVALID
+
+            validation_errors = _collect_validation_errors(e)
+            version.validation_errors = validation_errors
+            version.save()
+            return
+        except ValueError as e:
+            # A bare ValueError is thrown when dandischema generates its own exceptions, like a
+            # mismatched schemaVersion.
+            version.status = Version.Status.INVALID
+            version.validation_errors = [{'field': '', 'message': str(e)}]
+            version.save()
+            return
+        logger.info('Successfully validated version %s', version.id)
+        version.status = Version.Status.VALID
+        version.validation_errors = []
+        version.save()

--- a/dandiapi/api/services/metadata/exceptions.py
+++ b/dandiapi/api/services/metadata/exceptions.py
@@ -1,0 +1,13 @@
+from rest_framework import status
+
+from dandiapi.api.services.exceptions import DandiException
+
+
+class AssetHasBeenPublished(DandiException):
+    http_status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    message = 'This asset has been published and cannot be modified.'
+
+
+class VersionHasBeenPublished(DandiException):
+    http_status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    message = 'This version has been published and cannot be modified.'

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -1,11 +1,7 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
-import dandischema.exceptions
-from dandischema.metadata import validate
 from django.db import transaction
 from django.db.transaction import atomic
-from django.utils import timezone
-import jsonschema.exceptions
 
 from dandiapi.api.doi import delete_doi
 from dandiapi.api.manifests import (
@@ -45,7 +41,7 @@ def calculate_sha256(blob_id: int) -> None:
             # Note: while asset metadata is fairly lightweight compute-wise, memory-wise it can
             # become an issue during serialization/deserialization of the JSON blob by pydantic.
             # Therefore, we delay each validation to its own task.
-            validate_asset_metadata.delay(asset_id)
+            validate_asset_metadata_task.delay(asset_id)
 
     # Run on transaction commit
     transaction.on_commit(dispatch_validation)
@@ -64,96 +60,22 @@ def write_manifest_files(version_id: int) -> None:
     write_collection_jsonld(version)
 
 
-def encode_pydantic_error(error) -> dict[str, str]:
-    return {'field': error['loc'][0], 'message': error['msg']}
-
-
-def encode_jsonschema_error(error: jsonschema.exceptions.ValidationError) -> dict[str, str]:
-    return {'field': '.'.join([str(p) for p in error.path]), 'message': error.message}
-
-
-def collect_validation_errors(
-    error: dandischema.exceptions.ValidationError,
-) -> list[dict[str, str]]:
-    if type(error) is dandischema.exceptions.PydanticValidationError:
-        encoder = encode_pydantic_error
-    elif type(error) is dandischema.exceptions.JsonschemaValidationError:
-        encoder = encode_jsonschema_error
-    else:
-        raise error
-    return [encoder(error) for error in error.errors]
-
-
 @shared_task(soft_time_limit=10)
 @atomic
-def validate_asset_metadata(asset_id: int) -> None:
-    logger.info('Validating asset metadata for asset %s', asset_id)
+def validate_asset_metadata_task(asset_id: int) -> None:
+    from dandiapi.api.services.metadata import validate_asset_metadata
+
     asset: Asset = Asset.objects.get(id=asset_id)
-
-    asset.status = Asset.Status.VALIDATING
-    asset.save()
-
-    try:
-        metadata = asset.published_metadata()
-        validate(metadata, schema_key='PublishedAsset', json_validation=True)
-        logger.info('Successfully validated asset %s', asset_id)
-        asset.status = Asset.Status.VALID
-        asset.validation_errors = []
-    except dandischema.exceptions.ValidationError as e:
-        logger.info('Error while validating asset %s', asset_id)
-        asset.status = Asset.Status.INVALID
-
-        validation_errors = collect_validation_errors(e)
-        asset.validation_errors = validation_errors
-    except ValueError as e:
-        # A bare ValueError is thrown when dandischema generates its own exceptions, like a
-        # mismatched schemaVersion.
-        asset.status = Asset.Status.INVALID
-        asset.validation_errors = [{'field': '', 'message': str(e)}]
-
-    # Save asset
-    asset.save()
-
-    # Update modified timestamps on all draft versions this asset belongs to
-    asset.versions.filter(version='draft').update(modified=timezone.now())
+    validate_asset_metadata(asset=asset)
 
 
 @shared_task(soft_time_limit=30)
 @atomic
-def validate_version_metadata(version_id: int) -> None:
-    logger.info('Validating dandiset metadata for version %s', version_id)
+def validate_version_metadata_task(version_id: int) -> None:
+    from dandiapi.api.services.metadata import validate_version_metadata
+
     version: Version = Version.objects.get(id=version_id)
-
-    version.status = Version.Status.VALIDATING
-    version.save()
-
-    try:
-        publish_version = version.publish_version
-        metadata = publish_version.metadata
-
-        # Inject a dummy DOI so the metadata is valid
-        metadata['doi'] = '10.80507/dandi.123456/0.123456.1234'
-
-        validate(metadata, schema_key='PublishedDandiset', json_validation=True)
-    except dandischema.exceptions.ValidationError as e:
-        logger.info('Error while validating version %s', version_id)
-        version.status = Version.Status.INVALID
-
-        validation_errors = collect_validation_errors(e)
-        version.validation_errors = validation_errors
-        version.save()
-        return
-    except ValueError as e:
-        # A bare ValueError is thrown when dandischema generates its own exceptions, like a
-        # mismatched schemaVersion.
-        version.status = Version.Status.INVALID
-        version.validation_errors = [{'field': '', 'message': str(e)}]
-        version.save()
-        return
-    logger.info('Successfully validated version %s', version_id)
-    version.status = Version.Status.VALID
-    version.validation_errors = []
-    version.save()
+    validate_version_metadata(version=version)
 
 
 @shared_task

--- a/dandiapi/api/tasks/scheduled.py
+++ b/dandiapi/api/tasks/scheduled.py
@@ -15,7 +15,7 @@ from django.db.transaction import atomic
 
 from dandiapi.api.mail import send_pending_users_message
 from dandiapi.api.models import UserMetadata, Version
-from dandiapi.api.tasks import validate_version_metadata, write_manifest_files
+from dandiapi.api.tasks import validate_version_metadata_task, write_manifest_files
 
 logger = get_task_logger(__name__)
 
@@ -33,7 +33,7 @@ def validate_draft_version_metadata():
     if pending_draft_versions_count > 0:
         logger.info('Found %s versions to validate', pending_draft_versions_count)
         for draft_version_id in pending_draft_versions.iterator():
-            validate_version_metadata.delay(draft_version_id)
+            validate_version_metadata_task.delay(draft_version_id)
 
             # Revalidation should be triggered every time a version is modified,
             # so now is a good time to write out the manifests as well.

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -204,6 +204,7 @@ class PublishedAssetFactory(DraftAssetFactory):
     @classmethod
     def _create(cls, *args, **kwargs):
         asset: Asset = super()._create(*args, **kwargs)
+        asset.status = Asset.Status.VALID  # published assets are always valid
         asset.publish()
         asset.save()
         return asset

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -114,7 +114,7 @@ def test_write_manifest_files(storage: Storage, version: Version, asset_factory)
 
 @pytest.mark.django_db
 def test_validate_asset_metadata(asset: Asset):
-    tasks.validate_asset_metadata(asset.id)
+    tasks.validate_asset_metadata_task(asset.id)
 
     asset.refresh_from_db()
 
@@ -127,7 +127,7 @@ def test_validate_asset_metadata_malformed_schema_version(asset: Asset):
     asset.metadata['schemaVersion'] = 'xxx'
     asset.save()
 
-    tasks.validate_asset_metadata(asset.id)
+    tasks.validate_asset_metadata_task(asset.id)
 
     asset.refresh_from_db()
 
@@ -142,7 +142,7 @@ def test_validate_asset_metadata_no_encoding_format(asset: Asset):
     del asset.metadata['encodingFormat']
     asset.save()
 
-    tasks.validate_asset_metadata(asset.id)
+    tasks.validate_asset_metadata_task(asset.id)
 
     asset.refresh_from_db()
 
@@ -157,7 +157,7 @@ def test_validate_asset_metadata_no_digest(asset: Asset):
     asset.blob.sha256 = None
     asset.blob.save()
 
-    tasks.validate_asset_metadata(asset.id)
+    tasks.validate_asset_metadata_task(asset.id)
 
     asset.refresh_from_db()
 
@@ -172,7 +172,7 @@ def test_validate_asset_metadata_malformed_keywords(asset: Asset):
     asset.metadata['keywords'] = 'foo'
     asset.save()
 
-    tasks.validate_asset_metadata(asset.id)
+    tasks.validate_asset_metadata_task(asset.id)
 
     asset.refresh_from_db()
 
@@ -191,7 +191,7 @@ def test_validate_asset_metadata_saves_version(draft_asset: Asset, draft_version
     Version.objects.filter(id=draft_version.id).update(modified=old_datetime)
 
     # Run task
-    tasks.validate_asset_metadata(draft_asset.id)
+    tasks.validate_asset_metadata_task(draft_asset.id)
 
     # Test that version has new modified timestamp
     draft_version.refresh_from_db()
@@ -202,7 +202,7 @@ def test_validate_asset_metadata_saves_version(draft_asset: Asset, draft_version
 def test_validate_version_metadata(version: Version, asset: Asset):
     version.assets.add(asset)
 
-    tasks.validate_version_metadata(version.id)
+    tasks.validate_version_metadata_task(version.id)
 
     version.refresh_from_db()
 
@@ -217,7 +217,7 @@ def test_validate_version_metadata_malformed_schema_version(version: Version, as
     version.metadata['schemaVersion'] = 'xxx'
     version.save()
 
-    tasks.validate_version_metadata(version.id)
+    tasks.validate_version_metadata_task(version.id)
 
     version.refresh_from_db()
 
@@ -235,7 +235,7 @@ def test_validate_version_metadata_no_description(version: Version, asset: Asset
     del version.metadata['description']
     version.save()
 
-    tasks.validate_version_metadata(version.id)
+    tasks.validate_version_metadata_task(version.id)
 
     version.refresh_from_db()
 
@@ -252,7 +252,7 @@ def test_validate_version_metadata_malformed_license(version: Version, asset: As
     version.metadata['license'] = 'foo'
     version.save()
 
-    tasks.validate_version_metadata(version.id)
+    tasks.validate_version_metadata_task(version.id)
 
     version.refresh_from_db()
 

--- a/dandiapi/api/tests/test_unembargo.py
+++ b/dandiapi/api/tests/test_unembargo.py
@@ -138,7 +138,7 @@ def test_unembargo_dandiset(
 
     # Run unembargo and validate version metadata
     unembargo_dandiset(user=user, dandiset=dandiset)
-    tasks.validate_version_metadata(draft_version.pk)
+    tasks.validate_version_metadata_task(draft_version.pk)
     dandiset.refresh_from_db()
     draft_version.refresh_from_db()
 
@@ -203,7 +203,7 @@ def test_unembargo_dandiset_existing_blobs(
 
     # Run unembargo
     unembargo_dandiset(user=user, dandiset=dandiset)
-    tasks.validate_version_metadata(draft_version.pk)
+    tasks.validate_version_metadata_task(draft_version.pk)
     dandiset.refresh_from_db()
     draft_version.refresh_from_db()
 
@@ -253,7 +253,7 @@ def test_unembargo_dandiset_normal_asset_blob(
 
     # Run unembargo
     unembargo_dandiset(user=user, dandiset=dandiset)
-    tasks.validate_version_metadata(draft_version.pk)
+    tasks.validate_version_metadata_task(draft_version.pk)
     dandiset.refresh_from_db()
     draft_version.refresh_from_db()
 

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -430,12 +430,12 @@ def test_version_rest_info(api_client, version):
 def test_version_rest_info_with_asset(
     api_client,
     draft_version_factory,
-    asset_factory,
+    draft_asset_factory,
     asset_status: Asset.Status,
     expected_validation_error: str,
 ):
     version = draft_version_factory(status=Version.Status.VALID)
-    asset = asset_factory(status=asset_status)
+    asset = draft_asset_factory(status=asset_status)
     version.assets.add(asset)
 
     # These validation error types should have the asset path prepended to them:
@@ -608,7 +608,6 @@ def test_version_rest_publish(
 
     # Validate the metadata to mark the assets and version as `VALID`
     tasks.validate_asset_metadata_task(old_draft_asset.id)
-    tasks.validate_asset_metadata_task(old_published_asset.id)
     tasks.validate_version_metadata_task(draft_version.id)
     draft_version.refresh_from_db()
     assert draft_version.valid

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -607,9 +607,9 @@ def test_version_rest_publish(
     draft_version.assets.add(old_published_asset)
 
     # Validate the metadata to mark the assets and version as `VALID`
-    tasks.validate_asset_metadata(old_draft_asset.id)
-    tasks.validate_asset_metadata(old_published_asset.id)
-    tasks.validate_version_metadata(draft_version.id)
+    tasks.validate_asset_metadata_task(old_draft_asset.id)
+    tasks.validate_asset_metadata_task(old_published_asset.id)
+    tasks.validate_version_metadata_task(draft_version.id)
     draft_version.refresh_from_db()
     assert draft_version.valid
 
@@ -644,9 +644,9 @@ def test_version_rest_publish_zarr(
     draft_version.assets.add(normal_asset)
 
     # Validate the metadata to mark the assets and version as `VALID`
-    tasks.validate_asset_metadata(zarr_asset.id)
-    tasks.validate_asset_metadata(normal_asset.id)
-    tasks.validate_version_metadata(draft_version.id)
+    tasks.validate_asset_metadata_task(zarr_asset.id)
+    tasks.validate_asset_metadata_task(normal_asset.id)
+    tasks.validate_version_metadata_task(draft_version.id)
     draft_version.refresh_from_db()
     assert draft_version.valid
 


### PR DESCRIPTION
This is the start of a metadata service layer module. For this first PR, I've just moved the `validate_asset_metadata` and `validate_version_metadata` tasks into a `metadata` service.

The goal is to eventually have all metadata changes go through the service layer, so there's definitely other metadata-related functionality that can be moved into this service; but, I wanted to start with what are hopefully the least controversial changes.