### PR TITLE
Enable inline view of assets

### DIFF
--- a/dandiapi/api/storage.py
+++ b/dandiapi/api/storage.py
@@ -171,6 +171,17 @@ class VerbatimNameS3Storage(VerbatimNameStorageMixin, TimeoutS3Boto3Storage):
             },
         )
 
+    def generate_presigned_inline_url(self, key: str) -> str:
+        return self.connection.meta.client.generate_presigned_url(
+            'get_object',
+            Params={
+                'Bucket': self.bucket_name,
+                'Key': key,
+                'ResponseContentDisposition': 'inline',
+            },
+        )
+
+
     def sha256_checksum(self, key: str) -> str:
         calculator = ChecksumCalculatorFile()
         obj = self.bucket.Object(key)
@@ -211,6 +222,13 @@ class VerbatimNameMinioStorage(VerbatimNameStorageMixin, DeconstructableMinioSto
             self.bucket_name,
             key,
             response_headers={'response-content-disposition': f'attachment; filename="{path}"'},
+        )
+
+    def generate_presigned_inline_url(self, key: str) -> str:
+        return self.base_url_client.presigned_get_object(
+            self.bucket_name,
+            key,
+            response_headers={'response-content-disposition': 'inline'},
         )
 
     def sha256_checksum(self, key: str) -> str:

--- a/dandiapi/api/storage.py
+++ b/dandiapi/api/storage.py
@@ -171,13 +171,14 @@ class VerbatimNameS3Storage(VerbatimNameStorageMixin, TimeoutS3Boto3Storage):
             },
         )
 
-    def generate_presigned_inline_url(self, key: str) -> str:
+    def generate_presigned_inline_url(self, key: str, path: str, content_type: str) -> str:
         return self.connection.meta.client.generate_presigned_url(
             'get_object',
             Params={
                 'Bucket': self.bucket_name,
                 'Key': key,
-                'ResponseContentDisposition': 'inline',
+                'ResponseContentDisposition': f'inline; filename="{path}"',
+                'ResponseContentType': content_type,
             },
         )
 
@@ -223,11 +224,14 @@ class VerbatimNameMinioStorage(VerbatimNameStorageMixin, DeconstructableMinioSto
             response_headers={'response-content-disposition': f'attachment; filename="{path}"'},
         )
 
-    def generate_presigned_inline_url(self, key: str) -> str:
+    def generate_presigned_inline_url(self, key: str, path: str, content_type: str) -> str:
         return self.base_url_client.presigned_get_object(
             self.bucket_name,
             key,
-            response_headers={'response-content-disposition': 'inline'},
+            response_headers={
+                'response-content-disposition': f'inline; filename="{path}"',
+                'response-content-type': content_type,
+            },
         )
 
     def sha256_checksum(self, key: str) -> str:

--- a/dandiapi/api/storage.py
+++ b/dandiapi/api/storage.py
@@ -181,7 +181,6 @@ class VerbatimNameS3Storage(VerbatimNameStorageMixin, TimeoutS3Boto3Storage):
             },
         )
 
-
     def sha256_checksum(self, key: str) -> str:
         calculator = ChecksumCalculatorFile()
         obj = self.bucket.Object(key)

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -150,7 +150,11 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
                 storage.generate_presigned_download_url(asset_blob.blob.name, asset_basename)
             )
         elif content_disposition == 'inline':
