### PR TITLE
Optimize `ingest_zarr_archive` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# v0.3.4 (Tue Nov 29 2022)
+
+#### 🐛 Bug Fix
+
+- Add file upload instructions to file browser UI [#1342](https://github.com/dandi/dandi-archive/pull/1342) ([@mvandenburgh](https://github.com/mvandenburgh))
+
+#### 🏠 Internal
+
+- Convert FileBrowser component to <script setup> [#1340](https://github.com/dandi/dandi-archive/pull/1340) ([@mvandenburgh](https://github.com/mvandenburgh))
+- Convert `Meditor.vue` to `<script setup>` [#1303](https://github.com/dandi/dandi-archive/pull/1303) ([@mvandenburgh](https://github.com/mvandenburgh))
+
+#### Authors: 1
+
+- Mike VanDenburgh ([@mvandenburgh](https://github.com/mvandenburgh))
+
+---
+
 # v0.3.3 (Tue Nov 29 2022)
 
 #### 🐛 Bug Fix

--- a/dandiapi/api/management/commands/create_dev_dandiset.py
+++ b/dandiapi/api/management/commands/create_dev_dandiset.py
@@ -13,9 +13,9 @@ from dandiapi.api.tasks import calculate_sha256, validate_asset_metadata, valida
 
 @click.command()
 @click.option('--name', default='Development Dandiset')
-@click.option('--owner', required=True, help='The email address of the owner')
-def create_dev_dandiset(name: str, owner: str):
-    owner = User.objects.get(email=owner)
+@click.option('--owner', 'email', required=True, help='The email address of the owner')
+def create_dev_dandiset(name: str, email: str):
+    owner = User.objects.get(email=email)
 
     version_metadata = {
         'description': 'An informative description',

--- a/dandiapi/zarr/checksums.py
+++ b/dandiapi/zarr/checksums.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
+import heapq
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -132,6 +133,9 @@ class ZarrChecksumModification:
     directories_to_update: list[ZarrChecksum] = field(default_factory=list)
     paths_to_remove: list[str] = field(default_factory=list)
 
+    def __lt__(self, other):
+        return str(self.path) < str(other.path)
+
 
 class ZarrChecksumModificationQueue:
     """
@@ -143,38 +147,44 @@ class ZarrChecksumModificationQueue:
     """
 
     def __init__(self) -> None:
-        self._queue: dict[Path, ZarrChecksumModification] = {}
+        self._heap: list[tuple[int, ZarrChecksumModification]] = []
+        self._path_map: dict[Path, ZarrChecksumModification] = {}
+
+    def _add_path(self, key: Path):
+        modification = ZarrChecksumModification(path=key)
+
+        # Add link to modification
+        self._path_map[key] = modification
+
+        # Add modification to heap with length (negated to representa max heap)
+        length = len(key.parents)
+        heapq.heappush(self._heap, (-1 * length, modification))
+
+    def _get_path(self, key: Path):
+        if key not in self._path_map:
+            self._add_path(key)
+
+        return self._path_map[key]
 
     def queue_file_update(self, key: Path, checksum: ZarrChecksum):
-        if key not in self._queue:
-            self._queue[key] = ZarrChecksumModification(path=key)
-        self._queue[key].files_to_update.append(checksum)
+        self._get_path(key).files_to_update.append(checksum)
 
     def queue_directory_update(self, key: Path, checksum: ZarrChecksum):
-        if key not in self._queue:
-            self._queue[key] = ZarrChecksumModification(path=key)
-        self._queue[key].directories_to_update.append(checksum)
+        self._get_path(key).directories_to_update.append(checksum)
 
     def queue_removal(self, key: Path, path: Path | str):
-        if key not in self._queue:
-            self._queue[key] = ZarrChecksumModification(path=key)
-        self._queue[key].paths_to_remove.append(str(path))
+        self._get_path(key).paths_to_remove.append(str(path))
 
     def pop_deepest(self):
         """Find the deepest path in the queue, and return it and its children to be updated."""
-        longest_path = list(self._queue.keys())[0]
-        longest_path_length = str(longest_path).split('/')
-        # O(n) performance, consider a priority queue for optimization
-        for path in self._queue.keys():
-            path_length = str(path).split('/')
-            if path_length > longest_path_length:
-                longest_path = path
-                longest_path_length = path_length
-        return self._queue.pop(longest_path)
+        _, modification = heapq.heappop(self._heap)
+        del self._path_map[modification.path]
+
+        return modification
 
     @property
     def empty(self):
-        return len(self._queue) == 0
+        return len(self._heap) == 0
 
 
 class ZarrChecksumUpdater:


### PR DESCRIPTION
This optimization is achieved in two main ways:

1. Using a priority queue (heap) in the `ZarrChecksumModificationQueue` class, instead of a normal queue
2. Storing all s3 files in the queue before doing any processing (see below for memory usage).

The main benefit this provides is being able to update the checksum tree strictly from the bottom up, removing duplicate file updates.

Previously, a batch of files were fetched, immediately processed, and the next batch fetched, etc. This resulted in all parent checksum files being updated (up to the root checksum file) in every batch. The optimized method only updates each checksum file once.


#### Results
The outcome of this optimization is an almost 2x speed improvement. For a zarr archive with ~37k files (52.5GB), I observed an average runtime of ~83s, compared to a previous runtime of ~147s.

In regards to memory usage, it seems the max usage was ~411kb for the same zarr with ~37k files, decreasing as the ingestion goes on. This was the largest zarr I was able to test on, since this is the largest zarr in staging. Also, to clarify, this testing was done by using a local shell pointed at the staging database and s3 bucket, so these times should be representative of what we would observe in production.