### PR TITLE
Boost dandischema to 0.8.0 to get newer DANDI_SCHEMA_VERSION 0.6.4 supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'dandischema~=0.7.1',
+        'dandischema~=0.8.0',
         'django~=4.1.0',
         'django-admin-display',
         'django-allauth',


### PR DESCRIPTION
Closes #1520

Should be done soonish since otherwise we would end up with situation where users can't upload after they get their dandischema upgraded somehow (pip is not strict enough at times) and they start to try uploading with newer version of schema which archive does not support.

If I got it right there is no need for explicit specification of DANDI_SCHEMA_VERSION to be 0.6.4 , if that is not true -- please share how it should be done.