### PR TITLE
Serve pure JSON from /server-info frontend endpoint

### DIFF
--- a/web/netlify/plugins/server-info-build/index.js
+++ b/web/netlify/plugins/server-info-build/index.js
@@ -10,7 +10,7 @@ module.exports = {
     apiUrl = apiUrl.endsWith('/') ? apiUrl.slice(0, -1) : apiUrl;
     netlifyConfig.redirects.unshift({
       from: '/server-info',
-      to: `${apiUrl}/info/`,
+      to: `${apiUrl}/info/?format=json`,
       status: 200,
     });
   },


### PR DESCRIPTION
By default, the /api/info endpoint (to which the frontend /server-info endpoint performs a rewrite) serves a response with `format=api` which includes framing content, including CSS, etc., and a dropdown to switch formats, all of which is inappropriate for this frontend endpoint.

This PR changes the target of the rewrite to the `format=json` URL, sidestepping the problems reported in #1593.

Closes #1593.