### PR TITLE
Atomically delete dandiset and its versions

### DIFF
--- a/dandiapi/api/services/dandiset/__init__.py
+++ b/dandiapi/api/services/dandiset/__init__.py
@@ -56,5 +56,6 @@ def delete_dandiset(*, user, dandiset: Dandiset) -> None:
 
     # Delete all versions first, so that AssetPath deletion is cascaded
     # through versions, rather than through zarrs directly
-    dandiset.versions.all().delete()
-    dandiset.delete()
+    with transaction.atomic():
+        dandiset.versions.all().delete()
+        dandiset.delete()


### PR DESCRIPTION
This wasn't actively causing problems, but it's a good idea to do these in a transaction.