### PR TITLE
add scrollIntoView for UI tests

### DIFF
--- a/web/test/package.json
+++ b/web/test/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.5.0",
+    "core-js": "^3.31.0",
     "expect-puppeteer": "^6.1.1",
     "jest": "^29.1.2",
     "jest-puppeteer": "^6.1.1",

--- a/web/test/src/tests/registerDandiset.test.js
+++ b/web/test/src/tests/registerDandiset.test.js
@@ -23,6 +23,7 @@ describe('dandiset registration page', () => {
 
     await expect(page).toFillXPath(vTextField('Title'), name);
     await expect(page).toFillXPath(vTextarea('Description'), description);
+    // eslint-disable-next-line no-undef
     await page.evaluate(() => document.querySelector('button[type="submit"]').scrollIntoView());
     await expect(page).toClickXPath('//label[contains(.,"License")]/following::input[1]');
     await page.waitForTimeout(500); // Give dropdown time to render

--- a/web/test/src/tests/registerDandiset.test.js
+++ b/web/test/src/tests/registerDandiset.test.js
@@ -23,6 +23,7 @@ describe('dandiset registration page', () => {
 
     await expect(page).toFillXPath(vTextField('Title'), name);
     await expect(page).toFillXPath(vTextarea('Description'), description);
+    await page.evaluate(() => document.querySelector('button[type="submit"]').scrollIntoView());
     await expect(page).toClickXPath('//label[contains(.,"License")]/following::input[1]');
     await page.waitForTimeout(500); // Give dropdown time to render
     await expect(page).toClickXPath(vListItem('spdx:CC0-1.0'));

--- a/web/test/src/util.js
+++ b/web/test/src/util.js
@@ -109,6 +109,7 @@ export async function registerDandiset(name, description) {
   await expect(page).toClickXPath(vBtn('New Dandiset'));
   await expect(page).toFillXPath(vTextField('Title'), name);
   await expect(page).toFillXPath(vTextarea('Description'), description);
+  await page.evaluate(() => document.querySelector('button[type="submit"]').scrollIntoView());
   await expect(page).toClickXPath('//label[contains(.,"License")]/following::input[1]');
   await page.waitForTimeout(500); // Give dropdown time to render
   await expect(page).toClickXPath(vListItem('spdx:CC0-1.0'));

--- a/web/test/src/util.js
+++ b/web/test/src/util.js
@@ -109,6 +109,7 @@ export async function registerDandiset(name, description) {
   await expect(page).toClickXPath(vBtn('New Dandiset'));
   await expect(page).toFillXPath(vTextField('Title'), name);
   await expect(page).toFillXPath(vTextarea('Description'), description);
+  // eslint-disable-next-line no-undef
   await page.evaluate(() => document.querySelector('button[type="submit"]').scrollIntoView());
   await expect(page).toClickXPath('//label[contains(.,"License")]/following::input[1]');
   await page.waitForTimeout(500); // Give dropdown time to render

--- a/web/test/yarn.lock
+++ b/web/test/yarn.lock
@@ -2184,6 +2184,11 @@ core-js-compat@^3.9.0, core-js-compat@^3.9.1:
     browserslist "^4.16.6"
     semver "7.0.0"
 
+core-js@^3.31.0:
+  version "3.31.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.31.0.tgz#4471dd33e366c79d8c0977ed2d940821719db344"
+  integrity sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==
+
 cross-fetch@3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"


### PR DESCRIPTION
This PR adds core-js to frontend testing allowing us to use `scrollIntoView` on the puppeteer DOM.

It is good to note that this is a workaround. Ideally we would use the `scrollIntoView` function provided by puppeteer but that was not introduced until `v19.9.0`. We are currently on `v17.1.3`. There are quite a few breaking changes between these releases though.

https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v19.9.0