### PR TITLE
Specify `requests` as a prod dependency instead of test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'pydantic',
         'boto3[s3]',
         'more_itertools',
+        'requests',
         # Production-only
         'django-composed-configuration[prod]>=0.22.0',
         # pin directly to a version since we're extending the private multipart interface
@@ -88,7 +89,6 @@ setup(
             'pytest-factoryboy',
             'pytest-memray',
             'pytest-mock',
-            'requests',
         ],
     },
 )


### PR DESCRIPTION
`requests` is used to create DOIs, but is listed as a `test` dependency in setup.py.