### PR TITLE
Use flat file listing in zarr file browser

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -1246,10 +1246,7 @@ def test_asset_download_zarr(api_client, version, asset_factory, zarr_archive):
         f'/api/dandisets/{version.dandiset.identifier}/'
         f'versions/{version.version}/assets/{asset.asset_id}/download/'
     )
-
-    assert response.status_code == 302
-    download_url = response.get('Location')
-    assert download_url == f'/api/zarr/{zarr_archive.zarr_id}.zarr/'
+    assert response.status_code == 400
 
 
 @pytest.mark.django_db
@@ -1281,10 +1278,7 @@ def test_asset_direct_download_zarr(api_client, version, asset_factory, zarr_arc
     version.assets.add(asset)
 
     response = api_client.get(f'/api/assets/{asset.asset_id}/download/')
-
-    assert response.status_code == 302
-    download_url = response.get('Location')
-    assert download_url == f'/api/zarr/{zarr_archive.zarr_id}.zarr/'
+    assert response.status_code == 400
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -27,7 +27,6 @@ import os.path
 from django.conf import settings
 from django.db.models import QuerySet
 from django.http import HttpResponseRedirect
-from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django_filters import rest_framework as filters
 from drf_yasg.utils import swagger_auto_schema
@@ -121,12 +120,16 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
     def download(self, *args, **kwargs):
         asset = self.get_object()
 
-        # Assign asset blob or redirect if zarr
+        # Raise error if zarr
         if asset.is_zarr:
-            return HttpResponseRedirect(
-                reverse('zarr-explore', kwargs={'zarr_id': asset.zarr.zarr_id, 'path': ''})
+            return Response(
+                'Unable to provide download link for zarr assets.'
+                ' Please browse the zarr files directly to do so.',
+                status=status.HTTP_400_BAD_REQUEST,
             )
-        elif asset.is_blob:
+
+        # Assign asset_blob
+        if asset.is_blob:
             asset_blob = asset.blob
         elif asset.is_embargoed_blob:
             asset_blob = asset.embargoed_blob

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -26,7 +26,7 @@ from dandiapi.api.views import (
     users_me_view,
     users_search_view,
 )
-from dandiapi.zarr.views import ZarrViewSet, explore_zarr_archive
+from dandiapi.zarr.views import ZarrViewSet
 
 router = ExtendedSimpleRouter()
 (
@@ -96,11 +96,6 @@ urlpatterns = [
     path('api/users/search/', users_search_view),
     re_path(
         r'^api/users/questionnaire-form/$', user_questionnaire_form_view, name='user-questionnaire'
-    ),
-    re_path(
-        r'^api/zarr/(?P<zarr_id>[0-9a-f\-]{36}).zarr/(?P<path>.*)?$',
-        explore_zarr_archive,
-        name='zarr-explore',
     ),
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),

--- a/dandiapi/zarr/tests/test_zarr.py
+++ b/dandiapi/zarr/tests/test_zarr.py
@@ -431,28 +431,32 @@ def test_zarr_file_list(api_client, storage, zarr_archive: ZarrArchive, zarr_upl
 
     # Check base listing
     resp = api_client.get(f'/api/zarr/{zarr_archive.zarr_id}/files/')
-    assert [x['Key'] for x in resp.json()] == sorted(files)
+    assert [x['Key'] for x in resp.json()['results']] == sorted(files)
 
     # Check that prefix query param works as expected
     resp = api_client.get(
         f'/api/zarr/{zarr_archive.zarr_id}/files/',
         {'prefix': 'foo/'},
     )
-    assert [x['Key'] for x in resp.json()] == ['foo/bar/a.txt', 'foo/bar/b.txt', 'foo/baz.txt']
+    assert [x['Key'] for x in resp.json()['results']] == [
+        'foo/bar/a.txt',
+        'foo/bar/b.txt',
+        'foo/baz.txt',
+    ]
 
     # Check that prefix and after work together
     resp = api_client.get(
         f'/api/zarr/{zarr_archive.zarr_id}/files/',
         {'prefix': 'foo/', 'after': 'foo/bar/a.txt'},
     )
-    assert [x['Key'] for x in resp.json()] == ['foo/bar/b.txt', 'foo/baz.txt']
+    assert [x['Key'] for x in resp.json()['results']] == ['foo/bar/b.txt', 'foo/baz.txt']
 
     # Use limit query param
     resp = api_client.get(
         f'/api/zarr/{zarr_archive.zarr_id}/files/',
         {'prefix': 'foo/', 'after': 'foo/bar/a.txt', 'limit': 1},
     )
-    assert [x['Key'] for x in resp.json()] == ['foo/bar/b.txt']
+    assert [x['Key'] for x in resp.json()['results']] == ['foo/bar/b.txt']
 
     # Check download flag
     resp = api_client.get(

--- a/dandiapi/zarr/views/__init__.py
+++ b/dandiapi/zarr/views/__init__.py
@@ -97,7 +97,7 @@ class ZarrListSerializer(serializers.ModelSerializer):
 class ZarrExploreQuerySerializer(serializers.Serializer):
     after = serializers.CharField(default='')
     prefix = serializers.CharField(default='')
-    limit = serializers.IntegerField(default=1000)
+    limit = serializers.IntegerField(min_value=0, max_value=1000, default=1000)
     download = serializers.BooleanField(default=False)
 
 


### PR DESCRIPTION
This is a simplification, and will as a result fix any zarrs with out of sync file listings (any other zarrs affected by the underlying issue to https://github.com/dandi/dandi-archive/issues/1378).

@jwodder This is a breaking change and will require a corresponding CLI update. If anything here seem infeasible / unreasonable, please let me know.

Notable breaking changes:

* The url is now `zarr/{zarr_id}/files`
* To filter by prefix, use the `prefix` query param
* To limit the number of files returned, use the `limit` query param (default 1000)
* To perform pagination, provide the `after` query param, setting it to the key of the last item in the previous listing
* To be redirected to file download (requires providing file name in `prefix`), set the `download` flag to `true`
* The asset download endpoint no longer redirects to the zarr file explorer view if the specified asset contains a zarr. Instead, it returns a 400, instructing the user to use the zarr file listing endpoint directly. I prefer this than to blindly redirecting to zarr file listing endpoint, as the "download" operation on an entire zarr isn't something we support.


Head requests are still supported, and will use the provided `prefix` query param to return a presigned head URL. If the prefix is not the entire path of a file, the HEAD request against the presigned url will return a 404.