### PR TITLE
Optimize dandiset/versions and dandiset/versions/info endpoints

### DIFF
--- a/dandiapi/api/asset_paths.py
+++ b/dandiapi/api/asset_paths.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from django.db import IntegrityError, transaction
 from django.db.models import F, QuerySet, Sum
 from django.db.models.functions import Coalesce
 from tqdm import tqdm
 
-from dandiapi.api.models import Asset, AssetPath, AssetPathRelation, Version
-from dandiapi.zarr.models import ZarrArchive
+# Import only the asset paths models
+from dandiapi.api.models.asset_paths import AssetPath, AssetPathRelation
+
+# Import models for type checking only (prevent cyclic imports)
+if TYPE_CHECKING:
+    from dandiapi.api.models import Asset, Version
+    from dandiapi.zarr.models import ZarrArchive
+
 
 ####################################################################
 # Dandiset and version deletion will cascade to asset path deletion.

--- a/dandiapi/api/models/asset_paths.py
+++ b/dandiapi/api/models/asset_paths.py
@@ -2,21 +2,18 @@ from __future__ import annotations
 
 from django.db import models
 
-from dandiapi.api.models.asset import Asset
-from dandiapi.api.models.version import Version
-
 
 class AssetPath(models.Model):
     path = models.CharField(max_length=512)
 
     # Protect deletion, since otherwise aggregate fields would become out of sync
     asset = models.ForeignKey(
-        Asset, null=True, blank=True, related_name='leaf_paths', on_delete=models.PROTECT
+        'Asset', null=True, blank=True, related_name='leaf_paths', on_delete=models.PROTECT
     )
 
     # Cascade deletion, as if the entire version is deleted,
     # all paths associated to that version are no longer relevant
-    version = models.ForeignKey(Version, related_name='asset_paths', on_delete=models.CASCADE)
+    version = models.ForeignKey('Version', related_name='asset_paths', on_delete=models.CASCADE)
 
     # Aggregate fields
     aggregate_files = models.PositiveBigIntegerField(default=0)

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -81,20 +81,6 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
         return not self.assets.exclude(status=Asset.Status.VALID).exists()
 
     @property
-    def publish_status(self) -> Version.Status:
-        if self.status != Version.Status.VALID:
-            return self.status
-
-        # Import here to avoid dependency cycle
-        from .asset import Asset
-
-        invalid_asset = self.assets.exclude(status=Asset.Status.VALID).first()
-        if invalid_asset:
-            return Version.Status.INVALID
-
-        return Version.Status.VALID
-
-    @property
     def asset_validation_errors(self) -> list[str]:
         # Import here to avoid dependency cycle
         from .asset import Asset

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.db.models.query_utils import Q
 from django_extensions.db.models import TimeStampedModel
 
+from dandiapi.api.asset_paths import get_root_paths
 from dandiapi.api.models.metadata import PublishableMetadataMixin
 
 from .dandiset import Dandiset
@@ -59,14 +60,13 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
 
     @property
     def asset_count(self):
-        return self.assets.count()
+        return get_root_paths(self).aggregate(nfiles=models.Sum('aggregate_files'))['nfiles'] or 0
 
     @property
     def size(self):
         return (
-            (self.assets.aggregate(size=models.Sum('blob__size'))['size'] or 0)
-            + (self.assets.aggregate(size=models.Sum('embargoed_blob__size'))['size'] or 0)
-            + (self.assets.aggregate(size=models.Sum('zarr__size'))['size'] or 0)
+            get_root_paths(self).aggregate(total_size=models.Sum('aggregate_size'))['total_size']
+            or 0
         )
 
     @property

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -465,7 +465,7 @@ def test_version_rest_info_with_asset(
         'asset_count': 1,
         'metadata': version.metadata,
         'size': version.size,
-        'status': 'Valid' if asset_status == Asset.Status.VALID else 'Invalid',
+        'status': Asset.Status.VALID,
         'asset_validation_errors': expected_validation_error,
         'version_validation_errors': [],
         'contact_person': version.metadata['contributor'][0]['name'],

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from rest_framework.test import APIClient
 
 from dandiapi.api import tasks
+from dandiapi.api.asset_paths import add_version_asset_paths
 from dandiapi.api.models import Asset, Version
 from dandiapi.api.services.publish import _build_publishable_version_from_draft
 from dandiapi.zarr.tasks import ingest_zarr_archive
@@ -341,6 +342,8 @@ def test_version_size(
         asset_factory(blob=None, embargoed_blob=embargoed_asset_blob_factory(size=200))
     )
     version.assets.add(asset_factory(blob=None, zarr=zarr_archive_factory(size=400)))
+    add_version_asset_paths(version=version)
+
     assert version.size == 700
 
 
@@ -439,6 +442,7 @@ def test_version_rest_info_with_asset(
     version = draft_version_factory(status=Version.Status.VALID)
     asset = draft_asset_factory(status=asset_status)
     version.assets.add(asset)
+    add_version_asset_paths(version=version)
 
     # These validation error types should have the asset path prepended to them:
     if asset_status == Asset.Status.PENDING or asset_status == Asset.Status.VALIDATING:

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -173,8 +173,6 @@ class VersionDetailSerializer(VersionSerializer):
             'contact_person',
         ]
 
-    status = serializers.CharField(source='publish_status')
-
     # rename this field in the serializer to differentiate from asset_validation_errors
     version_validation_errors = serializers.JSONField(source='validation_errors')
 


### PR DESCRIPTION
These endpoint were making an excessive number of SQL queries and aggregations. This may have gone unnoticed due to this behavior stemming from properties on the `Version` model. I noticed this when viewing the DLP of dandiset `000026`, which takes several seconds to load due to these queries. This PR should greatly reduce that time.

This PR also removes the `publish_status` property from the `Version` model. This property is funtionally equivalent to the `valid` property, and causes unnecessary API slowdown, as the same information is already included in the `asset_validation_errors` field.