### PR TITLE
Temporarily disable s3 log file processing

### DIFF
--- a/dandiapi/analytics/tasks/__init__.py
+++ b/dandiapi/analytics/tasks/__init__.py
@@ -58,6 +58,7 @@ def process_s3_log_file_task(bucket: LogBucket, s3_log_key: str) -> None:
     asset blobs. Prevents duplicate processing with a unique constraint on the ProcessedS3Log name
     and embargoed fields.
     """
+    return
     assert bucket in [
         settings.DANDI_DANDISETS_LOG_BUCKET_NAME,
         settings.DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME,

--- a/dandiapi/analytics/tests/test_download_counts.py
+++ b/dandiapi/analytics/tests/test_download_counts.py
@@ -49,6 +49,7 @@ def s3_log_file(s3_log_bucket, asset_blob):
 
 
 @pytest.mark.django_db
+@pytest.mark.skip(reason='Temporarily disabled')
 def test_processing_s3_log_files(s3_log_bucket, s3_log_file, asset_blob):
     collect_s3_log_records_task(s3_log_bucket)
     asset_blob.refresh_from_db()
@@ -58,6 +59,7 @@ def test_processing_s3_log_files(s3_log_bucket, s3_log_file, asset_blob):
 
 
 @pytest.mark.django_db
+@pytest.mark.skip(reason='Temporarily disabled')
 def test_processing_s3_log_files_idempotent(s3_log_bucket, s3_log_file, asset_blob):
     collect_s3_log_records_task(s3_log_bucket)
     # run the task again, it should skip the existing log record


### PR DESCRIPTION
There are some bugs with using this method concurrently as it stands. In order to keep the queue moving along this short circuits the task while we troubleshoot.