### PR TITLE
open avi files in neurosift

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -339,6 +339,13 @@ const EXTERNAL_SERVICES = [
     maxsize: Infinity,
     endpoint: 'https://flatironinstitute.github.io/neurosift?p=/nwb&url=',
   },
+
+  {
+    name: 'Neurosift',
+    regex: /\.avi$/,
+    maxsize: Infinity,
+    endpoint: 'https://flatironinstitute.github.io/neurosift?p=/avi&url=',
+  },
 ];
 type Service = typeof EXTERNAL_SERVICES[0];
 


### PR DESCRIPTION
Here I propose to provide an external link for opening avi files in neurosift.

This addresses #1626 

Only a subset of video file types are supported by the browser. The .avi type is one that sometimes appears in dandisets and is not supported in the browser. For example here is one

https://dandiarchive.org/dandiset/000568/0.230705.1633/files?location=sub-fCamk1%2Fsub-fCamk1_ses-fCamk1-200827-sess9-no-raw-data_behavior%2Becephys%2Bimage%2Bogen

If you click the view button, it takes you to a new tab where the video does not play, because it is not supported by the browser.

This PR adds an external service for avi types which redirects to neurosift. For example, the above video would open to:

https://flatironinstitute.github.io/neurosift/?p=/avi&url=https://dandiarchive.s3.amazonaws.com/blobs/79f/50f/79f50f6d-501a-4bb4-ad07-ff5abb545f48

How does this work? Neurosift cannot play the .avi directly either. I have set up a neurosift cloud bucket that contains converted mp4 files for all of the avi files in the dandi archive. When neurosift receives the above url, it checks the dandi bucket for the ETag of the asset. It then looks for that converted.mp4 file located at that ETag on the neurosift bucket. In this way, the played video is guaranteed to correspond to the correct content, even if the video at that dandi location is modified.

At some point it might make sense to store these converted videos on the dandi archive bucket. At that point, we can turn off this service.

There is a question of when to trigger processing of a new dandiset that contains avi files.  There is also a question of how to clean up old mp4 files that correspond to a deleted asset. Those problems have not been solved yet on the neurosift end.



