### PR TITLE
Render description field as markdown

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -19,9 +19,11 @@
     "ajv": "^8.3.0",
     "axios": "^0.21.2",
     "core-js": "^3.12.1",
+    "dompurify": "^3.0.1",
     "filesize": "^6.3.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
+    "marked": "^4.3.0",
     "moment": "^2.29.1",
     "pinia": "^2.0.22",
     "vue": "^2.7.14",
@@ -32,9 +34,11 @@
     "vuetify": "~2.3.6"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.1",
     "@types/js-yaml": "^4.0.1",
     "@types/json-schema": "^7.0.7",
     "@types/lodash": "^4.14.168",
+    "@types/marked": "^4.0.8",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
     "@vue/cli-plugin-babel": "^4.5.19",

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -171,8 +171,8 @@
 
       <v-row class="mx-1 my-4 px-4 font-weight-light">
         <!-- Truncate text if necessary -->
-        <span v-if="meta.description && (meta.description.length > MAX_DESCRIPTION_LENGTH)">
-          {{ description }}
+        <div v-if="meta.description && (meta.description.length > MAX_DESCRIPTION_LENGTH)">
+          <div v-html=htmlDescription></div>
           <a
             v-if="showFullDescription"
             @click="showFullDescription = false"
@@ -180,8 +180,9 @@
           <a
             v-else
             @click="showFullDescription = true"
-          > [ + see more ]</a></span>
-        <span v-else>{{ description }}</span>
+          > [ + see more ]</a>
+        </div>
+        <div v-else v-html=htmlDescription></div>
       </v-row>
 
       <v-row class="justify-center">
@@ -267,7 +268,9 @@ import {
 } from 'vue';
 
 import filesize from 'filesize';
+import { marked } from 'marked';
 import moment from 'moment';
+import { sanitize } from 'dompurify';
 
 import { useDandisetStore } from '@/stores/dandiset';
 import type { AccessInformation, DandisetStats, SubjectMatterOfTheDataset } from '@/types';
@@ -368,6 +371,7 @@ export default defineComponent({
       shortenedDescription = `${shortenedDescription.substring(0, shortenedDescription.lastIndexOf(' '))}...`;
       return shortenedDescription;
     });
+    const htmlDescription: ComputedRef<string> = computed(() => sanitize(marked.parse(description.value)));
     const meta = computed(() => currentDandiset.value?.metadata);
 
     const accessInformation: ComputedRef<AccessInformation|undefined> = computed(
@@ -396,6 +400,7 @@ export default defineComponent({
       stats,
       transformFilesize,
       description,
+      htmlDescription,
       showFullDescription,
       MAX_DESCRIPTION_LENGTH,
 

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -170,7 +170,7 @@
       <v-divider />
 
       <v-row class="mx-1 my-4 px-4 font-weight-light">
-        <div v-html=htmlDescription></div>
+        <div v-html="htmlDescription" />
 
         <!-- Truncate text if necessary -->
         <a
@@ -365,7 +365,9 @@ export default defineComponent({
       shortenedDescription = `${shortenedDescription.substring(0, shortenedDescription.lastIndexOf(' '))}...`;
       return shortenedDescription;
     });
-    const htmlDescription: ComputedRef<string> = computed(() => sanitize(marked.parse(description.value)));
+    const htmlDescription: ComputedRef<string> = computed(
+      () => sanitize(marked.parse(description.value)),
+    );
     const meta = computed(() => currentDandiset.value?.metadata);
 
     const accessInformation: ComputedRef<AccessInformation|undefined> = computed(

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -170,19 +170,13 @@
       <v-divider />
 
       <v-row class="mx-1 my-4 px-4 font-weight-light">
+        <div v-html=htmlDescription></div>
+
         <!-- Truncate text if necessary -->
-        <div v-if="meta.description && (meta.description.length > MAX_DESCRIPTION_LENGTH)">
-          <div v-html=htmlDescription></div>
-          <a
-            v-if="showFullDescription"
-            @click="showFullDescription = false"
-          > [ - see less ]</a>
-          <a
-            v-else
-            @click="showFullDescription = true"
-          > [ + see more ]</a>
-        </div>
-        <div v-else v-html=htmlDescription></div>
+        <a
+          v-if="meta.description && (meta.description.length > MAX_DESCRIPTION_LENGTH)"
+          @click="showFullDescription = !showFullDescription"
+        > {{ showFullDescription ? "[ - see less ]" : "[ + see more ]" }}</a>
       </v-row>
 
       <v-row class="justify-center">

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1323,6 +1323,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/dompurify@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.0.1.tgz#7c49ef3dca25b04fc75bafb783b256f93e6936a4"
+  integrity sha512-ubq8VKmf8W+U48jUOiZO4BoSGS7NnbITPMvrF+7HgMN4L+eezCKv8QBPB8p3o4YPicLMmNeTyDkE5X4c2ViHJQ==
+  dependencies:
+    "@types/jsdom" "*"
+    "@types/trusted-types" "*"
+
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
   version "4.17.30"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz#0f2f99617fa8f9696170c46152ccf7500b34ac04"
@@ -1369,6 +1377,15 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
+"@types/jsdom@*":
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-21.1.1.tgz#e59e26352071267b507bf04d51841a1d7d3e8617"
+  integrity sha512-cZFuoVLtzKP3gmq9eNosUL1R50U+USkbLtUQ1bYVgl/lKp0FZM7Cq4aIHAL8oIvQ17uSHi7jXPtfDOdjPwBE7A==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^7.0.0"
+
 "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -1383,6 +1400,11 @@
   version "4.14.184"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.184.tgz#23f96cd2a21a28e106dc24d825d4aa966de7a9fe"
   integrity sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==
+
+"@types/marked@^4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.8.tgz#b316887ab3499d0a8f4c70b7bd8508f92d477955"
+  integrity sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==
 
 "@types/mime@*":
   version "3.0.1"
@@ -1456,6 +1478,16 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
+
+"@types/tough-cookie@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
+  integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+
+"@types/trusted-types@*":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
+  integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
 "@types/uglify-js@*":
   version "3.17.0"
@@ -4049,6 +4081,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.1.tgz#a0933f38931b3238934dd632043b727e53004289"
+  integrity sha512-60tsgvPKwItxZZdfLmamp0MTcecCta3avOhsLgPZ0qcWt96OasFfhkeIRbJ6br5i0fQawT1/RBGB5L58/Jpwuw==
+
 domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -4200,6 +4237,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 entities@~2.1.0:
   version "2.1.0"
@@ -6656,6 +6698,11 @@ markdown-it@^12.3.2:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+
 match-all@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/match-all/-/match-all-1.2.6.tgz#66d276ad6b49655551e63d3a6ee53e8be0566f8d"
@@ -7464,6 +7511,13 @@ parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
+parse5@^7.0.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
+  integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
+  dependencies:
+    entities "^4.4.0"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"


### PR DESCRIPTION
This PR introduces the use of [marked](https://github.com/markedjs/marked) and [DOMPurify](https://github.com/cure53/DOMPurify) to treat the description metadata field as a Markdown document.

The background here is that we'd like a way to give a bit more control to end users over the formatting of their Dandiset descriptions so they can put, e.g., "release notes" here to let consumers of their data know why they published a new version. The fuller solution for this is tracked in #189, but this feature allows a minor form of that ability in addition to its value in itself.

Closes #1567.