### PR TITLE
Temporary fix for breaking change in `django-allauth`

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -41,9 +41,10 @@ class DandiMixin(ConfigMixin):
 
         # TODO: remove this when the upstream fix is merged
         # (https://github.com/girder/django-composed-configuration/pull/189)
-        configuration.MIDDLEWARE += [
-            'allauth.account.middleware.AccountMiddleware',
-        ]
+        if 'allauth.account.middleware.AccountMiddleware' not in configuration.MIDDLEWARE:
+            configuration.MIDDLEWARE += [
+                'allauth.account.middleware.AccountMiddleware',
+            ]
 
         # Install guardian
         configuration.INSTALLED_APPS += ['guardian']


### PR DESCRIPTION
This should be removed once the corresponding fix upstream in `django-composed-confiugration` is merged.
https://github.com/girder/django-composed-configuration/pull/189

This is the cause of the CI failures in this PR #1674.