### PR TITLE
Add celery argument logging

### DIFF
--- a/dandiapi/celery.py
+++ b/dandiapi/celery.py
@@ -1,7 +1,12 @@
 import os
 
 from celery import Celery, signals
+import celery.app.trace
 import configurations.importer
+
+celery.app.trace.LOG_RECEIVED = """\
+Task %(name)s[%(id)s] received: (%(args)s, %(kwargs)s)\
+"""
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'dandiapi.settings'
 if not os.environ.get('DJANGO_CONFIGURATION'):


### PR DESCRIPTION
This should log the args and kwargs for each task received by a celery worker. https://docs.celeryq.dev/en/stable/userguide/extending.html#customizing-task-handling-logs