### PR TITLE
Fix zarr publish error bug

### DIFF
--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -116,13 +116,13 @@ const dandiRest = new Vue({
       }
     },
     async zarr({ dandiset }: { dandiset?: string }) : Promise<Paginated<Zarr>> {
-      const data: { dandiset?: string } = {};
+      const params: { dandiset?: string } = {};
       if (dandiset !== undefined) {
-        data.dandiset = dandiset;
+        params.dandiset = dandiset;
       }
 
       const resp = await client.get('zarr/', {
-        data,
+        params,
       });
 
       return resp.data;


### PR DESCRIPTION
`params` must be used to pass query parameters for a GET request with axios. Since we weren't using that, no dandiset id was being sent to the zarr endpoint, causing the zarr endpoint to return the count of zarrs in the entire system, which in turn caused dandisets with no zarrs to be flagged as having zarrs.