### PR TITLE
Call `clearInterval` after `setInterval` when needed

### DIFF
--- a/web/src/components/DLP/OverviewTab.vue
+++ b/web/src/components/DLP/OverviewTab.vue
@@ -224,7 +224,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, getCurrentInstance, onMounted } from 'vue';
+import {
+  computed, getCurrentInstance, onMounted, ref, onUnmounted,
+} from 'vue';
+
 import MetadataCard from '@/components/DLP/MetadataCard.vue';
 import { useDandisetStore } from '@/stores/dandiset';
 
@@ -318,8 +321,9 @@ const contactPeople = computed(
     .map((contributor) => contributor.name)),
 );
 
+const timer = ref<number| null>(null);
 onMounted(() => {
-  setInterval(async () => {
+  timer.value = window.setInterval(async () => {
     if (!currentDandiset.value || !assetSummaryBeingComputed.value) {
       return;
     }
@@ -327,6 +331,12 @@ onMounted(() => {
     const { version } = currentDandiset.value;
     await store.fetchDandiset({ identifier, version });
   }, 5000);
+});
+onUnmounted(() => {
+  if (timer.value === null) {
+    throw Error('Invalid timer value');
+  }
+  window.clearInterval(timer.value);
 });
 
 </script>

--- a/web/src/components/DLP/OverviewTab.vue
+++ b/web/src/components/DLP/OverviewTab.vue
@@ -225,7 +225,7 @@
 
 <script setup lang="ts">
 import {
-  computed, getCurrentInstance, onMounted, ref, onUnmounted,
+  computed, getCurrentInstance, onMounted, onUnmounted,
 } from 'vue';
 
 import MetadataCard from '@/components/DLP/MetadataCard.vue';
@@ -321,9 +321,9 @@ const contactPeople = computed(
     .map((contributor) => contributor.name)),
 );
 
-const timer = ref<number| null>(null);
+let timer: number | undefined;
 onMounted(() => {
-  timer.value = window.setInterval(async () => {
+  timer = window.setInterval(async () => {
     if (!currentDandiset.value || !assetSummaryBeingComputed.value) {
       return;
     }
@@ -333,10 +333,10 @@ onMounted(() => {
   }, 5000);
 });
 onUnmounted(() => {
-  if (timer.value === null) {
+  if (timer === undefined) {
     throw Error('Invalid timer value');
   }
-  window.clearInterval(timer.value);
+  window.clearInterval(timer);
 });
 
 </script>

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -567,9 +567,9 @@ const publishDisabledMessage: ComputedRef<string> = computed(() => {
   return '';
 });
 
-const timer = ref<number | null>(null);
+let timer: number | undefined;
 onMounted(() => {
-  timer.value = window.setInterval(async () => {
+  timer = window.setInterval(async () => {
   // When a dandiset is being published, poll the server to check if it's finished
     if (publishing.value && currentDandiset.value) {
       const { identifier } = currentDandiset.value.dandiset!;
@@ -589,10 +589,10 @@ onMounted(() => {
   }, 2000);
 });
 onUnmounted(() => {
-  if (timer.value === null) {
+  if (timer === undefined) {
     throw Error('Invalid timer value');
   }
-  window.clearInterval(timer.value);
+  window.clearInterval(timer);
 });
 
 const publishButtonDisabled = computed(() => !!(


### PR DESCRIPTION
This fixes a bug where the `setInterval` would continue firing after the user navigates from one dandiset to a new dandiset. This would result in unexpected behavior, such as the overwriting of the new dandiset with the metadata from the old one retrieved by the `setInterval` call.

One note about the changes - I changed the use of `setInterval` to `window.setInterval`. I couldn't get TypeScript to play nicely with the return value of `setInterval` for some reason; it was trying to get me to import a type from NodeJS, but since we're in a browser environment it was erroring out. They are functionally identical though.