### PR TITLE
Fix search UI for smaller screens

### DIFF
--- a/web/src/components/Search/SearchParameters.vue
+++ b/web/src/components/Search/SearchParameters.vue
@@ -15,7 +15,7 @@ const SEARCH_PARAMS = [
 <template>
   <v-container class="pa-3">
     <span class="text-h4">Search Assets</span>
-    <v-sheet class="ma-2 pa-2">
+    <v-sheet class="ma-2">
       <v-card
         v-for="(param, i) in SEARCH_PARAMS"
         :key="i"

--- a/web/src/components/Search/forms/FileSizeForm.vue
+++ b/web/src/components/Search/forms/FileSizeForm.vue
@@ -10,8 +10,10 @@ import { searchParameters } from '../store';
       <span>Min</span>
       <v-text-field
         v-model="searchParameters.file_size_min"
+        dense
         type="number"
         outlined
+        style="min-width: 4ch;"
       />
     </v-col>
     <v-spacer />
@@ -19,8 +21,10 @@ import { searchParameters } from '../store';
       <span>Max</span>
       <v-text-field
         v-model="searchParameters.file_size_max"
+        dense
         type="number"
         outlined
+        style="min-width: 4ch;"
       />
     </v-col>
     <v-spacer />

--- a/web/src/views/SearchView/SearchView.vue
+++ b/web/src/views/SearchView/SearchView.vue
@@ -6,10 +6,16 @@ import SearchResults from '@/components/Search/SearchResults.vue';
 <template>
   <v-container fluid>
     <v-row no-gutters>
-      <v-col cols="3">
+      <v-col
+        md="3"
+        sm="12"
+      >
         <SearchParameters />
       </v-col>
-      <v-col cols="9">
+      <v-col
+        md="9"
+        sm="12"
+      >
         <SearchResults />
       </v-col>
     </v-row>


### PR DESCRIPTION
The search UI is unusable on smaller screens. I played around with different viewport heights/widths in the chrome dev tools and fixed all of the issues I could find -

- Remove some unneeded padding
- Make file size inputs "dense" to make them look nicer on smaller screens
- Specify a minimum width for the file size inputs
- Introduce a bit of responsive design for smaller screens - if the screen is not wide enough to accommodate the search filters on the left and the search results on the right, they will instead stack on top of each other.