### PR TITLE
Rename field in zarr file request to `base64md5` for clarity

### DIFF
--- a/dandiapi/api/storage.py
+++ b/dandiapi/api/storage.py
@@ -143,14 +143,14 @@ class VerbatimNameS3Storage(VerbatimNameStorageMixin, TimeoutS3Boto3Storage):
                 return etag[1:-1]
             return etag
 
-    def generate_presigned_put_object_url(self, blob_name: str, md5: str) -> str:
+    def generate_presigned_put_object_url(self, blob_name: str, base64md5: str) -> str:
         return self.connection.meta.client.generate_presigned_url(
             ClientMethod='put_object',
             Params={
                 'Bucket': self.bucket_name,
                 'Key': blob_name,
                 'ACL': 'bucket-owner-full-control',
-                'ContentMD5': md5,
+                'ContentMD5': base64md5,
             },
             ExpiresIn=600,  # TODO proper expiration
         )

--- a/dandiapi/zarr/models.py
+++ b/dandiapi/zarr/models.py
@@ -70,7 +70,7 @@ class BaseZarrArchive(TimeStampedModel):
 
     def generate_upload_urls(self, path_md5s: list[dict]):
         return [
-            self.storage.generate_presigned_put_object_url(self.s3_path(o['path']), o['md5'])
+            self.storage.generate_presigned_put_object_url(self.s3_path(o['path']), o['base64md5'])
             for o in path_md5s
         ]
 

--- a/dandiapi/zarr/tests/test_zarr_upload.py
+++ b/dandiapi/zarr/tests/test_zarr_upload.py
@@ -25,7 +25,7 @@ def test_zarr_rest_upload_start(
     # Request upload files
     resp = authenticated_api_client.post(
         f'/api/zarr/{zarr_archive.zarr_id}/files/',
-        [{'path': 'foo/bar.txt', 'md5': '12345'}],
+        [{'path': 'foo/bar.txt', 'base64md5': '12345'}],
         format='json',
     )
     assert resp.status_code == 200
@@ -41,7 +41,7 @@ def test_zarr_rest_upload_start(
     # Request more
     resp = authenticated_api_client.post(
         f'/api/zarr/{zarr_archive.zarr_id}/files/',
-        [{'path': 'foo/bar2.txt', 'md5': '12345'}],
+        [{'path': 'foo/bar2.txt', 'base64md5': '12345'}],
         format='json',
     )
     assert resp.status_code == 200
@@ -52,7 +52,7 @@ def test_zarr_rest_upload_start(
 def test_zarr_rest_upload_start_not_an_owner(authenticated_api_client, zarr_archive: ZarrArchive):
     resp = authenticated_api_client.post(
         f'/api/zarr/{zarr_archive.zarr_id}/files/',
-        [{'path': 'foo/bar.txt', 'md5': '12345'}],
+        [{'path': 'foo/bar.txt', 'base64md5': '12345'}],
         format='json',
     )
     assert resp.status_code == 403

--- a/dandiapi/zarr/views/__init__.py
+++ b/dandiapi/zarr/views/__init__.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 class ZarrFileCreationSerializer(serializers.Serializer):
     path = serializers.CharField()
-    md5 = serializers.CharField()
+    base64md5 = serializers.CharField()
 
 
 class ZarrDeleteFileRequestSerializer(serializers.Serializer):


### PR DESCRIPTION
Follow on from #1497 