### PR TITLE
Pin django-allauth to minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,9 @@ setup(
         'dandischema~=0.8.2',
         'django~=4.1.0',
         'django-admin-display',
-        'django-allauth',
+        # TODO: unpin allauth when https://github.com/girder/django-composed-configuration/pull/189
+        # is merged and released
+        'django-allauth>=0.56.1',
         'django-click',
         'django-configurations[database,email]',
         'django-extensions',


### PR DESCRIPTION
There is a breaking change in this version, so we need to ensure we are at or above it for compatibility reasons. 
Merging #1678 caused the fix for this breaking change to get applied in staging, but staging is still running an older version of allauth due to Heroku's dependency caching.

Should be reverted when https://github.com/girder/django-composed-configuration/pull/189 is merged.