### PR TITLE
Add concurrency=1 worker dyno for processing S3 logs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -6,6 +6,8 @@ web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi --timeout 25
 # This is OK for now because of how lightweight all high priority tasks currently are,
 # but we may need to switch back to a dedicated worker in the future.
 # The queue `celery` is the default queue.
-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery,s3-log-processing -B
+worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B
 # The checksum-worker calculates blob checksums and updates zarr checksum files
 checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256,ingest_zarr_archive
+# The analytics-worker processes s3 log files serially
+analytics-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --concurrency 1 -Q s3-log-processing


### PR DESCRIPTION
Sibling PR to https://github.com/dandi/dandi-infrastructure/pull/152.

Ultimately there is too much contention between updating blob counts to do it in parallel. This is because closeby log files often contain similar blobs and so multiple jobs are fighting over which gets to lock those blob records first.