### PR TITLE
Rename e2e test package

### DIFF
--- a/web/test/package.json
+++ b/web/test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test",
+  "name": "e2e-tests",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
`test` is the name of a core node module and shouldn't be used here. This will silence the warning that gets printed in CI when the e2e tests run.

ref: https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields