### PR TITLE
Disable the publish button when Zarrs are contained in the Dandiset

### DIFF
--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import { mapState } from 'pinia';
 import OAuthClient from '@girder/oauth-client';
 import {
-  Asset, Dandiset, Paginated, User, Version, Info, AssetPath,
+  Asset, Dandiset, Paginated, User, Version, Info, AssetPath, Zarr,
 } from '@/types';
 import { Dandiset as DandisetMetadata, DandisetContributors, Organization } from '@/types/schema';
 // eslint-disable-next-line import/no-cycle
@@ -114,6 +114,18 @@ const dandiRest = new Vue({
         }
         throw error;
       }
+    },
+    async zarr({ dandiset }: { dandiset?: string }) : Promise<Paginated<Zarr>> {
+      const data: { dandiset?: string } = {};
+      if (dandiset !== undefined) {
+        data.dandiset = dandiset;
+      }
+
+      const resp = await client.get('zarr/', {
+        data,
+      });
+
+      return resp.data;
     },
     async assetPaths(
       identifier: string,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -54,6 +54,16 @@ export interface Asset {
   version: Version,
 }
 
+export interface Zarr {
+  name: string;
+  dandiset: string;
+  zarr_id: string;
+  status: 'Pending' | 'Ingesting' | 'Complete';
+  checksum: string;
+  file_count: number;
+  size: number;
+}
+
 export interface Paginated<T> {
   count: number,
   next: string,

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -438,7 +438,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ComputedRef, ref } from 'vue';
+import {
+  computed, ComputedRef, ref, watchEffect,
+} from 'vue';
 
 import axios from 'axios';
 import moment from 'moment';
@@ -518,6 +520,17 @@ const publishedVersion = ref('');
 
 const alreadyBeingPublishedError = ref(false);
 
+const containsZarr = ref(false);
+watchEffect(async () => {
+  if (currentDandiset.value) {
+    const zarr = await dandiRest.zarr({
+      dandiset: currentDandiset.value.dandiset.identifier,
+    });
+
+    containsZarr.value = zarr.count > 0;
+  }
+});
+
 const publishDisabledMessage: ComputedRef<string> = computed(() => {
   if (!loggedIn.value) {
     return 'You must be logged in to edit.';
@@ -542,6 +555,9 @@ const publishDisabledMessage: ComputedRef<string> = computed(() => {
   }
   if (publishing.value) {
     return 'This dandiset is being published, please wait.';
+  }
+  if (containsZarr.value) {
+    return 'Dandisets containing Zarr archives cannot currently be published.';
   }
   return '';
 });


### PR DESCRIPTION
To see this in action, go to this [dandiset](https://deploy-preview-1517--gui-staging-dandiarchive-org.netlify.app/dandiset/207380) that only contains a single Zarr and a single NWB file, and hover over the publish button.

Closes #857.