### PR TITLE
Handle zarrs properly in asset metadata validation

### DIFF
--- a/dandiapi/zarr/tests/test_ingest_zarr_archive.py
+++ b/dandiapi/zarr/tests/test_ingest_zarr_archive.py
@@ -79,10 +79,10 @@ def test_ingest_zarr_archive_force(zarr_archive_factory, zarr_file_factory):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_ingest_zarr_archive_assets(zarr_archive_factory, zarr_file_factory, asset_factory):
+def test_ingest_zarr_archive_assets(zarr_archive_factory, zarr_file_factory, draft_asset_factory):
     # Create zarr and asset
     zarr: ZarrArchive = zarr_archive_factory()
-    asset = asset_factory(zarr=zarr, blob=None, embargoed_blob=None)
+    asset = draft_asset_factory(zarr=zarr, blob=None, embargoed_blob=None)
 
     # Assert asset size, metadata
     assert asset.size == 0


### PR DESCRIPTION
Closes #1362

This should fix the issues with all of the zarr assets stuck in the `PENDING` state. However, when we do deploy this, we'll need to manually queue any existing zarr assets for metadata validation.