### PR TITLE
Make deploy workflow names more consistent

### DIFF
--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -1,4 +1,4 @@
-name: Update release branch
+name: Deploy backend to production
 
 on:
   release:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   reset-release-branch:
+    name: Update release branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,6 +21,7 @@ jobs:
           git push --force origin release
 
   production-deploy:
+    name: Deploy to Heroku
     runs-on: ubuntu-latest
     needs: reset-release-branch
     steps:

--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -1,4 +1,4 @@
-name: Trigger staging deploy of backend server on push to master
+name: Deploy backend to staging
 
 on:
   push:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   deploy:
+    name: Deploy to Heroku
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I was having trouble finding where our production deployment was happening, because the name of the github action ("Update release branch") didn't make that clear. This PR updates that, plus the individual steps of our staging/production deploy workflows to make it easier to identify them in the github UI.