### PR TITLE
Ignore patch updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
       include: scope
     labels:
       - internal
+    ignore:
+      - update-types: ["patch"]
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: "weekly"
     labels:
       - internal
+    ignore:
+    - update-types: ["patch"]


### PR DESCRIPTION
This should make dependabot even less noisy by only providing PRs for minor and major updates.

I also added a label to our project called `skip-release`. It has no effect and shouldn't be used, but it will trick dependabot into omitting the major/minor labels that conflict with our release process, see:
- https://github.com/dependabot/dependabot-core/issues/3465
- https://github.com/dependabot/dependabot-core/blob/5dc907e3148961c74ddc0b4494730f8e86118f79/common/lib/dependabot/pull_request_creator/labeler.rb#L206

Meanwhile, we should subscribe/upvote the grouped updates feature https://github.com/dependabot/dependabot-core/issues/1190.