### PR TITLE
Limit aggregate asset summaries to valid assets

### DIFF
--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -74,7 +74,9 @@ def version_aggregate_assets_summary(version: Version):
         raise VersionHasBeenPublished()
 
     version.metadata['assetsSummary'] = aggregate_assets_summary(
-        version.assets.values_list('metadata', flat=True).iterator()
+        version.assets.filter(status=Asset.Status.VALID)
+        .values_list('metadata', flat=True)
+        .iterator()
     )
 
     Version.objects.filter(id=version.id, version='draft').update(

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -10,6 +10,8 @@ from freezegun import freeze_time
 from guardian.shortcuts import assign_perm
 import pytest
 
+from dandiapi.api.services.metadata import version_aggregate_assets_summary
+
 if TYPE_CHECKING:
     from rest_framework.test import APIClient
 
@@ -226,6 +228,15 @@ def test_version_metadata_assets_summary_missing(version, asset):
 
     # Verify that an Asset with no aggregatable metadata doesn't break anything
     version.save()
+
+
+@pytest.mark.django_db
+def test_version_aggregate_assets_summary_valid_assets(draft_version, draft_asset_factory):
+    valid_asset = draft_asset_factory(status=Asset.Status.VALID)
+    invalid_asset = draft_asset_factory(status=Asset.Status.INVALID)
+    draft_version.assets.add(valid_asset, invalid_asset)
+    version_aggregate_assets_summary(draft_version)
+    assert draft_version.metadata['assetsSummary']['numberOfFiles'] == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes https://github.com/dandi/dandi-schema/issues/183.

This should remove the `encodingFormat` errors we've been getting for a while. After this I'll manually trigger a re-aggregation for draft versions.
