### PR TITLE
Fix max length for name/description on Create Dandiset page

### DIFF
--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -10,7 +10,7 @@
           label="Name*"
           hint="Provide a title for this dataset"
           persistent-hint
-          :counter="120"
+          :counter="nameMaxLength"
           required
           outlined
         />
@@ -18,7 +18,7 @@
           v-model="description"
           label="Description*"
           hint="Provide a description for this dataset"
-          :counter="3000"
+          :counter="descriptionMaxLength"
           persistent-hint
           required
           outlined
@@ -145,6 +145,10 @@ const awardNumberRules = computed(
   () => [(v: string) => awardNumberValidator(v) || VALIDATION_FAIL_MESSAGE],
 );
 
+const nameMaxLength: ComputedRef<number> = computed(() => store.schema.properties.name.maxLength);
+const descriptionMaxLength: ComputedRef<number> = computed(
+  () => store.schema.properties.description.maxLength,
+);
 const dandiLicenses: ComputedRef<LicenseType[]> = computed(
   () => store.schema.definitions.LicenseType.enum,
 );


### PR DESCRIPTION
There was an inconsistency because we were hardcoding the max lengths for name and description, while the meditor was pulling them from the schema. This PR updates the create dandiset page to pull these values from the schema as well.

Fixes #1474