### PR TITLE
Use 1080p resolution browser window for e2e tests

### DIFF
--- a/web/test/jest.setup.js
+++ b/web/test/jest.setup.js
@@ -21,7 +21,7 @@ beforeEach(async () => {
   await jestPuppeteer.resetBrowser();
   // Widen the viewport to make sure puppeteer can see the full page. If we don't do this then part
   // of the navbar will be collapsed into a hamburger menu, which will break some tests
-  await page.setViewport({ width: 1366, height: 768 });
+  await page.setViewport({ width: 1920, height: 1080 });
   await page.goto(CLIENT_URL, { timeout: 0 });
   await waitForRequestsToFinish();
 });


### PR DESCRIPTION
This makes the puppeteer browser window bigger and increases the amount of elements jest/puppeteer can "see" without needing to scroll the window.