### PR TITLE
ENH: explicitly describe both cases of not allowed dandiset deletion

### DIFF
--- a/dandiapi/api/services/dandiset/__init__.py
+++ b/dandiapi/api/services/dandiset/__init__.py
@@ -48,7 +48,7 @@ def create_dandiset(
 
 def delete_dandiset(*, user, dandiset: Dandiset) -> None:
     if not user.has_perm('owner', dandiset):
-        raise NotAllowed('Cannot delete dandsets which you do not own.')
+        raise NotAllowed('Cannot delete dandisets which you do not own.')
     if dandiset.embargo_status != Dandiset.EmbargoStatus.OPEN:
         raise NotAllowed('Cannot delete dandisets which are embargoed.')
     if dandiset.versions.exclude(version='draft').exists():

--- a/dandiapi/api/services/dandiset/__init__.py
+++ b/dandiapi/api/services/dandiset/__init__.py
@@ -47,12 +47,10 @@ def create_dandiset(
 
 
 def delete_dandiset(*, user, dandiset: Dandiset) -> None:
-    if (
-        not user.has_perm('owner', dandiset)
-        or dandiset.embargo_status != Dandiset.EmbargoStatus.OPEN
-    ):
-        raise NotAllowed()
-
+    if not user.has_perm('owner', dandiset):
+        raise NotAllowed('Cannot delete dandsets which you do not own.')
+    if dandiset.embargo_status != Dandiset.EmbargoStatus.OPEN:
+        raise NotAllowed('Cannot delete dandisets which are embargoed.')
     if dandiset.versions.exclude(version='draft').exists():
         raise NotAllowed('Cannot delete dandisets with published versions.')
     if dandiset.versions.filter(status=Version.Status.PUBLISHING).exists():


### PR DESCRIPTION
User reported being unable to delete a dandiset and it was not clear why it was denied.  If we do channel those messages in responses - this should make it clear why request was denied.