### PR TITLE
Remove "app" prop from footer

### DIFF
--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-footer
-    class="text-body-2"
-    app
-  >
+  <v-footer class="text-body-2">
     <v-container>
       <cookie-law theme="blood-orange">
         <div slot="message">


### PR DESCRIPTION
It seems the app prop causes the footer to overlap with the rest of the page content in an undesirable way. @marySalvi applied another change via #1633 which fixes the underlying issue (#1611) more directly, so the `app` prop can be removed.