### PR TITLE
use substitutions for external service endpoints

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -309,35 +309,35 @@ const EXTERNAL_SERVICES = [
     name: 'Bioimagesuite/Viewer',
     regex: /\.nii(\.gz)?$/,
     maxsize: 1e9,
-    endpoint: 'https://bioimagesuiteweb.github.io/unstableapp/viewer.html?image=$s3_url$',
+    endpoint: 'https://bioimagesuiteweb.github.io/unstableapp/viewer.html?image=$asset_s3_download_url$',
   },
 
   {
     name: 'MetaCell/NWBExplorer',
     regex: /\.nwb$/,
     maxsize: 1e9,
-    endpoint: 'http://nwbexplorer.opensourcebrain.org/nwbfile=$s3_url$',
+    endpoint: 'http://nwbexplorer.opensourcebrain.org/nwbfile=$asset_s3_download_url$',
   },
 
   {
     name: 'VTK/ITK Viewer',
     regex: /\.ome\.zarr$/,
     maxsize: Infinity,
-    endpoint: 'https://kitware.github.io/itk-vtk-viewer/app/?gradientOpacity=0.3&image=$s3_url$',
+    endpoint: 'https://kitware.github.io/itk-vtk-viewer/app/?gradientOpacity=0.3&image=$asset_s3_download_url$',
   },
 
   {
     name: 'OME Zarr validator',
     regex: /\.ome\.zarr$/,
     maxsize: Infinity,
-    endpoint: 'https://ome.github.io/ome-ngff-validator/?source=$s3_url$',
+    endpoint: 'https://ome.github.io/ome-ngff-validator/?source=$asset_s3_download_url$',
   },
 
   {
     name: 'Neurosift',
     regex: /\.nwb$/,
     maxsize: Infinity,
-    endpoint: 'https://flatironinstitute.github.io/neurosift?p=/nwb&url=$api_download_url$',
+    endpoint: 'https://flatironinstitute.github.io/neurosift?p=/nwb&url=$asset_api_download_url$',
   },
 ];
 type Service = typeof EXTERNAL_SERVICES[0];
@@ -402,8 +402,9 @@ function getExternalServices(path: AssetPath) {
     ? 'https://api-staging.dandiarchive.org'
     : 'https://api.dandiarchive.org';
   const substitutions = path.asset ? {
-    $s3_url$: trimEnd(path.asset.url, '/'),
-    $api_download_url$: `${baseApiUrl}/api/assets/${path.asset.asset_id}/download/`,
+    $asset_s3_download_url$: trimEnd(path.asset.url, '/'),
+    $asset_api_download_url$: `${baseApiUrl}/api/assets/${path.asset.asset_id}/download/`,
+    $asset_id$: path.asset.asset_id,
   } : undefined;
 
   return EXTERNAL_SERVICES

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -389,8 +389,6 @@ function replaceStringsInEndpoint(
   return result;
 }
 
-const isStaging = process.env.VUE_APP_SENTRY_ENVIRONMENT === 'staging';
-
 function getExternalServices(path: AssetPath) {
   const servicePredicate = (service: Service, _path: AssetPath) => (
     new RegExp(service.regex).test(path.path)
@@ -398,12 +396,11 @@ function getExternalServices(path: AssetPath) {
           && _path.aggregate_size <= service.maxsize
   );
 
-  const baseApiUrl = isStaging
-    ? 'https://api-staging.dandiarchive.org'
-    : 'https://api.dandiarchive.org';
+  const baseApiUrl = process.env.VUE_APP_DANDI_API_ROOT;
+
   const substitutions = path.asset ? {
     $asset_s3_download_url$: trimEnd(path.asset.url, '/'),
-    $asset_api_download_url$: `${baseApiUrl}/api/assets/${path.asset.asset_id}/download/`,
+    $asset_api_download_url$: `${baseApiUrl}assets/${path.asset.asset_id}/download/`,
     $asset_id$: path.asset.asset_id,
   } : undefined;
 

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -265,7 +265,7 @@ import axios from 'axios';
 
 import { dandiRest } from '@/rest';
 import { useDandisetStore } from '@/stores/dandiset';
-import type { AssetFile, AssetPath } from '@/types';
+import type { AssetPath } from '@/types';
 import FileBrowserPagination from '@/components/FileBrowser/FileBrowserPagination.vue';
 import FileUploadInstructions from '@/components/FileBrowser/FileUploadInstructions.vue';
 
@@ -410,7 +410,7 @@ function getExternalServices(path: AssetPath) {
     .filter((service) => servicePredicate(service, path))
     .map((service) => ({
       name: service.name,
-      url: replaceStringsInEndpoint(service.endpoint, substitutions)
+      url: replaceStringsInEndpoint(service.endpoint, substitutions),
     }));
 }
 

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -396,11 +396,11 @@ function getExternalServices(path: AssetPath) {
           && _path.aggregate_size <= service.maxsize
   );
 
-  const baseApiUrl = process.env.VUE_APP_DANDI_API_ROOT;
+  const baseApiUrl = trimEnd(process.env.VUE_APP_DANDI_API_ROOT, '/');
 
   const substitutions = path.asset ? {
     $asset_s3_download_url$: trimEnd(path.asset.url, '/'),
-    $asset_api_download_url$: `${baseApiUrl}assets/${path.asset.asset_id}/download/`,
+    $asset_api_download_url$: `${baseApiUrl}/assets/${path.asset.asset_id}/download/`,
     $asset_id$: path.asset.asset_id,
   } : undefined;
 


### PR DESCRIPTION
In light of this issue on neurosift
https://github.com/flatironinstitute/neurosift/issues/112

it is necessary to use the DANDI API asset download URL rather than the s3 bucket URL for the endpoint of the neurosift external service.

For example, here's an s3 bucket URL
https://dandiarchive.s3.amazonaws.com/blobs/d64/0c3/d640c378-7025-4c3b-a334-169ec3df4f3f

which corresponds to the following DANDI API download URL:
https://api.dandiarchive.org/api/assets/34a21ebe-c756-4da4-a30b-f1a838a6430b/download/

As described in the above quoted issue: In the cases of embargoed dandisets, it is necessary for neurosift to receive the API download URL so that it can use proper authentication to retrieve the signed download URL. The direct s3 bucket URL will never work.

This PR enables this, while still utilizing the s3 URL for the other services.

A detail about the modified code: While the s3 bucket url is directly available on the path.asset object, the api download url is not. So I needed to construct the url, and that required knowing whether or not it's the staging site.

In short, this PR is needed to allow Neurosift to be able to view assets from embargoed dandisets.