### PR TITLE
Fix user approval workflow

### DIFF
--- a/dandiapi/api/views/dashboard.py
+++ b/dandiapi/api/views/dashboard.py
@@ -96,6 +96,8 @@ def user_approval_view(request, username: str):
 
         if user.metadata.status == UserMetadata.Status.APPROVED:
             send_approved_user_message(user, social_account)
+            user.is_active = True
+            user.save()
         elif user.metadata.status == UserMetadata.Status.REJECTED:
             send_rejected_user_message(user, social_account)
             user.is_active = False

--- a/dandiapi/api/views/dashboard.py
+++ b/dandiapi/api/views/dashboard.py
@@ -97,11 +97,11 @@ def user_approval_view(request, username: str):
         if user.metadata.status == UserMetadata.Status.APPROVED:
             send_approved_user_message(user, social_account)
             user.is_active = True
-            user.save()
         elif user.metadata.status == UserMetadata.Status.REJECTED:
             send_rejected_user_message(user, social_account)
             user.is_active = False
-            user.save()
+
+        user.save()
 
     return render(
         request,


### PR DESCRIPTION
The user approval form handler was relying on "active" being the default state for a Django user, and therefore users who were approved after being rejected retained their "inactive" status. This PR fixes that by explicitly setting users to active whenever they are approved.

Closes #1619.