### PR TITLE
Consolidate two DB queries into one

### DIFF
--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -106,8 +106,9 @@ def _publish_dandiset(dandiset_id: int) -> None:
 
     Calling `_lock_dandiset_for_publishing()` is a precondition for calling this function.
     """
-    old_version: Version = (
-        Dandiset.objects.get(id=dandiset_id).versions.select_for_update().get(version='draft')
+    old_version: Version = Version.objects.select_for_update().get(
+        dandiset_id=dandiset_id,
+        version='draft',
     )
 
     with transaction.atomic():


### PR DESCRIPTION
We're evaluating two querysets here (which produces two SQL queries), when we really only need to evaluate one.