### PR TITLE
Remove overly aggressive exception handling

### DIFF
--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -73,14 +73,9 @@ def version_aggregate_assets_summary(version: Version):
     if version.version != 'draft':
         raise VersionHasBeenPublished()
 
-    try:
-        version.metadata['assetsSummary'] = aggregate_assets_summary(
-            version.assets.values_list('metadata', flat=True).iterator()
-        )
-    except Exception:
-        # The assets summary aggregation may fail if any asset metadata is invalid, skip
-        # updating it if it fails.
-        logger.info('Error calculating assetsSummary', exc_info=True)
+    version.metadata['assetsSummary'] = aggregate_assets_summary(
+        version.assets.values_list('metadata', flat=True).iterator()
+    )
 
     Version.objects.filter(id=version.id, version='draft').update(
         modified=timezone.now(), metadata=version.metadata


### PR DESCRIPTION
Related #1489 

@satra I think I understand what you're getting at and this PR is what I'm hoping satisfies requirements. I'll recap my understanding of these changes and rationale for confirmation/discussion.

1. Stop catching ValueErrors when validating assets
	We shouldn't be marking assets invalid for what are likely bugs in our dandi-archive/dandi-schema software. Instead, an exception will be unhandled and thus tracked in Sentry. The asset will be unable to be validated until we intervene to fix the bug. Since we've been masking this error and storing the results, we can say that all ValueErrors that have been caught to date are of the form `Metadata version x.y.z is not allowed. Allowed are: x.y.z, ...`. (Maybe this is related to https://github.com/dandi/dandi-cli/issues/935).
2. Stop catching blanket exceptions when aggregating assets summary
	This could also hide genuine bugs. These are currently logged but not alerted, which is problematic. Historically this has resulted in masking this error:
```
Traceback (most recent call last):                          
    File "/app/dandiapi/api/models/version.py", line 237, in _populate_metadata                             
    summary = aggregate_assets_summary(                     
    File "/app/.heroku/python/lib/python3.10/site-packages/dandischema/metadata.py", line 334, in aggregate_assets_summary                                    
    _add_asset_to_stats(meta, stats)                        
    File "/app/.heroku/python/lib/python3.10/site-packages/dandischema/metadata.py", line 319, in _add_asset_to_stats                                         
    if "nwb" in assetmeta["encodingFormat"]:                
KeyError: 'encodingFormat'                                  
```

Does this sound right? And if so, is the idea to merge a PR like this and then address #1450?