### PR TITLE
Move asset validation to a scheduled task

### DIFF
--- a/dandiapi/api/services/asset/__init__.py
+++ b/dandiapi/api/services/asset/__init__.py
@@ -10,7 +10,6 @@ from dandiapi.api.services.asset.exceptions import (
     DraftDandisetNotModifiable,
     ZarrArchiveBelongsToDifferentDandiset,
 )
-from dandiapi.api.services.asset.metadata import _maybe_validate_asset_metadata
 from dandiapi.zarr.models import ZarrArchive
 
 
@@ -147,13 +146,6 @@ def add_asset_to_version(
         version.status = Version.Status.PENDING
         # Save the version so that the modified field is updated
         version.save()
-
-    # The sha256 may have been newly calculated in the time since the asset was created. If so, we
-    # need to fetch the latest record from the DB so that _maybe_validate_asset_metadata sees the
-    # new sha256 value and includes it in the asset metadata properly.
-    asset.refresh_from_db()
-
-    _maybe_validate_asset_metadata(asset)
 
     return asset
 

--- a/dandiapi/api/services/asset/metadata.py
+++ b/dandiapi/api/services/asset/metadata.py
@@ -2,30 +2,6 @@ from django.db import transaction
 from django.db.models.query import QuerySet
 
 from dandiapi.api.models.asset import Asset
-from dandiapi.api.services.metadata import validate_asset_metadata
-
-
-def _maybe_validate_asset_metadata(asset: Asset):
-    """
-    Validate asset metadata if a checksum for its blob has already been computed.
-
-    If the checksum isn't there yet, it's the responsibility of the checksum code
-    to trigger validation for all assets pointing to its blob.
-    """
-    # Checksums are necessary for the asset metadata to be validated. For asset blobs, the sha256
-    # checksum is required. For zarrs, the zarr checksum is required. In both of these cases, if
-    # the checksum is not present, asset metadata is not yet validated, and that validation should
-    # be kicked off at the end of their respective checksum calculation tasks.
-    if asset.is_zarr:
-        if asset.zarr.checksum is None:
-            return
-    else:
-        blob = asset.blob or asset.embargoed_blob
-        if blob.sha256 is None:
-            return
-
-    # We do not bother to delay this because it should run very quickly.
-    validate_asset_metadata(asset=asset)
 
 
 def bulk_recalculate_asset_metadata(*, assets: QuerySet[Asset]):

--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -41,9 +41,6 @@ def validate_asset_metadata(*, asset: Asset) -> None:
         raise AssetHasBeenPublished()
 
     with transaction.atomic():
-        asset.status = Asset.Status.VALIDATING
-        asset.save()
-
         try:
             metadata = asset.published_metadata()
             validate(metadata, schema_key='PublishedAsset', json_validation=True)

--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -69,7 +69,7 @@ def validate_asset_metadata(*, asset: Asset) -> None:
         asset.versions.filter(version='draft').update(modified=timezone.now())
 
 
-def version_aggregate_assets_summary(version: Version):
+def version_aggregate_assets_summary(version: Version) -> None:
     if version.version != 'draft':
         raise VersionHasBeenPublished()
 
@@ -82,8 +82,6 @@ def version_aggregate_assets_summary(version: Version):
     Version.objects.filter(id=version.id, version='draft').update(
         modified=timezone.now(), metadata=version.metadata
     )
-    version.refresh_from_db()
-    return version
 
 
 def validate_version_metadata(*, version: Version) -> None:

--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -34,9 +34,6 @@ def publish_asset(*, asset: Asset) -> None:
         locked_asset.published = True
         locked_asset.save()
 
-    # Original asset is now stale, so we need to refresh from DB
-    asset.refresh_from_db()
-
 
 def _lock_dandiset_for_publishing(*, user: User, dandiset: Dandiset) -> None:
     """

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -50,8 +50,9 @@ def write_manifest_files(version_id: int) -> None:
 def validate_asset_metadata_task(asset_id: int) -> None:
     from dandiapi.api.services.metadata import validate_asset_metadata
 
-    asset: Asset = Asset.objects.get(id=asset_id)
-    validate_asset_metadata(asset=asset)
+    asset: Asset = Asset.objects.filter(id=asset_id, status=Asset.Status.PENDING).first()
+    if asset:
+        validate_asset_metadata(asset=asset)
 
 
 @shared_task(soft_time_limit=30)

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -17,8 +17,7 @@ logger = get_task_logger(__name__)
 
 
 @shared_task(queue='calculate_sha256', soft_time_limit=86_400)
-@atomic
-def calculate_sha256(blob_id: int) -> None:
+def calculate_sha256(blob_id: str) -> None:
     try:
         asset_blob = AssetBlob.objects.get(blob_id=blob_id)
         logger.info(f'Found AssetBlob {blob_id}')

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -208,6 +208,7 @@ class PublishedAssetFactory(DraftAssetFactory):
         asset.status = Asset.Status.VALID  # published assets are always valid
         asset.save()
         publish_asset(asset=asset)
+        asset.refresh_from_db()
         return asset
 
 

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -51,28 +51,6 @@ def test_calculate_checksum_task_embargo(storage: Storage, embargoed_asset_blob_
 
 
 @pytest.mark.django_db
-def test_checksum_task_invokes_asset_validation(
-    storage: Storage, asset_blob_factory, draft_asset_factory, django_capture_on_commit_callbacks
-):
-    # Pretend like AssetBlob was defined with the given storage
-    AssetBlob.blob.field.storage = storage
-    asset_blob = asset_blob_factory(sha256=None)
-    assets: list[Asset] = [draft_asset_factory(blob=asset_blob) for _ in range(3)]
-
-    # Assert status before checksum
-    assert all([asset.status == Asset.Status.PENDING for asset in assets])
-
-    # Dispatch task, capture any transaction callbacks
-    with django_capture_on_commit_callbacks(execute=True):
-        tasks.calculate_sha256(asset_blob.blob_id)
-
-    # Assert metadata validation ran
-    for asset in assets:
-        asset.refresh_from_db()
-        assert asset.status != Asset.Status.PENDING
-
-
-@pytest.mark.django_db
 def test_write_manifest_files(storage: Storage, version: Version, asset_factory):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls
@@ -158,6 +136,9 @@ def test_validate_asset_metadata_no_encoding_format(draft_asset: Asset):
 def test_validate_asset_metadata_no_digest(draft_asset: Asset):
     draft_asset.blob.sha256 = None
     draft_asset.blob.save()
+
+    del draft_asset.metadata['digest']
+    draft_asset.save()
 
     tasks.validate_asset_metadata_task(draft_asset.id)
 

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -651,6 +651,7 @@ def test_version_rest_publish_zarr(
     zarr_archive = zarr_archive_factory(dandiset=draft_version.dandiset)
     zarr_file_factory(zarr_archive=zarr_archive)
     ingest_zarr_archive(zarr_archive.zarr_id)
+    zarr_archive.refresh_from_db()
 
     zarr_asset: Asset = draft_asset_factory(zarr=zarr_archive, blob=None)
     normal_asset: Asset = draft_asset_factory()

--- a/dandiapi/zarr/tasks/__init__.py
+++ b/dandiapi/zarr/tasks/__init__.py
@@ -8,7 +8,6 @@ from zarr_checksum.generators import S3ClientOptions, yield_files_s3
 
 from dandiapi.api.asset_paths import add_zarr_paths, delete_zarr_paths
 from dandiapi.api.storage import get_storage_params
-from dandiapi.api.tasks import validate_asset_metadata_task
 from dandiapi.zarr.models import ZarrArchive, ZarrArchiveStatus
 
 logger = get_task_logger(__name__)
@@ -66,17 +65,6 @@ def ingest_zarr_archive(zarr_id: str, force: bool = False):
 
         # Add asset paths after ingest is finished
         add_zarr_paths(zarr)
-
-        # Use function instead of lambda for correct closure
-        def dispatch_validation():
-            for asset_id in zarr.assets.values_list('id', flat=True).iterator():
-                # Note: while asset metadata is fairly lightweight compute-wise, memory-wise it can
-                # become an issue during serialization/deserialization of the JSON blob by pydantic.
-                # Therefore, we delay each validation to its own task.
-                validate_asset_metadata_task.delay(asset_id)
-
-        # Kickoff metadata validation for all zarr assets after the transaction completes
-        transaction.on_commit(dispatch_validation)
 
 
 def ingest_dandiset_zarrs(dandiset_id: int, **kwargs):


### PR DESCRIPTION
Addresses #1479 

This addresses a few potential race conditions and uses a scheduled task for asset validation instead of the previous flow where it could be triggered on asset creation or by completion of a sha256.