### PR TITLE
Assume that browser can play any "video/" content type.

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -156,7 +156,7 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
                 content_type,
             )
 
-            if content_type == 'video/x-matroska':
+            if content_type.startswith('video/'):
                 return HttpResponse(
                     f"""
                     <video autoplay muted controls>

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -160,7 +160,7 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
                 return HttpResponse(
                     f"""
                     <video autoplay muted controls>
-                        <source src="{url}" type="video/mp4">
+                        <source src="{url}">
                     </video>
                 """,
                     content_type='text/html',


### PR DESCRIPTION
x-matroska is not the only one which browsers should be able to play. E.g. video/mp4, video/webm, and video/ogg are the other ones I (and chat gpt) knows to generally be supported.  To avoid needing to list them all explicitly and thus always playing catch up game of assumptions, I would just allow browser to try on any video/ one. Worse could happen it would not work, and might ask to download I guess.

Might close (edited by @waxlamp: it doesn't) #1626 but I didn't check if it would work for those files:

    ❯ curl --silent https://api.dandiarchive.org/api/assets/942b0806-2c8b-4289-a072-9e965884fcb6/ | jq .encodingFormat
    "video/x-msvideo"