### PR TITLE
Fix dependabot ignore type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     labels:
       - internal
     ignore:
-      - update-types: ["patch"]
+      - update-types: ["version-update:semver-patch"]
   - package-ecosystem: pip
     directory: /
     schedule:
@@ -18,4 +18,4 @@ updates:
     labels:
       - internal
     ignore:
-    - update-types: ["patch"]
+      - update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
I misread the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore) :sweat_smile: 