### PR TITLE
Manage CI dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
       include: scope
     labels:
       - internal
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: "weekly"
+    labels:
+      - internal

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
             'flake8-docstrings==1.6.0',
             'flake8-isort==5.0.3',
             'flake8-quotes==3.3.1',
+            'pep8-naming==0.13.2',
         ],
         'type': [
             'mypy==0.982',

--- a/setup.py
+++ b/setup.py
@@ -75,10 +75,6 @@ setup(
             'django-s3-file-field[minio]',
             'ipython',
             'tox',
-            'boto3-stubs[s3]',
-            'django-stubs',
-            'djangorestframework-stubs',
-            'types-setuptools',
             'memray',
         ],
         'test': [
@@ -89,6 +85,21 @@ setup(
             'pytest-factoryboy',
             'pytest-memray',
             'pytest-mock',
+        ],
+        'lint': [
+            'flake8==5.0.4',
+            'flake8-black==0.3.5',
+            'flake8-bugbear==22.12.6',
+            'flake8-docstrings==1.6.0',
+            'flake8-isort==5.0.3',
+            'flake8-quotes==3.3.1',
+        ],
+        'type': [
+            'mypy==0.982',
+            'boto3-stubs[s3]==1.26.27',
+            'django-stubs==1.13.1',
+            'djangorestframework-stubs==1.8.0',
+            'types-setuptools==65.6.0.2',
         ],
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -7,23 +7,15 @@ envlist =
 
 [testenv:lint]
 skipsdist = true
-skip_install = true
-deps =
-    flake8<6
-    flake8-black >= 0.2.4
-    flake8-bugbear
-    flake8-docstrings
-    flake8-isort
-    flake8-quotes
-    pep8-naming
+extras =
+    lint
 commands =
     flake8 --config=tox.ini {posargs:.}
 
 [testenv:type]
-deps =
-    mypy==0.982
 extras =
     dev
+    type
 commands =
     mypy {posargs:dandiapi/}
 


### PR DESCRIPTION
We keep having issues with CI/testing dependencies introducing breaking changes, causing CI to fail. 

#1359 
#1380 
https://github.com/dandi/dandi-archive/pull/1387#issuecomment-1343052208
etc...

I think we should just pin all testing dependencies and let dependabot manage updating them for us. Since we'd only be pinning testing dependencies, any dependabot PRs that pass CI can just be merged without a second thought.