### PR TITLE
Temporarily pin flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
-    flake8
+    flake8<6
     flake8-black >= 0.2.4
     flake8-bugbear
     flake8-docstrings


### PR DESCRIPTION
Temporarily pins flake8, should be reverted once [the breakage in `flake8-quotes`](https://github.com/zheller/flake8-quotes/issues/110) is fixed.