### PR TITLE
Embed glob-derived regex inside a ^/$ pair

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -1457,6 +1457,9 @@ def test_asset_direct_info(api_client, asset):
         ('a/b/d/*', ['a/b/d/e.txt']),
         ('*b*e.txt', ['a/b/c/e.txt', 'a/b/d/e.txt']),
         ('.*[a|b].txt', []),  # regexes shouldn't be evaluated
+        ('a/b/c', []),
+        ('a/b/c*', ['a/b/c.txt', 'a/b/c/d.txt', 'a/b/c/e.txt']),
+        ('a/b/c.txt', ['a/b/c.txt']),
     ],
 )
 def test_asset_rest_glob(api_client, asset_factory, version, glob_pattern, expected_paths):

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -405,7 +405,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
             # since we are using postgres' regex search. A malicious user who knows this could
             # include a regex as part of the glob expression, which postgres would happily parse
             # and use if it's not escaped.
-            glob_pattern = re.escape(glob_pattern)
+            glob_pattern = f'^{re.escape(glob_pattern)}$'
             queryset = queryset.filter(path__iregex=glob_pattern.replace('\\*', '.*'))
 
         # Paginate and return


### PR DESCRIPTION
Closes #1563

This makes the `glob` parameter of the asset search endpoint more useful. Now, when supplying a string to the parameter, the search will be for exact matches to the string. The original behavior can be recovered by prepending and appending `*`s to cause the search to allow for an arbitrary prefix/suffix to the supplied string.

This is a breaking change, but my suspicion is that no one is using the `glob` parameter at present; furthermore, this fix adds a new capability to the system of finding assets by exact path, something that was requested in #444.

We should discuss whether a warning to the userbase is necessary because of this change.