### PR TITLE
Always clear checksum files during zarr ingestion

### DIFF
--- a/dandiapi/zarr/tasks/__init__.py
+++ b/dandiapi/zarr/tasks/__init__.py
@@ -123,6 +123,9 @@ def ingest_zarr_archive(
         # Remove all asset paths associated with this zarr before ingest
         delete_zarr_paths(zarr)
 
+        # Clear any existing checksum files before running ingestion
+        clear_checksum_files(zarr)
+
         # Reset before compute
         if not no_size:
             zarr.size = 0
@@ -154,10 +157,6 @@ def ingest_zarr_archive(
                         for file in files
                     }
                 )
-
-        # If no files were actually yielded, remove all checksum files
-        if empty:
-            clear_checksum_files(zarr)
 
         # Set checksum field to top level checksum, after ingestion completion
         checksum = zarr.get_checksum()


### PR DESCRIPTION
Addresses the underlying issue of #1378

My original approach to this was to delete any necessary checksum files alongside zarr file deletion, but I think it complicated the zarr workflow/lifecycle too much.