### PR TITLE
Simplify ingest_zarr_archive task

### DIFF
--- a/dandiapi/zarr/checksums.py
+++ b/dandiapi/zarr/checksums.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -116,6 +117,34 @@ class ZarrChecksumFileUpdater(AbstractContextManager):
         if self._checksums is None:
             raise ValueError('This method is only valid when used by a context manager')
         self._checksums.remove_checksums([Path(path).name for path in paths])
+
+
+class SessionZarrChecksumFileUpdater(ZarrChecksumFileUpdater):
+    """Override ZarrChecksumFileUpdater to ignore old files."""
+
+    def __init__(self, *args, session_start: datetime, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Set the start of when new files may have been written
+        self._session_start = session_start
+
+    def read_checksum_file(self) -> ZarrChecksumListing | None:
+        """Load a checksum listing from the checksum file."""
+        storage = self.zarr_archive.storage
+        checksum_path = self.checksum_file_path
+
+        # Check if this file was modified during this session
+        read_existing = False
+        if storage.exists(checksum_path):
+            read_existing = storage.modified_time(self.checksum_file_path) >= self._session_start
+
+        # Read existing file if necessary
+        if read_existing:
+            with storage.open(checksum_path) as f:
+                x = f.read()
+                return self._serializer.deserialize(x)
+        else:
+            return None
 
 
 @dataclass
@@ -239,3 +268,28 @@ class ZarrChecksumUpdater:
         for path in paths:
             modifications.queue_removal(Path(path).parent, path)
         self.modify(modifications)
+
+
+class SessionZarrChecksumUpdater(ZarrChecksumUpdater):
+    """ZarrChecksumUpdater to distinguish existing and new checksum files."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Set microseconds to zero, since the timestamp from S3/Minio won't include them
+        # Failure to set this to zero will result in false negatives
+        self._session_start = datetime.now().replace(tzinfo=None, microsecond=0)
+
+    def apply_modification(
+        self, modification: ZarrChecksumModification
+    ) -> SessionZarrChecksumFileUpdater:
+        with SessionZarrChecksumFileUpdater(
+            zarr_archive=self.zarr_archive,
+            zarr_directory_path=modification.path,
+            session_start=self._session_start,
+        ) as file_updater:
+            file_updater.add_file_checksums(modification.files_to_update)
+            file_updater.add_directory_checksums(modification.directories_to_update)
+            file_updater.remove_checksums(modification.paths_to_remove)
+
+        return file_updater

--- a/dandiapi/zarr/checksums.py
+++ b/dandiapi/zarr/checksums.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 import heapq
 from pathlib import Path
+import re
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -20,6 +21,18 @@ from dandischema.digests.zarr import (
     ZarrChecksums,
     ZarrJSONChecksumSerializer,
 )
+
+ZARR_CHECKSUM_REGEX = r'[0-9a-f]+-(\d+)--(\d+)'
+
+
+def parse_checksum_string(checksum: str) -> tuple[int, int]:
+    """Return a tuple of (file count, total size)."""
+    match = re.match(ZARR_CHECKSUM_REGEX, checksum)
+    if match is None:
+        raise Exception('Invalid zarr checksum provided.')
+
+    count, size = match.groups()
+    return (int(count), int(size))
 
 
 class ZarrChecksumFileUpdater(AbstractContextManager):

--- a/dandiapi/zarr/management/commands/ingest_dandiset_zarrs.py
+++ b/dandiapi/zarr/management/commands/ingest_dandiset_zarrs.py
@@ -5,9 +5,6 @@ from dandiapi.zarr.tasks import ingest_dandiset_zarrs as _ingest_dandiset_zarrs
 
 @click.command()
 @click.argument('dandiset_id', type=str)
-@click.option('--no-checksum', help="Don't recompute checksums", is_flag=True)
-@click.option('--no-size', help="Don't recompute total size", is_flag=True)
-@click.option('--no-count', help="Don't recompute total file count", is_flag=True)
 @click.option('-f', '--force', help='Force re-ingestion', is_flag=True)
 def ingest_dandiset_zarrs(dandiset_id: str, **kwargs):
     _ingest_dandiset_zarrs(dandiset_id=int(dandiset_id.lstrip('0')), **kwargs)

--- a/dandiapi/zarr/management/commands/ingest_zarr_archive.py
+++ b/dandiapi/zarr/management/commands/ingest_zarr_archive.py
@@ -5,9 +5,6 @@ from dandiapi.zarr.tasks import ingest_zarr_archive as _ingest_zarr_archive
 
 @click.command()
 @click.argument('zarr_id', type=str)
-@click.option('--no-checksum', help="Don't recompute checksums", is_flag=True)
-@click.option('--no-size', help="Don't recompute total size", is_flag=True)
-@click.option('--no-count', help="Don't recompute total file count", is_flag=True)
 @click.option('-f', '--force', help='Force re-ingestion', is_flag=True)
 def ingest_zarr_archive(*args, **kwargs):
     _ingest_zarr_archive(*args, **kwargs)


### PR DESCRIPTION
Depends on #1387 and #1390

This PR simplifies the zarr ingest task in the following ways:
* Don't explicitly count files/size, just retrieve from the checksum afterwards
* Remove `no_checksum`, `no_count`,  `no_size` flags