### PR TITLE
Compute asset summary asynchronously for draft versions

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -388,6 +388,7 @@ def test_dandiset_rest_create(api_client, user):
             }
         ],
         'assetsSummary': {
+            'schemaKey': 'AssetsSummary',
             'numberOfBytes': 0,
             'numberOfFiles': 0,
         },
@@ -480,6 +481,7 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
             }
         ],
         'assetsSummary': {
+            'schemaKey': 'AssetsSummary',
             'numberOfBytes': 0,
             'numberOfFiles': 0,
         },
@@ -585,6 +587,7 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
             }
         ],
         'assetsSummary': {
+            'schemaKey': 'AssetsSummary',
             'numberOfBytes': 0,
             'numberOfFiles': 0,
         },
@@ -675,6 +678,7 @@ def test_dandiset_rest_create_embargoed(api_client, user):
             }
         ],
         'assetsSummary': {
+            'schemaKey': 'AssetsSummary',
             'numberOfBytes': 0,
             'numberOfFiles': 0,
         },

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 from dandiapi.api import tasks
 from dandiapi.api.models import Asset, Version
+from dandiapi.api.services.publish import _build_publishable_version_from_draft
 from dandiapi.zarr.tasks import ingest_zarr_archive
 
 from .fuzzy import TIMESTAMP_RE, URN_RE, UTC_ISO_TIMESTAMP_RE, VERSION_ID_RE
@@ -279,7 +280,7 @@ def test_version_publish_version(draft_version, asset):
     draft_version.assets.add(asset)
     draft_version.save()
 
-    publish_version = draft_version.publish_version
+    publish_version = _build_publishable_version_from_draft(draft_version)
     publish_version.doi = fake_doi
     publish_version.save()
 
@@ -320,6 +321,7 @@ def test_version_publish_version(draft_version, asset):
         # The published_version cannot have a properly defined assetsSummary yet, since that would
         # require having created rows the Asset-to-Version join table, which is a side affect.
         'assetsSummary': {
+            'schemaKey': 'AssetsSummary',
             'numberOfBytes': 0,
             'numberOfFiles': 0,
         },


### PR DESCRIPTION
For some background: modifying assets requires modifying the draft version to update the asset summary. This creates write contention on the version when assets that belong to the same version are being modified concurrently. The problem is complicated because the asset summary can take several seconds on larger dandisets and the time grows linearly with the asset count. To date this has only been a problem with our largest dandiset. 

This PR moves the asset summary computation to an asynchronous task, similar to version metadata validation. 

@mvandenburgh Can you take a look at this PR closely since it touches some of your recently modified publishing code? 

This is a draft for right now, I want to look closer into the version lifecycle before I merge.