### PR TITLE
Improve validation error display

### DIFF
--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -414,7 +414,7 @@ def test_version_rest_info(api_client, version):
         'metadata': version.metadata,
         'size': version.size,
         'status': 'Pending',
-        'asset_validation_errors': {},
+        'asset_validation_errors': [],
         'version_validation_errors': [],
         'contact_person': version.metadata['contributor'][0]['name'],
     }
@@ -434,14 +434,16 @@ def test_version_rest_info_with_asset(
     add_version_asset_paths(version=version)
 
     # Create expected validation errors for pending/validating assets
-    asset_validating_error = {
-        'field': '',
-        'message': 'asset is currently being validated, please wait.',
-    }
-    expected_validation_error = (
-        {asset.path: [asset_validating_error]}
+    expected_validation_errors = (
+        [
+            {
+                'field': '',
+                'message': 'asset is currently being validated, please wait.',
+                'path': asset.path,
+            }
+        ]
         if asset_status in [Asset.Status.PENDING, Asset.Status.VALIDATING]
-        else {}
+        else []
     )
 
     assert api_client.get(
@@ -462,7 +464,7 @@ def test_version_rest_info_with_asset(
         'metadata': version.metadata,
         'size': version.size,
         'status': Asset.Status.VALID,
-        'asset_validation_errors': expected_validation_error,
+        'asset_validation_errors': expected_validation_errors,
         'version_validation_errors': [],
         'contact_person': version.metadata['contributor'][0]['name'],
     }
@@ -537,7 +539,7 @@ def test_version_rest_update(api_client, user, draft_version):
         'metadata': saved_metadata,
         'size': draft_version.size,
         'status': 'Pending',
-        'asset_validation_errors': {},
+        'asset_validation_errors': [],
         'version_validation_errors': [],
         'contact_person': 'Vargas, Getúlio',
     }

--- a/web/src/components/DLP/ValidationErrorDialog.vue
+++ b/web/src/components/DLP/ValidationErrorDialog.vue
@@ -72,7 +72,7 @@
           class="overflow-y-auto"
         >
           <v-expansion-panels multiple>
-            <template v-for="(errors, path) in assetValidationErrors">
+            <template v-for="(errors, path) in groupedAssetValidationErrors">
               <v-list-item
                 :key="path"
               >
@@ -144,7 +144,7 @@ import { VALIDATION_ICONS } from '@/utils/constants';
 
 const props = defineProps({
   assetValidationErrors: {
-    type: Object as PropType<Record<string, ValidationError[]>>,
+    type: Array as PropType<ValidationError[]>,
     required: true,
   },
   versionValidationErrors: {
@@ -170,6 +170,17 @@ watch(() => props.selectedTab, (val) => {
 
 const showMetadataTab = computed(() => !!props.versionValidationErrors.length);
 const showAssetsTab = computed(() => !!Object.keys(props.assetValidationErrors));
+const groupedAssetValidationErrors = computed(() => {
+  const path_asset_map: Record<string, ValidationError[]> = {};
+  props.assetValidationErrors.forEach((err) => {
+    if (!(err.path in path_asset_map)) {
+      path_asset_map[err.path] = [];
+    }
+    path_asset_map[err.path].push(err);
+  });
+
+  return path_asset_map;
+});
 
 function getValidationErrorIcon(errorField: string): string {
   const icons = Object.keys(VALIDATION_ICONS).filter((field) => errorField.includes(field));

--- a/web/src/components/DLP/ValidationErrorDialog.vue
+++ b/web/src/components/DLP/ValidationErrorDialog.vue
@@ -72,32 +72,62 @@
           class="overflow-y-auto"
         >
           <v-expansion-panels multiple>
-            <v-expansion-panel
-              v-for="(errors, path) in assetValidationErrors"
-              :key="path"
-            >
-              <v-expansion-panel-header>
-                {{ path }}
-              </v-expansion-panel-header>
-              <v-expansion-panel-content>
-                <v-list-item
-                  v-for="error in errors"
-                  :key="`${error.field}-${error.message}`"
-                >
-                  <v-list-item-icon>
-                    <v-icon>
-                      {{ getValidationErrorIcon(error.field) }}
-                    </v-icon>
-                  </v-list-item-icon>
-                  <v-list-item-content>
-                    <template v-if="error.field">
-                      {{ error.field }}:
+            <template v-for="(errors, path) in assetValidationErrors">
+              <v-list-item
+                :key="path"
+              >
+                <v-list-item-icon>
+                  <v-icon>
+                    <template v-if="errors.length > 1">
+                      mdi-alert-plus
                     </template>
-                    {{ error.message }}
+                    <template v-else>
+                      {{ getValidationErrorIcon(errors[0].field) }}
+                    </template>
+                  </v-icon>
+                </v-list-item-icon>
+
+                <!-- Inline single errors -->
+                <template v-if="errors.length === 1">
+                  <v-list-item-content>
+                    <strong>{{ path }}</strong>
+                    <template v-if="errors[0].field">
+                      {{ errors[0].field }} -
+                    </template>
+                    {{ errors[0].message }}
                   </v-list-item-content>
-                </v-list-item>
-              </v-expansion-panel-content>
-            </v-expansion-panel>
+                </template>
+
+                <!-- Group multiple asset errors -->
+                <template v-else>
+                  <v-list-group class="multi-error-list-group">
+                    <template #activator>
+                      <v-list-item-content>
+                        <strong>{{ path }}</strong>
+                        <v-list-item-subtitle>Click to expand</v-list-item-subtitle>
+                      </v-list-item-content>
+                    </template>
+
+                    <v-list-item
+                      v-for="error in errors"
+                      :key="`${error.field}-${error.message}`"
+                    >
+                      <v-list-item-icon>
+                        <v-icon>
+                          {{ getValidationErrorIcon(error.field) }}
+                        </v-icon>
+                      </v-list-item-icon>
+                      <v-list-item-content>
+                        <template v-if="error.field">
+                          {{ error.field }}:
+                        </template>
+                        {{ error.message }}
+                      </v-list-item-content>
+                    </v-list-item>
+                  </v-list-group>
+                </template>
+              </v-list-item>
+            </template>
           </v-expansion-panels>
         </v-list>
       </v-tab-item>
@@ -150,3 +180,9 @@ function getValidationErrorIcon(errorField: string): string {
 }
 
 </script>
+<style>
+.multi-error-list-group .v-list-group__header {
+  padding-left: 0;
+  padding-right: 0;
+}
+</style>

--- a/web/src/components/DLP/ValidationErrorDialog.vue
+++ b/web/src/components/DLP/ValidationErrorDialog.vue
@@ -169,7 +169,7 @@ watch(() => props.selectedTab, (val) => {
 });
 
 const showMetadataTab = computed(() => !!props.versionValidationErrors.length);
-const showAssetsTab = computed(() => !!Object.keys(props.assetValidationErrors));
+const showAssetsTab = computed(() => !!Object.keys(props.assetValidationErrors).length);
 const groupedAssetValidationErrors = computed(() => {
   const path_asset_map: Record<string, ValidationError[]> = {};
   props.assetValidationErrors.forEach((err) => {

--- a/web/src/components/DLP/ValidationErrorDialog.vue
+++ b/web/src/components/DLP/ValidationErrorDialog.vue
@@ -1,0 +1,152 @@
+<template>
+  <v-card
+    min-height="90vh"
+    class="pa-2"
+  >
+    <v-tabs v-model="tab">
+      <v-tab
+        v-if="showMetadataTab"
+        key="metadata"
+        href="#metadata"
+      >
+        Metadata
+      </v-tab>
+      <v-tab
+        v-if="showAssetsTab"
+        key="assets"
+        href="#assets"
+      >
+        Assets
+      </v-tab>
+    </v-tabs>
+    <v-tabs-items v-model="tab">
+      <!-- Metadata -->
+      <v-tab-item
+        v-if="showMetadataTab"
+        key="metadata"
+        value="metadata"
+        :transition="false"
+      >
+        <v-btn
+          v-if="owner"
+          class="mt-1"
+          color="primary"
+          @click="$emit('openMeditor')"
+        >
+          Fix issues
+        </v-btn>
+        <v-list
+          class="overflow-y-auto"
+        >
+          <div
+            v-for="(error, index) in versionValidationErrors"
+            :key="index"
+          >
+            <v-list-item>
+              <v-list-item-icon>
+                <v-icon>
+                  {{ getValidationErrorIcon(error.field) }}
+                </v-icon>
+              </v-list-item-icon>
+
+              <v-list-item-content>
+                <template v-if="error.field">
+                  {{ error.field }}:
+                </template>
+                {{ error.message }}
+              </v-list-item-content>
+            </v-list-item>
+            <v-divider />
+          </div>
+        </v-list>
+      </v-tab-item>
+
+      <!-- Assets -->
+      <v-tab-item
+        v-if="showAssetsTab"
+        key="assets"
+        value="assets"
+        :transition="false"
+      >
+        <v-list
+          class="overflow-y-auto"
+        >
+          <v-expansion-panels multiple>
+            <v-expansion-panel
+              v-for="(errors, path) in assetValidationErrors"
+              :key="path"
+            >
+              <v-expansion-panel-header>
+                {{ path }}
+              </v-expansion-panel-header>
+              <v-expansion-panel-content>
+                <v-list-item
+                  v-for="error in errors"
+                  :key="`${error.field}-${error.message}`"
+                >
+                  <v-list-item-icon>
+                    <v-icon>
+                      {{ getValidationErrorIcon(error.field) }}
+                    </v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-content>
+                    <template v-if="error.field">
+                      {{ error.field }}:
+                    </template>
+                    {{ error.message }}
+                  </v-list-item-content>
+                </v-list-item>
+              </v-expansion-panel-content>
+            </v-expansion-panel>
+          </v-expansion-panels>
+        </v-list>
+      </v-tab-item>
+    </v-tabs-items>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import type { ValidationError } from '@/types';
+import type { PropType } from 'vue';
+import { watch, computed, ref } from 'vue';
+
+import { VALIDATION_ICONS } from '@/utils/constants';
+
+const props = defineProps({
+  assetValidationErrors: {
+    type: Object as PropType<Record<string, ValidationError[]>>,
+    required: true,
+  },
+  versionValidationErrors: {
+    type: Array as PropType<ValidationError[]>,
+    required: true,
+  },
+  selectedTab: {
+    type: String as PropType<'metadata' | 'assets'>,
+    required: false,
+    default: 'metadata',
+  },
+  owner: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+});
+
+const tab = ref(props.selectedTab);
+watch(() => props.selectedTab, (val) => {
+  tab.value = val;
+});
+
+const showMetadataTab = computed(() => !!props.versionValidationErrors.length);
+const showAssetsTab = computed(() => !!Object.keys(props.assetValidationErrors));
+
+function getValidationErrorIcon(errorField: string): string {
+  const icons = Object.keys(VALIDATION_ICONS).filter((field) => errorField.includes(field));
+  if (icons.length > 0) {
+    return (VALIDATION_ICONS as any)[icons[0]];
+  }
+  return VALIDATION_ICONS.DEFAULT;
+}
+
+</script>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -30,6 +30,7 @@ export interface DandisetSearchResult extends Dandiset {
 export interface ValidationError {
   field: string,
   message: string,
+  path: string,
 }
 
 export interface Version {
@@ -43,7 +44,7 @@ export interface Version {
   modified: string,
   dandiset: Dandiset,
   metadata?: DandisetMetadata,
-  asset_validation_errors: Record<string, ValidationError[]>,
+  asset_validation_errors: ValidationError[],
   version_validation_errors: ValidationError[],
   contact_person?: string,
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -43,7 +43,7 @@ export interface Version {
   modified: string,
   dandiset: Dandiset,
   metadata?: DandisetMetadata,
-  asset_validation_errors: ValidationError[],
+  asset_validation_errors: Record<string, ValidationError[]>,
   version_validation_errors: ValidationError[],
   contact_person?: string,
 }

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -359,7 +359,7 @@ import { useDandisetStore } from '@/stores/dandiset';
 import router from '@/router';
 import type { User, Version } from '@/types';
 
-import { draftVersion, VALIDATION_ICONS } from '@/utils/constants';
+import { draftVersion } from '@/utils/constants';
 import { open as meditorOpen } from '@/components/Meditor/state';
 
 import ValidationErrorDialog from '@/components/DLP/ValidationErrorDialog.vue';
@@ -372,14 +372,6 @@ const PUBLISH_CHECKLIST = [
   'Funding information (DANDI treats funding agencies as contributors, so you can add multiple contributing institutions as needed. If you are the funder, you can add a new contributor of type "organization", uncheck "include contributor in citation", set the role as "dcite:Funder", and include the relevant award information)',
   'References to code in GitHub, related publications, etc.',
 ];
-
-function getValidationErrorIcon(errorField: string): string {
-  const icons = Object.keys(VALIDATION_ICONS).filter((field) => errorField.includes(field));
-  if (icons.length > 0) {
-    return (VALIDATION_ICONS as any)[icons[0]];
-  }
-  return VALIDATION_ICONS.DEFAULT;
-}
 
 // Sort versions from most recently modified to least recently modified.
 // The DRAFT version is always the first element when present.

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -510,9 +510,7 @@ const numAssetValidationErrors = computed(() => {
     return 0;
   }
 
-  return Object.values(
-    currentDandiset.value.asset_validation_errors,
-  ).reduce((sum, errs) => sum + errs.length, 0);
+  return currentDandiset.value.asset_validation_errors.length;
 });
 const publishButtonDisabled = computed(() => !!(
   currentDandiset.value?.version_validation_errors.length

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -200,167 +200,78 @@
       </v-menu>
     </v-row>
 
-    <v-row
-      v-else-if="currentDandiset.version_validation_errors.length "
-      class="my-2 px-1"
-      no-gutters
+    <!-- Dialog where version and asset errors are shown -->
+    <v-dialog v-model="errorDialogOpen">
+      <ValidationErrorDialog
+        :selected-tab="selectedTab"
+        :asset-validation-errors="currentDandiset.asset_validation_errors"
+        :version-validation-errors="currentDandiset.version_validation_errors"
+        :owner="isOwner"
+        @openMeditor="openMeditor"
+      />
+    </v-dialog>
+
+    <!-- Version Validation Errors Button -->
+    <v-card
+      v-if="currentDandiset.version_validation_errors.length"
+      class="my-2 px-1 amber lighten-5 no-text-transform"
+      outlined
+      @click="openErrorDialog('metadata')"
     >
-      <v-menu
-        :nudge-width="200"
-        offset-y
-        open-on-hover
-      >
-        <template #activator="{ on: menu, attrs }">
-          <v-tooltip bottom>
-            <template #activator="{ on: tooltip }">
-              <v-card
-                class="amber lighten-5 no-text-transform"
-                outlined
-                v-bind="attrs"
-                v-on="{ ...tooltip, ...menu }"
-              >
-                <v-row class="align-center px-4">
-                  <v-col
-                    cols="1"
-                    class="justify-center py-0"
-                  >
-                    <v-icon
-                      color="warning"
-                      class="mr-1"
-                    >
-                      mdi-playlist-remove
-                    </v-icon>
-                  </v-col>
-                  <v-spacer />
-                  <v-col cols="9">
-                    <div
-                      v-if="currentDandiset"
-                      class="text-caption"
-                    >
-                      This Dandiset has {{ currentDandiset.version_validation_errors.length }}
-                      metadata validation error(s).
-                    </div>
-                  </v-col>
-                </v-row>
-              </v-card>
-            </template>
-            <span>Fix issues with metadata</span>
-          </v-tooltip>
-        </template>
-        <v-card class="pa-1">
-          <v-list
-            style="max-height: 200px"
-            class="overflow-y-auto"
+      <v-row class="align-center px-4">
+        <v-col
+          cols="1"
+          class="justify-center py-0"
+        >
+          <v-icon
+            color="warning"
+            class="mr-1"
           >
-            <div
-              v-for="(error, index) in currentDandiset.version_validation_errors"
-              :key="index"
-            >
-              <v-list-item>
-                <v-list-item-icon>
-                  <v-icon>
-                    {{ getValidationErrorIcon(error.field) }}
-                  </v-icon>
-                </v-list-item-icon>
-
-                <v-list-item-content>
-                  <template v-if="error.field">
-                    {{ error.field }}:
-                  </template>
-                  {{ error.message }}
-                </v-list-item-content>
-              </v-list-item>
-              <v-divider />
-            </div>
-          </v-list>
-          <v-btn
-            v-if="isOwner"
-            color="primary"
-            @click="openMeditor = true"
+            mdi-playlist-remove
+          </v-icon>
+        </v-col>
+        <v-spacer />
+        <v-col cols="9">
+          <div
+            v-if="currentDandiset"
+            class="text-caption"
           >
-            Fix issues
-          </v-btn>
-        </v-card>
-      </v-menu>
-    </v-row>
+            This Dandiset has {{ currentDandiset.version_validation_errors.length }}
+            metadata validation error(s).
+          </div>
+        </v-col>
+      </v-row>
+    </v-card>
 
-    <v-row
-      v-if="currentDandiset.asset_validation_errors.length"
-      class="my-2 px-1"
-      no-gutters
+    <!-- Asset Validation Errors Button -->
+    <v-card
+      v-if="numAssetValidationErrors"
+      class="my-2 px-1 amber lighten-5 no-text-transform"
+      outlined
+      @click="openErrorDialog('assets')"
     >
-      <v-menu
-
-        :nudge-width="200"
-        offset-y
-        open-on-hover
-      >
-        <template #activator="{ on: menu, attrs }">
-          <v-tooltip bottom>
-            <template #activator="{ on: tooltip }">
-              <v-card
-                class="amber lighten-5 no-text-transform"
-                outlined
-                v-bind="attrs"
-                v-on="{ ...tooltip, ...menu }"
-              >
-                <v-row class="align-center px-4">
-                  <v-col
-                    cols="1"
-                    class="justify-center py-0"
-                  >
-                    <v-icon
-                      color="warning"
-                      class="mr-1"
-                    >
-                      mdi-database-remove
-                    </v-icon>
-                  </v-col>
-                  <v-spacer />
-                  <v-col cols="9">
-                    <div
-                      v-if="currentDandiset"
-                      class="text-caption"
-                    >
-                      This Dandiset has {{ currentDandiset.asset_validation_errors.length }}
-                      asset validation error(s).
-                    </div>
-                  </v-col>
-                </v-row>
-              </v-card>
-            </template>
-            <span>Fix issues with assets</span>
-          </v-tooltip>
-        </template>
-        <v-card class="pa-1">
-          <v-list
-            style="max-height: 200px"
-            class="overflow-y-auto"
+      <v-row class="align-center px-4">
+        <v-col
+          cols="1"
+          class="justify-center py-0"
+        >
+          <v-icon
+            color="warning"
+            class="mr-1"
           >
-            <div
-              v-for="(error, index) in currentDandiset.asset_validation_errors"
-              :key="index"
-            >
-              <v-list-item>
-                <v-list-item-icon>
-                  <v-icon>
-                    {{ getValidationErrorIcon(error.field) }}
-                  </v-icon>
-                </v-list-item-icon>
+            mdi-database-remove
+          </v-icon>
+        </v-col>
+        <v-spacer />
+        <v-col cols="9">
+          <div class="text-caption">
+            This Dandiset has {{ numAssetValidationErrors }}
+            asset validation error(s).
+          </div>
+        </v-col>
+      </v-row>
+    </v-card>
 
-                <v-list-item-content>
-                  <template v-if="error.field">
-                    {{ error.field }}:
-                  </template>
-                  {{ error.message }}
-                </v-list-item-content>
-              </v-list-item>
-              <v-divider />
-            </div>
-          </v-list>
-        </v-card>
-      </v-menu>
-    </v-row>
     <v-row>
       <v-subheader class="mb-2 black--text text-h5">
         This Version
@@ -449,7 +360,9 @@ import router from '@/router';
 import type { User, Version } from '@/types';
 
 import { draftVersion, VALIDATION_ICONS } from '@/utils/constants';
-import { open as openMeditor } from '@/components/Meditor/state';
+import { open as meditorOpen } from '@/components/Meditor/state';
+
+import ValidationErrorDialog from '@/components/DLP/ValidationErrorDialog.vue';
 
 const PUBLISH_CHECKLIST = [
   'A descriptive title (e.g., <span class="font-italic">Data related to foraging behavior in bees</span> rather than <span class="font-italic">Smith et al 2022</span>)',
@@ -586,9 +499,32 @@ onUnmounted(() => {
   window.clearInterval(timer);
 });
 
+// Error dialog
+const errorDialogOpen = ref(false);
+type ErrorCategory = 'metadata' | 'assets';
+const selectedTab = ref<ErrorCategory>('metadata');
+function openErrorDialog(tab: ErrorCategory) {
+  errorDialogOpen.value = true;
+  selectedTab.value = tab;
+}
+
+function openMeditor() {
+  errorDialogOpen.value = false;
+  meditorOpen.value = true;
+}
+
+const numAssetValidationErrors = computed(() => {
+  if (currentDandiset.value === null) {
+    return 0;
+  }
+
+  return Object.values(
+    currentDandiset.value.asset_validation_errors,
+  ).reduce((sum, errs) => sum + errs.length, 0);
+});
 const publishButtonDisabled = computed(() => !!(
   currentDandiset.value?.version_validation_errors.length
-      || currentDandiset.value?.asset_validation_errors.length
+      || numAssetValidationErrors.value
       || currentDandiset.value?.dandiset.embargo_status !== 'OPEN'
       || publishDisabledMessage.value
 ));


### PR DESCRIPTION
This displays validation errors in a modal, instead of a small menu next to the sidebar. The version metadata validation errors remain largely unchanged. The asset validation errors have been improved to both display the path of the asset, as well as group the errors of an asset, if an asset contains multiple errors.

This is how it looks now:

![image](https://user-images.githubusercontent.com/11370025/235507123-24f47fd0-957d-44a1-b0ca-b4d8743b66a3.png)
