### PR TITLE
Avoid instantiating classes in `swagger_auto_schema` when possible

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -172,7 +172,7 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
         method='GET',
         operation_summary='Django serialization of an asset',
         manual_parameters=[ASSET_ID_PARAM],
-        responses={200: AssetDetailSerializer()},
+        responses={200: AssetDetailSerializer},
     )
     @action(methods=['GET', 'HEAD'], detail=True)
     def info(self, *args, **kwargs):
@@ -247,7 +247,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         method='GET',
         operation_summary='Django serialization of an asset',
         manual_parameters=[ASSET_ID_PARAM, VERSIONS_DANDISET_PK_PARAM, VERSIONS_VERSION_PARAM],
-        responses={200: AssetDetailSerializer()},
+        responses={200: AssetDetailSerializer},
     )
     @action(detail=True, methods=['GET'])
     def info(self, *args, **kwargs):
@@ -271,7 +271,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
     # Remaining actions
 
     @swagger_auto_schema(
-        responses={200: AssetValidationSerializer()},
+        responses={200: AssetValidationSerializer},
         manual_parameters=[ASSET_ID_PARAM, VERSIONS_DANDISET_PK_PARAM, VERSIONS_VERSION_PARAM],
         operation_summary='Get any validation errors associated with an asset',
         operation_description='',
@@ -283,9 +283,9 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        request_body=AssetRequestSerializer(),
+        request_body=AssetRequestSerializer,
         responses={
-            200: AssetDetailSerializer(),
+            200: AssetDetailSerializer,
             404: 'If a blob with the given checksum has not been validated',
         },
         manual_parameters=[VERSIONS_DANDISET_PK_PARAM, VERSIONS_VERSION_PARAM],
@@ -319,8 +319,8 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        request_body=AssetRequestSerializer(),
-        responses={200: AssetDetailSerializer()},
+        request_body=AssetRequestSerializer,
+        responses={200: AssetDetailSerializer},
         manual_parameters=[VERSIONS_DANDISET_PK_PARAM, VERSIONS_VERSION_PARAM],
         operation_summary='Update the metadata of an asset.',
         operation_description='User must be an owner of the associated dandiset.\
@@ -384,7 +384,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
 
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
-    @swagger_auto_schema(query_serializer=AssetListSerializer, responses={200: AssetSerializer()})
+    @swagger_auto_schema(query_serializer=AssetListSerializer, responses={200: AssetSerializer})
     def list(self, request, *args, **kwargs):
         serializer = AssetListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
@@ -418,7 +418,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         return Response(serializer.data)
 
     @swagger_auto_schema(
-        query_serializer=AssetPathsQueryParameterSerializer(),
+        query_serializer=AssetPathsQueryParameterSerializer,
         responses={200: AssetPathsSerializer(many=True)},
     )
     @action(detail=False, methods=['GET'], filter_backends=[])

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -158,7 +158,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         return dandiset
 
     @swagger_auto_schema(
-        query_serializer=DandisetQueryParameterSerializer(),
+        query_serializer=DandisetQueryParameterSerializer,
         responses={200: DandisetListSerializer(many=True)},
     )
     def list(self, request, *args, **kwargs):
@@ -229,9 +229,9 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         return self.get_paginated_response(serializer.data)
 
     @swagger_auto_schema(
-        request_body=VersionMetadataSerializer(),
-        query_serializer=CreateDandisetQueryParameterSerializer(),
-        responses={200: DandisetDetailSerializer()},
+        request_body=VersionMetadataSerializer,
+        query_serializer=CreateDandisetQueryParameterSerializer,
+        responses={200: DandisetDetailSerializer},
         operation_summary='Create a new dandiset.',
         operation_description='',
     )

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -74,8 +74,8 @@ class UploadCompletionResponseSerializer(serializers.Serializer):
     method='POST',
     operation_summary='Fetch an existing asset blob by digest, if it exists.',
     operation_description=f'Supported digest algorithms: {", ".join(supported_digests)}',
-    request_body=DigestSerializer(),
-    responses={200: AssetBlobSerializer()},
+    request_body=DigestSerializer,
+    responses={200: AssetBlobSerializer},
 )
 @api_view(['POST'])
 @parser_classes([JSONParser])
