### PR TITLE
Add 12 hour cache to stats endpoint

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Apply migrations to API server
         run: python manage.py migrate
 
+      - name: Create any cache tables
+        run: python manage.py createcachetable
+
       - name: Install E2E tests
         run: yarn install --frozen-lockfile
         working-directory: web/test

--- a/dandiapi/api/views/stats.py
+++ b/dandiapi/api/views/stats.py
@@ -1,10 +1,13 @@
 from django.contrib.auth.models import User
+from django.views.decorators.cache import cache_page
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from dandiapi.api.models import Asset, Dandiset
 
 
+# Cache this response for 12 hours
+@cache_page(60 * 60 * 12)
 @api_view()
 def stats_view(self):
     dandiset_count = Dandiset.objects.count()

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -142,6 +142,13 @@ class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
     CELERY_TASK_EAGER_PROPAGATES = True
     CELERY_TASK_ALWAYS_EAGER = True
 
+    # Use a dummy cache for testing
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        }
+    }
+
 
 class ProductionConfiguration(DandiMixin, ProductionBaseConfiguration):
     pass

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -51,6 +51,14 @@ class DandiMixin(ConfigMixin):
             'rest_framework.authentication.TokenAuthentication',
         ]
 
+        # Caching
+        configuration.CACHES = {
+            'default': {
+                'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+                'LOCATION': 'dandi_cache_table',
+            }
+        }
+
         # Permission
         configuration.REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES'] += [
             'dandiapi.api.permissions.IsApprovedOrReadOnly'

--- a/web/test/src/tests/homePage.test.js
+++ b/web/test/src/tests/homePage.test.js
@@ -1,55 +1,6 @@
-import {
-  CLIENT_URL,
-  registerNewUser,
-  registerDandiset,
-  uniqueId,
-  waitForRequestsToFinish,
-} from '../util';
-import * as homePage from '../pages/homePage';
-
 const VERSION_LINK_REGEX = /https:\/\/github.com\/dandi\/dandi-archive\/commit\/[0-9a-f]{5,40}/;
 
 describe('home page stats', () => {
-  it('increments users stat when a new user registers', async () => {
-    // wait for stats to load
-    const initialUserCount = await homePage.getStat('users');
-
-    // register a new user to increment the user count
-    await registerNewUser();
-
-    // refresh the page to get the new stats
-    await page.reload();
-    await waitForRequestsToFinish();
-
-    const finalUserCount = await homePage.getStat('users');
-
-    expect(finalUserCount).toStrictEqual(initialUserCount + 1);
-  });
-
-  it('increments dandisets stat when a new dandiset is registered', async () => {
-    await registerNewUser();
-
-    const dandisetName = `dandiset${uniqueId()}`;
-    const dandisetDescription = `Description! ${uniqueId()}`;
-
-    // The value that `homePage.getStat` looks for is retrieved via XHR, so
-    // wait until all requests are finished before trying to retrieve it.
-    await waitForRequestsToFinish();
-
-    const initialDandisetCount = await homePage.getStat('dandisets');
-
-    // register a new dandiset to increment the dandiset count
-    await registerDandiset(dandisetName, dandisetDescription);
-
-    // refresh the page to get the new stats
-    await page.goto(CLIENT_URL, { timeout: 0 });
-    await waitForRequestsToFinish();
-
-    const finalDandisetCount = await homePage.getStat('dandisets');
-
-    expect(finalDandisetCount).toStrictEqual(initialDandisetCount + 1);
-  });
-
   it('checks version link', async () => {
     /* eslint-disable-next-line no-undef */
     const versionLink = await page.evaluate(() => document.querySelector('.version-link').getAttribute('href'));


### PR DESCRIPTION
Closes #1412 

Notably, this doesn't actually change how the stats are computed, it just adds a cache. Using the asset paths models to compute this results in a slightly different value than we have now. Rather than try to determine what course of action we should take (a behavior change), I just wanted to get the difference making optimization in.