### PR TITLE
Pin to Node 16 in CI

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
+        with:
+          node-version: 16 # TODO: use latest version when we update to Vue 3
 
       - name: Install Vue app
         run: yarn install


### PR DESCRIPTION
CI is currently failing due to the `setup-node` action now defaulting to Node 18. Ideally we would use node 18, but 18 isn't compatible with vue-cli 4. I tried updating to vue-cli 5, but that also implicitly bumps webpack from v4 to v5, which one of our dependencies has some compatibility issues with. We're presumably going to upgrade to Vue 3 relatively soon, at which point this will all be moot because we'll be using Vite instead of vue-cli/webpack. So, for now I've just pinned our node version to 16.