-            url = storage.generate_presigned_inline_url(asset_blob.blob.name)
+            url = storage.generate_presigned_inline_url(
+                asset_blob.blob.name,
+                asset_basename,
+                asset.metadata.get('encodingFormat', 'application/octet-stream'),
+            )
 
             if asset_basename.endswith('.mkv'):
                 return HttpResponse(

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -147,22 +147,20 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
 
         if content_disposition == 'attachment':
             return HttpResponseRedirect(
-                storage.generate_presigned_download_url(
-                    asset_blob.blob.name, asset_basename
-                )
+                storage.generate_presigned_download_url(asset_blob.blob.name, asset_basename)
             )
         elif content_disposition == 'inline':
-            url = storage.generate_presigned_inline_url(
-                asset_blob.blob.name
-            )
-
+            url = storage.generate_presigned_inline_url(asset_blob.blob.name)
 
             if asset_basename.endswith('.mkv'):
-                return HttpResponse(f'''
+                return HttpResponse(
+                    f"""
                     <video>
                         <source src="{url}" type="video/mp4"
                     </video>
-                ''', content_type="text/html")
+                """,
+                    content_type='text/html',
+                )
 
             return HttpResponseRedirect(url)
 

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -113,7 +113,7 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
         method='GET',
         operation_summary='Get the download link for an asset.',
         operation_description='',
-        manual_parameters=[ASSET_ID_PARAM, CONTENT_DISPOSITION_PARAM],
+        query_serializer=AssetDownloadQueryParameterSerializer,
         responses={
             200: None,  # This disables the auto-generated 200 response
             301: 'Redirect to object store',

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -143,6 +143,7 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
         serializer = AssetDownloadQueryParameterSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         content_disposition = serializer.validated_data['content_disposition']
+        content_type = asset.metadata.get('encodingFormat', 'application/octet-stream')
         asset_basename = os.path.basename(asset.path)
 
         if content_disposition == 'attachment':
@@ -153,10 +154,10 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
             url = storage.generate_presigned_inline_url(
                 asset_blob.blob.name,
                 asset_basename,
-                asset.metadata.get('encodingFormat', 'application/octet-stream'),
+                content_type,
             )
 
-            if asset_basename.endswith('.mkv'):
+            if content_type == 'video/x-matroska':
                 return HttpResponse(
                     f"""
                     <video autoplay muted controls>

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -159,8 +159,8 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
             if asset_basename.endswith('.mkv'):
                 return HttpResponse(
                     f"""
-                    <video>
-                        <source src="{url}" type="video/mp4"
+                    <video autoplay muted controls>
+                        <source src="{url}" type="video/mp4">
                     </video>
                 """,
                     content_type='text/html',

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -44,7 +44,6 @@ from dandiapi.api.models import Asset, AssetBlob, Dandiset, Version
 from dandiapi.api.models.asset import EmbargoedAssetBlob, validate_asset_path
 from dandiapi.api.views.common import (
     ASSET_ID_PARAM,
-    CONTENT_DISPOSITION_PARAM,
     VERSIONS_DANDISET_PK_PARAM,
     VERSIONS_VERSION_PARAM,
     DandiPagination,

--- a/dandiapi/api/views/common.py
+++ b/dandiapi/api/views/common.py
@@ -23,15 +23,6 @@ ASSET_ID_PARAM = openapi.Parameter(
     pattern=r'[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}',
 )
 
-CONTENT_DISPOSITION_PARAM = openapi.Parameter(
-    'content_disposition',
-    openapi.IN_QUERY,
-    'Content Disposition',
-    type=openapi.TYPE_STRING,
-    required=False,
-    pattern='inline|attachment',
-)
-
 DANDISET_PK_PARAM = openapi.Parameter(
     'dandiset__pk',
     openapi.IN_PATH,

--- a/dandiapi/api/views/common.py
+++ b/dandiapi/api/views/common.py
@@ -23,6 +23,15 @@ ASSET_ID_PARAM = openapi.Parameter(
     pattern=r'[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}',
 )
 
+CONTENT_DISPOSITION_PARAM = openapi.Parameter(
+    'content_disposition',
+    openapi.IN_QUERY,
+    'Content Disposition',
+    type=openapi.TYPE_STRING,
+    required=False,
+    pattern='inline|attachment',
+)
+
 DANDISET_PK_PARAM = openapi.Parameter(
     'dandiset__pk',
     openapi.IN_PATH,

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -203,15 +203,12 @@ class AssetValidationSerializer(serializers.ModelSerializer):
 class AssetDownloadQueryParameterSerializer(serializers.Serializer):
     content_disposition = serializers.CharField(default='attachment')
 
-    def validate(self, data):
-        value = data['content_disposition']
-
+    def validate_content_disposition(self, value):
         if value not in ['attachment', 'inline']:
             raise ValidationError(
                 f'Illegal value {value} for parameter "content_disposition"', code=400
             )
-
-        return super().validate(data)
+        return value
 
 
 class EmbargoedSlugRelatedField(serializers.SlugRelatedField):

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -207,7 +207,9 @@ class AssetDownloadQueryParameterSerializer(serializers.Serializer):
         value = data['content_disposition']
 
         if value not in ['attachment', 'inline']:
-            raise ValidationError(f'Illegal value {value} for parameter "content_disposition"', code=400)
+            raise ValidationError(
+                f'Illegal value {value} for parameter "content_disposition"', code=400
+            )
 
         return super().validate(data)
 

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
 
 from dandiapi.api.models import Asset, AssetBlob, AssetPath, Dandiset, Version
 
@@ -201,14 +200,7 @@ class AssetValidationSerializer(serializers.ModelSerializer):
 
 
 class AssetDownloadQueryParameterSerializer(serializers.Serializer):
-    content_disposition = serializers.CharField(default='attachment')
-
-    def validate_content_disposition(self, value):
-        if value not in ['attachment', 'inline']:
-            raise ValidationError(
-                f'Illegal value {value} for parameter "content_disposition"', code=400
-            )
-        return value
+    content_disposition = serializers.ChoiceField(['attachment', 'inline'], default='attachment')
 
 
 class EmbargoedSlugRelatedField(serializers.SlugRelatedField):

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from dandiapi.api.models import Asset, AssetBlob, AssetPath, Dandiset, Version
 
@@ -197,6 +198,18 @@ class AssetValidationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Asset
         fields = ['status', 'validation_errors']
+
+
+class AssetDownloadQueryParameterSerializer(serializers.Serializer):
+    content_disposition = serializers.CharField(default='attachment')
+
+    def validate(self, data):
+        value = data['content_disposition']
+
+        if value not in ['attachment', 'inline']:
+            raise ValidationError(f'Illegal value {value} for parameter "content_disposition"', code=400)
+
+        return super().validate(data)
 
 
 class EmbargoedSlugRelatedField(serializers.SlugRelatedField):

--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -242,6 +242,9 @@ const dandiRest = new Vue({
     assetDownloadURI(identifier: string, version: string, uuid: string) {
       return `${dandiApiRoot}assets/${uuid}/download/`;
     },
+    assetInlineURI(identifier: string, version: string, uuid: string) {
+      return `${dandiApiRoot}assets/${uuid}/download?content_disposition=inline`;
+    },
     assetMetadataURI(identifier: string, version: string, uuid: string) {
       return `${dandiApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}`;
     },

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -147,6 +147,18 @@
                 <v-list-item-action v-if="item.asset">
                   <v-btn
                     icon
+                    :href="inlineURI(item.asset.asset_id)"
+                    target="_blank"
+                  >
+                    <v-icon color="primary">
+                      mdi-eye
+                    </v-icon>
+                  </v-btn>
+                </v-list-item-action>
+
+                <v-list-item-action v-if="item.asset">
+                  <v-btn
+                    icon
                     :href="downloadURI(item.asset.asset_id)"
                   >
                     <v-icon color="primary">
@@ -390,6 +402,10 @@ function navigateToParent() {
 
 function downloadURI(asset_id: string) {
   return dandiRest.assetDownloadURI(props.identifier, props.version, asset_id);
+}
+
+function inlineURI(asset_id: string) {
+  return dandiRest.assetInlineURI(props.identifier, props.version, asset_id);
 }
 
 function assetMetadataURI(asset_id: string) {


### PR DESCRIPTION
Closes #1389
Closes #1057 

This is a simple premise: add the generation of asset download URLs with a content-disposition of `inline`, and use those to drive an in-browser view of assets in the file browser.

This works for many file types, including text files and video files, but specifically not for `.mkv` files. This PR contains a hack to generate an HTML response with a `<video>` tag that "shims" the lack of support for those files.