### PR TITLE
Add license info to dandiset creation page + do a style overhaul

### DIFF
--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -5,38 +5,9 @@
     </v-card-title>
     <v-card-text class="my-3">
       <v-form>
-        <h1>Dandiset Title</h1>
-        <div>
-          Provide a title for this Dandiset. The title will appear in search
-          results and at the top of the home page for this Dandiset, so make it
-          concise and descriptive.
-        </div>
-        <v-text-field
-          v-model="name"
-          label="Title"
-          :counter="nameMaxLength"
-          required
-          outlined
-        />
-
-        <h1>Description</h1>
-        <div>
-          Provide a description for this Dandiset. This will appear prominently
-          under the title in the home page for this Dandiset.
-        </div>
-        <v-textarea
-          v-model="description"
-          label="Description"
-          :counter="descriptionMaxLength"
-          required
-          outlined
-          class="my-4"
-        />
         <div>
           <v-checkbox
             v-model="embargoed"
-            hide-details
-            class="shrink mr-2 mt-0"
           >
             <template #label>
               Embargo this Dandiset
@@ -67,21 +38,6 @@
               </v-tooltip>
             </template>
           </v-checkbox>
-          <v-text-field
-            v-if="embargoed"
-            v-model="awardNumber"
-            label="Award number*"
-            hint="Provide an NIH award number for this embargoed dataset.
-                Note: this can be changed at any time and additional award
-                numbers can be added later."
-            persistent-hint
-            :counter="120"
-            :required="embargoed"
-            outlined
-            class="mt-4 shrink"
-            style="width: 20vw;"
-            :rules="awardNumberRules"
-          />
         </div>
         <h1>Title</h1>
         <div>
@@ -132,6 +88,24 @@
           />
         </div>
         <small class="float-right font-weight-bold">*indicates required field</small>
+        <div v-else>
+          <h1>NIH Award Number</h1>
+          <div>
+            Provide an NIH award number for this embargoed Dandiset. Note: this
+            can be changed at any time and additional award numbers can be added
+            later.
+          </div>
+          <v-text-field
+            v-model="awardNumber"
+            label="Award number"
+            :counter="120"
+            :required="embargoed"
+            outlined
+            dense
+            class="my-4"
+            :rules="awardNumberRules"
+          />
+        </div>
       </v-form>
     </v-card-text>
     <v-card-actions>

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -5,21 +5,29 @@
     </v-card-title>
     <v-card-text class="my-3">
       <v-form>
+        <h1>Dandiset Title</h1>
+        <div>
+          Provide a title for this Dandiset. The title will appear in search
+          results and at the top of the home page for this Dandiset, so make it
+          concise and descriptive.
+        </div>
         <v-text-field
           v-model="name"
-          label="Name*"
-          hint="Provide a title for this dataset"
-          persistent-hint
+          label="Title"
           :counter="nameMaxLength"
           required
           outlined
         />
+
+        <h1>Description</h1>
+        <div>
+          Provide a description for this Dandiset. This will appear prominently
+          under the title in the home page for this Dandiset.
+        </div>
         <v-textarea
           v-model="description"
-          label="Description*"
-          hint="Provide a description for this dataset"
+          label="Description"
           :counter="descriptionMaxLength"
-          persistent-hint
           required
           outlined
           class="my-4"
@@ -87,7 +95,7 @@
           <v-select
             v-model="license"
             :items="dandiLicenses"
-            label="License*"
+            label="License"
             class="my-4"
             outlined
             dense

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card v-page-title="'Create Dandiset'">
     <v-card-title>
-      <span class="text-h5">Register a new dataset</span>
+      <span class="text-h3">Register a new Dandiset</span>
     </v-card-title>
     <v-card-text class="my-3">
       <v-form>
@@ -39,7 +39,7 @@
             class="shrink mr-2 mt-0"
           >
             <template #label>
-              Embargo this dataset
+              Embargo this Dandiset
               <v-tooltip
                 right
                 max-width="25%"
@@ -59,7 +59,7 @@
                   </div>
                 </template>
                 <span>
