### PR TITLE
Unpin dev-only dependencies + disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,12 +12,3 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: "weekly"
-    labels:
-      - internal
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,10 @@ setup(
             'ipython',
             'tox',
             'memray',
+            'boto3-stubs[s3]',
+            'django-stubs',
+            'djangorestframework-stubs',
+            'types-setuptools',
         ],
         'test': [
             'factory-boy',
@@ -93,22 +97,6 @@ setup(
             'pytest-factoryboy',
             'pytest-memray',
             'pytest-mock',
-        ],
-        'lint': [
-            'flake8==6.0.0',
-            'flake8-black==0.3.6',
-            'flake8-bugbear==23.6.5',
-            'flake8-docstrings==1.7.0',
-            'flake8-isort==6.0.0',
-            'flake8-quotes==3.3.2',
-            'pep8-naming==0.13.3',
-        ],
-        'type': [
-            'mypy==1.4.1',
-            'boto3-stubs[s3]==1.26.50',
-            'django-stubs==4.2.0',
-            'djangorestframework-stubs==3.14.0',
-            'types-setuptools==68.0.0.0',
         ],
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -7,18 +7,25 @@ envlist =
 
 [testenv:lint]
 skipsdist = true
-extras =
-    lint
+skip_install = true
 deps =
     codespell~=2.0
+    flake8
+    flake8-black >= 0.2.4
+    flake8-bugbear
+    flake8-docstrings
+    flake8-isort
+    flake8-quotes
+    pep8-naming
 commands =
     flake8 --config=tox.ini {posargs:.}
     codespell {posargs:.}
 
 [testenv:type]
+deps =
+    mypy
 extras =
     dev
-    type
 commands =
     mypy {posargs:dandiapi/}
 


### PR DESCRIPTION
#1402 was a useful experiment to see if we could avoid having to deal with CI failures due to breaking changes in flake8, black, mypy, etc. by pinning them and managing upgrades via dependabot. But as we discussed, the large volume of dependabot PRs that it resulted in ends up consuming more time to approve and merge than it is to deal with the (very) occasional breakage. Thus, this PR effectively reverts #1402.