### PR TITLE
Add new Django setting to restrict allauth endpoints that are exposed

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -39,11 +39,14 @@ class DandiMixin(ConfigMixin):
             'dandiapi.zarr.apps.ZarrConfig',
         ] + configuration.INSTALLED_APPS
 
-        # Install additional apps
-        configuration.INSTALLED_APPS += [
-            'guardian',
-            'allauth.socialaccount.providers.github',
-        ]
+        # Install guardian
+        configuration.INSTALLED_APPS += ['guardian']
+
+        # Install github provider only if github oauth is enabled
+        if configuration.ENABLE_GITHUB_OAUTH:
+            configuration.INSTALLED_APPS += [
+                'allauth.socialaccount.providers.github',
+            ]
 
         # Authentication
         configuration.AUTHENTICATION_BACKENDS += ['guardian.backends.ObjectPermissionBackend']

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -129,6 +129,9 @@ class DandiMixin(ConfigMixin):
     # Automatically approve new users by default
     AUTO_APPROVE_USERS = True
 
+    # Disable github oauth by default
+    ENABLE_GITHUB_OAUTH = False
+
 
 class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
     # This makes pydantic model schema allow URLs with localhost in them.
@@ -173,6 +176,8 @@ class HerokuProductionConfiguration(DandiMixin, HerokuProductionBaseConfiguratio
     def mutate_configuration(configuration: type[ComposedConfiguration]):
         # We're configuring sentry by hand since we need to pass custom options (traces_sampler).
         configuration.INSTALLED_APPS.remove('composed_configuration.sentry.apps.SentryConfig')
+
+    ENABLE_GITHUB_OAUTH = True
 
     # All login attempts in production should go straight to GitHub
     LOGIN_URL = '/accounts/github/login/'

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -113,10 +113,14 @@ urlpatterns = [
 
 if settings.ENABLE_GITHUB_OAUTH:
     # Include github oauth endpoints only
-    urlpatterns += [path('accounts/', include('allauth.socialaccount.providers.github.urls'))]
+    urlpatterns.append(
+        path('accounts/', include('allauth.socialaccount.providers.github.urls')),
+    )
 else:
     # Include "account" endpoints only (i.e. endpoints needed for username/password login flow)
-    urlpatterns += [path('accounts/', include('allauth.account.urls'))]
+    urlpatterns.append(
+        path('accounts/', include('allauth.account.urls')),
+    )
 
 if settings.DEBUG:
     import debug_toolbar

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -100,7 +100,6 @@ urlpatterns = [
     ),
     path('api/search/genotypes/', search_genotypes),
     path('api/search/species/', search_species),
-    path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
     path('dashboard/', DashboardView.as_view(), name='dashboard-index'),
     path('dashboard/user/<str:username>/', user_approval_view, name='user-approval'),
@@ -111,6 +110,13 @@ urlpatterns = [
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]
+
+if settings.ENABLE_GITHUB_OAUTH:
+    # Include github oauth endpoints only
+    urlpatterns += [path('accounts/', include('allauth.socialaccount.providers.github.urls'))]
+else:
+    # Include "account" endpoints only (i.e. endpoints needed for username/password login flow)
+    urlpatterns += [path('accounts/', include('allauth.account.urls'))]
 
 if settings.DEBUG:
     import debug_toolbar


### PR DESCRIPTION
Currently, we use allauth's regular "account" provider for user management in dev, and its github "socialaccount" provider for prod. However, we expose endpoints for both of these auth flows in prod and dev. This means that someone can sign up using the regular "account" provider in production, bypassing github entirely. In practice, this hasn't happened before because we don't advertise these URLs publicy; however if you know the URL, a user could navigate to https://api.dandiarchive.org/accounts/signup/ directly and sign up.

This PR adds a new setting `ENABLE_GITHUB_OAUTH`. If enabled, only the github socialaccount provider endpoints are exposed. If disabled, only the "account" provider endpoints are exposed.