### PR TITLE
Remove excess rows to fix responsive view of stats bar

### DIFF
--- a/web/src/views/HomeView/HomeView.vue
+++ b/web/src/views/HomeView/HomeView.vue
@@ -41,9 +41,7 @@
         <DandisetSearchField :dense="false" />
       </v-col>
     </v-row>
-    <v-row class="flex-grow-0">
-      <StatsBar />
-    </v-row>
+    <StatsBar />
   </v-container>
 </template>
 

--- a/web/src/views/HomeView/SingleStat.vue
+++ b/web/src/views/HomeView/SingleStat.vue
@@ -1,11 +1,9 @@
 <template>
-  <v-container
-    fluid
-    class="py-0 px-8"
-    data-id="stat"
-    :data-name="name"
-  >
-    <v-row class="text-h3 font-weight-thin text-center white--text">
+  <div>
+    <v-row
+      class="text-h3 font-weight-thin text-center white--text"
+      no-gutters
+    >
       <v-col
         class="pa-0"
         data-id="value"
@@ -13,7 +11,10 @@
         {{ value }}
       </v-col>
     </v-row>
-    <v-row class="text-h6 font-weight-light text-center light-blue--text text--lighten-1">
+    <v-row
+      class="text-h6 font-weight-light text-center light-blue--text text--lighten-1"
+      no-gutters
+    >
       <v-col
         class="pa-0"
         data-id="name"
@@ -43,7 +44,7 @@
         </v-tooltip>
       </v-col>
     </v-row>
-  </v-container>
+  </div>
 </template>
 
 <script lang="ts">

--- a/web/src/views/HomeView/StatsBar.vue
+++ b/web/src/views/HomeView/StatsBar.vue
@@ -3,7 +3,7 @@
     class="grey darken-3 pa-0"
     fluid
   >
-    <v-row class="py-6">
+    <v-row class="py-6 mt-2">
       <template v-for="stat in stats">
         <v-col
           :key="stat.name"
@@ -19,13 +19,6 @@
             :href="stat.href"
           />
         </v-col>
-        <!-- TODO dividers destroy the grid system breakpoints
-        <v-divider
-          :key="stat.name + '-divider'"
-          vertical
-          class="grey"
-        />
-        -->
       </template>
     </v-row>
   </v-container>


### PR DESCRIPTION
fixes #1611 
Removes excess rows and adjusts props for remaining rows to fix the responsive view of stats bar. Phone view shown below.



![image](https://github.com/dandi/dandi-archive/assets/40494088/4d660123-da2b-41e6-8334-fef8b68edf18)
