### PR TITLE
Fix publishing UI bug

### DIFF
--- a/web/src/stores/dandiset.ts
+++ b/web/src/stores/dandiset.ts
@@ -11,7 +11,6 @@ import { draftVersion } from '@/utils/constants';
 interface State {
   dandiset: Version | null;
   versions: Version[] | null,
-  loading: boolean,
   owners: User[] | null,
   schema: any,
 }
@@ -20,7 +19,6 @@ export const useDandisetStore = defineStore('dandiset', {
   state: (): State => ({
     dandiset: null,
     versions: null,
-    loading: false,
     owners: null,
     schema: null,
   }),
@@ -47,7 +45,6 @@ export const useDandisetStore = defineStore('dandiset', {
       this.dandiset = null;
       this.versions = null;
       this.owners = null;
-      this.loading = false;
     },
     async initializeDandisets({ identifier, version }: Record<string, string>) {
       this.uninitializeDandisets();
@@ -58,7 +55,6 @@ export const useDandisetStore = defineStore('dandiset', {
       await this.fetchOwners(identifier);
     },
     async fetchDandisetVersions({ identifier }: Record<string, string>) {
-      this.loading = true;
       let res;
       try {
         res = await dandiRest.versions(identifier);
@@ -75,16 +71,12 @@ export const useDandisetStore = defineStore('dandiset', {
         const { results } = res;
         this.versions = results || [];
       }
-
-      this.loading = false;
     },
     async fetchDandiset({ identifier, version }: Record<string, string>) {
-      this.loading = true;
       const sanitizedVersion = version || (await dandiRest.mostRecentVersion(identifier))?.version;
 
       if (!sanitizedVersion) {
         this.dandiset = null;
-        this.loading = false;
         return;
       }
 
@@ -98,8 +90,6 @@ export const useDandisetStore = defineStore('dandiset', {
           throw err;
         }
       }
-
-      this.loading = false;
     },
     async fetchSchema() {
       const { schema_url: schemaUrl } = await dandiRest.info();
@@ -114,12 +104,8 @@ export const useDandisetStore = defineStore('dandiset', {
       this.schema = schema;
     },
     async fetchOwners(identifier: string) {
-      this.loading = true;
-
       const { data } = await dandiRest.owners(identifier);
       this.owners = data;
-
-      this.loading = false;
     },
   },
 });

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -116,7 +116,7 @@ const router = useRouter();
 const store = useDandisetStore();
 
 const currentDandiset = computed(() => store.dandiset);
-const loading = computed(() => store.loading);
+const loading = ref(false);
 const schema = computed(() => store.schema);
 const userCanModifyDandiset = computed(() => store.userCanModifyDandiset);
 
@@ -140,12 +140,15 @@ function navigateToVersion(versionToNavigateTo: string) {
 watch(() => props.identifier, async () => {
   const { identifier, version } = props;
   if (identifier) {
+    loading.value = true;
     await store.initializeDandisets({ identifier, version });
+    loading.value = false;
   }
 }, { immediate: true });
 
 watch([() => props.identifier, () => props.version], async () => {
   const { identifier, version } = props;
+  loading.value = true;
   if (version) {
     // On version change, fetch the new dandiset (not initial)
     await store.fetchDandiset({ identifier, version });
@@ -164,6 +167,7 @@ watch([() => props.identifier, () => props.version], async () => {
       navigateToVersion(draftVersion);
     }
   }
+  loading.value = false;
 });
 
 const page = ref(Number(route.query.pos) || 1);

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -632,6 +632,7 @@ async function publish() {
     }
 
     showPublishChecklistDialog.value = false;
+    showPublishWarningDialog.value = false;
 
     publishing.value = true;
     try {


### PR DESCRIPTION
To replicate this bug, go to a publishable dandiset and click publish:

https://gui-staging.dandiarchive.org/dandiset/204686?page=6&sortOption=0&sortDir=-1&showDrafts=true&showEmpty=false&pos=41

https://gui-staging.dandiarchive.org/dandiset/204685?page=6&sortOption=0&sortDir=-1&showDrafts=true&showEmpty=false&pos=42

https://gui-staging.dandiarchive.org/dandiset/204677?page=6&sortOption=0&sortDir=-1&showDrafts=true&showEmpty=false&pos=45

https://gui-staging.dandiarchive.org/dandiset/204681?page=6&sortOption=0&sortDir=-1&showDrafts=true&showEmpty=false&pos=44

After clicking publish, the UI immediately starts bugging out and rerendering the DLP every few seconds. This is caused by some reactivity bug with the `loading` variable in the store. This particular variable is only used in a single component, so I refactored it to a local variable within that component, and now the publish UI behaves as expected.