### PR TITLE
Enable path-only changes to metadata to trigger asset change

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -240,6 +240,7 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
         asset_blob: AssetBlob | EmbargoedAssetBlob | None = None,
         zarr_archive: ZarrArchive | EmbargoedZarrArchive | None = None,
         metadata: dict,
+        path: str,
     ) -> bool:
         from dandiapi.zarr.models import EmbargoedZarrArchive, ZarrArchive
 
@@ -262,6 +263,9 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
 
         if isinstance(zarr_archive, EmbargoedZarrArchive):
             raise NotImplementedError
+
+        if self.path != path:
+            return True
 
         if self.metadata != metadata:
             return True

--- a/dandiapi/api/services/asset/__init__.py
+++ b/dandiapi/api/services/asset/__init__.py
@@ -66,7 +66,10 @@ def change_asset(
     new_metadata_stripped = Asset.strip_metadata(new_metadata)
 
     if not asset.is_different_from(
-        asset_blob=new_asset_blob, zarr_archive=new_zarr_archive, metadata=new_metadata_stripped, path=path
+        asset_blob=new_asset_blob,
+        zarr_archive=new_zarr_archive,
+        metadata=new_metadata_stripped,
+        path=path,
     ):
         return asset, False
 

--- a/dandiapi/api/services/asset/__init__.py
+++ b/dandiapi/api/services/asset/__init__.py
@@ -66,7 +66,7 @@ def change_asset(
     new_metadata_stripped = Asset.strip_metadata(new_metadata)
 
     if not asset.is_different_from(
-        asset_blob=new_asset_blob, zarr_archive=new_zarr_archive, metadata=new_metadata_stripped
+        asset_blob=new_asset_blob, zarr_archive=new_zarr_archive, metadata=new_metadata_stripped, path=path
     ):
         return asset, False
 


### PR DESCRIPTION
The logic for PUT on asset metadata includes a check to see if the asset is "different" enough to warrant an actual change. This works in part by stripping the supplied metadata of all computed fields, of which `path` is one, and then comparing what remains. This had the effect of barring any "move" type operations (by changing just the `path` value of a metadata and performing a PUT), as changes to the path did not "count" towards being different enough. The workaround was to _also_ change a _non_-computed metadata field; this made the asset different enough to trigger a change, which included the changed path.

The fix is to teach the "is different" function about path-only changes.

Thanks to @AlmightyYakob for his help in figuring this out.

TODO:
- [x] add a test (@AlmightyYakob)

Closes #1682.