### PR TITLE
Use proper syntax for only locking ZarrArchive table

### DIFF
--- a/dandiapi/zarr/views/__init__.py
+++ b/dandiapi/zarr/views/__init__.py
@@ -187,8 +187,7 @@ class ZarrViewSet(ReadOnlyModelViewSet):
     @action(methods=['POST'], detail=True)
     def upload(self, request, zarr_id):
         """Start an upload of files to a zarr archive."""
-        # reset select_related to prevent locking additional rows
-        queryset = self.get_queryset().select_related(None).select_for_update()
+        queryset = self.get_queryset().select_for_update(of=['self'])
         with transaction.atomic():
             zarr_archive: ZarrArchive = get_object_or_404(queryset, zarr_id=zarr_id)
             if zarr_archive.status == ZarrArchiveStatus.INGESTING:
@@ -218,8 +217,7 @@ class ZarrViewSet(ReadOnlyModelViewSet):
     @action(methods=['POST'], url_path='upload/complete', detail=True)
     def upload_complete(self, request, zarr_id):
         """Finish an upload of files to a zarr archive."""
-        # reset select_related to prevent locking additional rows
-        queryset = self.get_queryset().select_related(None).select_for_update()
+        queryset = self.get_queryset().select_for_update(of=['self'])
         with transaction.atomic():
             zarr_archive: ZarrArchive = get_object_or_404(queryset, zarr_id=zarr_id)
             if not self.request.user.has_perm('owner', zarr_archive.dandiset):


### PR DESCRIPTION
From https://docs.djangoproject.com/en/4.1/ref/models/querysets/#select-for-update

> By default, select_for_update() locks all rows that are selected by the query. For example, rows of related objects specified in [select_related()](https://docs.djangoproject.com/en/4.1/ref/models/querysets/#django.db.models.query.QuerySet.select_related) are locked in addition to rows of the queryset’s model. If this isn’t desired, specify the related objects you want to lock in select_for_update(of=(...)) using the same fields syntax as [select_related()](https://docs.djangoproject.com/en/4.1/ref/models/querysets/#django.db.models.query.QuerySet.select_related). Use the value 'self' to refer to the queryset’s model.