-                  Embargoed datasets are hidden from public access until a specific time period has
+                  Embargoed Dandisets are hidden from public access until a specific time period has
                   elapsed. Uploading data to the DANDI archive under embargo requires a relevant
                   NIH award number, and the data will be automatically published when the embargo
                   period expires.
@@ -113,7 +113,7 @@
         depressed
         @click="registerDandiset"
       >
-        Register dataset
+        Register Dandiset
         <template #loader>
           <span>Registering...</span>
         </template>

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -39,7 +39,7 @@
             </template>
           </v-switch>
         </div>
-        <h1>Title</h1>
+        <div class="text-h4">Title</div>
         <div>
           Provide a title for this Dandiset. The title will appear in search
           results and at the top of the home page for this Dandiset, so make it
@@ -55,7 +55,7 @@
           class="my-4"
         />
 
-        <h1>Description</h1>
+        <div class="text-h4">Description</div>
         <div>
           Provide a description for this Dandiset. This will appear prominently
           under the title in the home page for this Dandiset.
@@ -70,7 +70,7 @@
           class="my-4"
         />
         <div v-if="!embargoed">
-          <h1>License</h1>
+          <div class="text-h4">License</div>
           <div>
             Select a license under which to share the contents of this Dandiset.
             You can learn more about <a
@@ -88,7 +88,7 @@
           />
         </div>
         <div v-else>
-          <h1>NIH Award Number</h1>
+          <div class="text-h4">NIH Award Number</div>
           <div>
             Provide an NIH award number for this embargoed Dandiset. Note: this
             can be changed at any time and additional award numbers can be added

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -6,7 +6,7 @@
     <v-card-text class="my-3">
       <v-form>
         <div>
-          <v-checkbox
+          <v-switch
             v-model="embargoed"
           >
             <template #label>
@@ -37,7 +37,7 @@
                 </span>
               </v-tooltip>
             </template>
-          </v-checkbox>
+          </v-switch>
         </div>
         <h1>Title</h1>
         <div>

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -83,6 +83,36 @@
             :rules="awardNumberRules"
           />
         </div>
+        <h1>Title</h1>
+        <div>
+          Provide a title for this Dandiset. The title will appear in search
+          results and at the top of the home page for this Dandiset, so make it
+          concise and descriptive.
+        </div>
+        <v-text-field
+          v-model="name"
+          label="Title"
+          :counter="nameMaxLength"
+          required
+          outlined
+          dense
+          class="my-4"
+        />
+
+        <h1>Description</h1>
+        <div>
+          Provide a description for this Dandiset. This will appear prominently
+          under the title in the home page for this Dandiset.
+        </div>
+        <v-textarea
+          v-model="description"
+          label="Description"
+          :counter="descriptionMaxLength"
+          required
+          outlined
+          dense
+          class="my-4"
+        />
         <div v-if="!embargoed">
           <h1>License</h1>
           <div>

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -76,6 +76,14 @@
           />
         </div>
         <div v-if="!embargoed">
+          <h1>License</h1>
+          <div>
+            Select a license under which to share the contents of this Dandiset.
+            You can learn more about <a
+              href="https://www.dandiarchive.org/handbook/35_data_licenses/"
+              target="_blank" rel="noopener">licenses
+            for Dandisets</a>.
+          </div>
           <v-select
             v-model="license"
             :items="dandiLicenses"

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -87,7 +87,6 @@
             dense
           />
         </div>
-        <small class="float-right font-weight-bold">*indicates required field</small>
         <div v-else>
           <h1>NIH Award Number</h1>
           <div>
@@ -106,6 +105,7 @@
             :rules="awardNumberRules"
           />
         </div>
+        <small class="float-right font-weight-bold">All fields are required</small>
       </v-form>
     </v-card-text>
     <v-card-actions>

