### PR TITLE
Add more detailed logging to development postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   postgres:
     image: postgres:latest
+    command: postgres -c log_lock_waits=on -c log_min_duration_statement=100
     environment:
       POSTGRES_DB: django
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
See https://www.postgresql.org/docs/current/runtime-config-logging.html.

This should log all queries that take > 100ms and all queries that take more than 1s to acquire a lock.