### PR TITLE
Pin `django-minio-storage`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,12 @@ setup(
         'django-storages[boto3]',
         'gunicorn',
         # Development-only, but required
-        'django-minio-storage',
+        # TODO: starting with v0.5.0, django-minio-storage requires v7
+        # of the minio-py library. minio-py 7 introduces several
+        # breaking changes to the API, and django-s3-file-field is also
+        # incompatible with it since it has minio<7 as a dependency.
+        # Until these issues are resolved, we pin it to an older version.
+        'django-minio-storage<0.5.0',
         'tqdm',
     ],
     extras_require={


### PR DESCRIPTION
Deploys are currently failing https://github.com/dandi/dandi-archive/actions/runs/5047436699, due to a breaking change in the `minio` python library ([this commit](https://github.com/minio/minio-py/commit/b81883a98e6f8a09e2903609caabbf0956dd0ec9), for reference)

I explained the issue behind this in the code comment, but to summarize:

- `django_s3_file_field[minio]` does not pin `django-minio-storage`, but does pin `minio` to <7. https://github.com/girder/django-s3-file-field/blob/master/setup.py#L72
- dandi does not pin either of these dependencies, but we do list `django-minio-storage` (unpinned) in our production dependencies.
- Because `django_s3_file_field[minio]` is a dev dependency, it's not installed in the Heroku environment, thus the pip resolver does not take into account the `minio<7` requirement, and thus it ends up installing the latest version of `minio`.
- This results in diverging behavior in development where the older version of minio is installed because we _do_ install `django_s3_file_field[minio]` there.

This PR fixes the immediate issue by simply pinning `django-minio-storage` to the latest version that doesn't require `minio<7`. The long term fix will require updating `django_s3_file_field` to use the latest `django-minio-storage`/`minio`.