### PR TITLE
Fix possible race condition in deployment actions

### DIFF
--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [released]
 
+concurrency:
+  # If this workflow is already running, cancel it to avoid a scenario
+  # where the older run finishes *after* the newer run and overwrites
+  # the deployment with an older version of the app.
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   reset-release-branch:
     name: Update release branch

--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -7,6 +7,13 @@ on:
     paths-ignore:
       - "web/**"
 
+concurrency:
+  # If this workflow is already running, cancel it to avoid a scenario
+  # where the older run finishes *after* the newer run and overwrites
+  # the deployment with an older version of the app.
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy to Heroku


### PR DESCRIPTION
We don't enforce any `concurrency` rule on the github actions that deploy our Django app to Heroku. This opens us up to potential issues, such as a scenario where an older deploy job ends up running after a newer job, causing the older version of the app to "overwrite" the newer one on Heroku.