### PR TITLE
Load search results on page load

### DIFF
--- a/web/src/components/Search/store.ts
+++ b/web/src/components/Search/store.ts
@@ -27,7 +27,7 @@ async function updateSearchQuery() {
 watch(searchParameters, () => {
   page.value = 1;
   updateSearchQuery();
-}, { deep: true });
+}, { deep: true, immediate: true });
 
 export {
   loading,


### PR DESCRIPTION
Currently, the search page is empty when a user navigates to it, and only gets populated with results after they interact with the search controls. This updates it to instead fetch a list of initial results.