--- a/web/test/src/tests/registerDandiset.test.js
+++ b/web/test/src/tests/registerDandiset.test.js
@@ -14,6 +14,11 @@ describe('dandiset registration page', () => {
 
     await registerNewUser();
 
+    // Dismiss the cookie banner, as it interferes with this test (the License
+    // menu gets hidden right behind it, so the attempted click to open it does
+    // not succeed).
+    await page.click('button.Cookie__button');
+
     await expect(page).toClickXPath(vBtn('New Dandiset'));
 
     await expect(page).toFillXPath(vTextField('Title'), name);

--- a/web/test/src/tests/registerDandiset.test.js
+++ b/web/test/src/tests/registerDandiset.test.js
@@ -16,14 +16,14 @@ describe('dandiset registration page', () => {
 
     await expect(page).toClickXPath(vBtn('New Dandiset'));
 
-    await expect(page).toFillXPath(vTextField('Name*'), name);
-    await expect(page).toFillXPath(vTextarea('Description*'), description);
-    await expect(page).toClickXPath('//label[contains(.,"License*")]/following::input[1]');
+    await expect(page).toFillXPath(vTextField('Title'), name);
+    await expect(page).toFillXPath(vTextarea('Description'), description);
+    await expect(page).toClickXPath('//label[contains(.,"License")]/following::input[1]');
     await page.waitForTimeout(500); // Give dropdown time to render
     await expect(page).toClickXPath(vListItem('spdx:CC0-1.0'));
     await page.waitForTimeout(500); // Form validation can *sometimes* take too long
 
-    await expect(page).toClickXPath(vBtn('Register dataset'));
+    await expect(page).toClickXPath(vBtn('Register Dandiset'));
     await waitForRequestsToFinish();
 
     await expect(page).toMatch('Licenses: spdx:CC0-1.0');

--- a/web/test/src/util.js
+++ b/web/test/src/util.js
@@ -95,6 +95,17 @@ export async function registerNewUser() {
  * @returns {string} identifier of the new dandiset
  */
 export async function registerDandiset(name, description) {
+  // Dismiss the cookie banner, as it interferes with this test (the License
+  // menu gets hidden right behind it, so the attempted click to open it does
+  // not succeed).
+  //
+  // This is conditional on the banner's existence because some tests run this
+  // function twice and the click will fail on the second run in those cases.
+  const cookieBanner = await page.$('button.Cookie__button');
+  if (cookieBanner) {
+    await cookieBanner.click();
+  }
+
   await expect(page).toClickXPath(vBtn('New Dandiset'));
   await expect(page).toFillXPath(vTextField('Title'), name);
   await expect(page).toFillXPath(vTextarea('Description'), description);

--- a/web/test/src/util.js
+++ b/web/test/src/util.js
@@ -96,13 +96,13 @@ export async function registerNewUser() {
  */
 export async function registerDandiset(name, description) {
   await expect(page).toClickXPath(vBtn('New Dandiset'));
-  await expect(page).toFillXPath(vTextField('Name*'), name);
-  await expect(page).toFillXPath(vTextarea('Description*'), description);
-  await expect(page).toClickXPath('//label[contains(.,"License*")]/following::input[1]');
+  await expect(page).toFillXPath(vTextField('Title'), name);
+  await expect(page).toFillXPath(vTextarea('Description'), description);
+  await expect(page).toClickXPath('//label[contains(.,"License")]/following::input[1]');
   await page.waitForTimeout(500); // Give dropdown time to render
   await expect(page).toClickXPath(vListItem('spdx:CC0-1.0'));
   await page.waitForTimeout(500); // Form validation can *sometimes* take too long
-  await expect(page).toClickXPath(vBtn('Register dataset'));
+  await expect(page).toClickXPath(vBtn('Register Dandiset'));
   await waitForRequestsToFinish();
   return page.url().split('/').pop();
 }


### PR DESCRIPTION
- closes #758
- depends on https://github.com/dandi/handbook/pull/82 being merged and deployed

Some background: my intent here was to add a link to a new handbook page including information about licenses (see the first commit in this PR, https://github.com/dandi/dandi-archive/commit/4a42b189a3caeeb446f2ff7511df721ecc099751). But due to the way I had to add that information (without using a `hint` prop since the v-select component lacks it), this created a style dissonance. Then I looked closer and discovered several other inconsistencies in the page, which I addressed over the course of the remaining commits.

So I'd be ok with reformulating some of the changes into follow-on PRs, but I also think the improvements are of enough value that we could just accept them in this PR. As for reviews, I would request that @bendichter focus on the new content (i.e. the link to the handbook page and the text surrounding it) while @mvandenburgh focus on the overall changes I've made (as well as Vuetify style, etc.).