@@ -98,9 +98,9 @@ def blob_read_view(request: Request) -> HttpResponseBase:
 
 @swagger_auto_schema(
     method='POST',
-    request_body=UploadInitializationRequestSerializer(),
+    request_body=UploadInitializationRequestSerializer,
     responses={
-        200: UploadInitializationResponseSerializer(),
+        200: UploadInitializationResponseSerializer,
         409: 'Blob already exists. '
         'The Location header will be set to the UUID of the existing asset blob.',
     },
@@ -174,8 +174,8 @@ def upload_initialize_view(request: Request) -> HttpResponseBase:
 
 @swagger_auto_schema(
     method='POST',
-    request_body=UploadCompletionRequestSerializer(),
-    responses={200: UploadCompletionResponseSerializer()},
+    request_body=UploadCompletionRequestSerializer,
+    responses={200: UploadCompletionResponseSerializer},
 )
 @api_view(['POST'])
 @parser_classes([JSONParser])

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -67,7 +67,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
     @swagger_auto_schema(
         manual_parameters=[DANDISET_PK_PARAM, VERSION_PARAM],
-        responses={200: VersionDetailSerializer()},
+        responses={200: VersionDetailSerializer},
     )
     @action(detail=True, methods=['GET'])
     def info(self, request, **kwargs):
@@ -77,8 +77,8 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        request_body=VersionMetadataSerializer(),
-        responses={200: VersionDetailSerializer()},
+        request_body=VersionMetadataSerializer,
+        responses={200: VersionDetailSerializer},
         manual_parameters=[DANDISET_PK_PARAM, VERSION_PARAM],
     )
     @method_decorator(permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk')))
@@ -114,7 +114,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     @swagger_auto_schema(
         request_body=no_body,
         manual_parameters=[DANDISET_PK_PARAM, VERSION_PARAM],
-        responses={200: VersionSerializer()},
+        responses={200: VersionSerializer},
     )
     @action(detail=True, methods=['POST'])
     @method_decorator(permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk')))

--- a/dandiapi/zarr/views/__init__.py
+++ b/dandiapi/zarr/views/__init__.py
@@ -95,7 +95,7 @@ class ZarrViewSet(ReadOnlyModelViewSet):
     lookup_value_regex = ZarrArchive.UUID_REGEX
 
     @swagger_auto_schema(
-        query_serializer=ZarrListQuerySerializer(),
+        query_serializer=ZarrListQuerySerializer,
         responses={200: ZarrListSerializer(many=True)},
         operation_summary='List zarr archives.',
     )
@@ -117,8 +117,8 @@ class ZarrViewSet(ReadOnlyModelViewSet):
         return self.get_paginated_response(serializer.data)
 
     @swagger_auto_schema(
-        request_body=ZarrSerializer(),
-        responses={200: ZarrSerializer()},
+        request_body=ZarrSerializer,
+        responses={200: ZarrSerializer},
         operation_summary='Create a new zarr archive.',
         operation_description='',
     )
@@ -180,7 +180,7 @@ class ZarrViewSet(ReadOnlyModelViewSet):
             200: 'Listing of s3 objects',
             302: 'Redirect to an object in S3',
         },
-        query_serializer=ZarrExploreInputSerializer(),
+        query_serializer=ZarrExploreInputSerializer,
     )
     @action(methods=['HEAD', 'GET'], detail=True)
     def files(self, request, zarr_id: str):
@@ -253,7 +253,7 @@ class ZarrViewSet(ReadOnlyModelViewSet):
     @swagger_auto_schema(
         request_body=ZarrFileCreationSerializer(),
         responses={
-            200: ZarrFileCreationSerializer(),
+            200: ZarrFileCreationSerializer,
             400: ZarrArchive.INGEST_ERROR_MSG,
         },
         operation_summary='Request to upload files to a zarr archive.',


### PR DESCRIPTION
As we discovered last week while discussing #1598, serializer classes used in the `swagger_auto_schema` decorator don't need to be instantiated; just passing the class itself is sufficient. Instantiating the class causes the `__init__` constructor to be called, which in most cases has no negative impact, but has the potential to lead to strange bugs like we saw with the search serializer.