### PR TITLE
Pin django-storages temporarily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
         'django-composed-configuration[prod]>=0.22.0',
         # pin directly to a version since we're extending the private multipart interface
         'django-s3-file-field[boto3]==0.3.2',
-        'django-storages[boto3]',
+        # TODO: unpin this when dandi is updating for breaking changes
+        'django-storages[boto3]<=1.13.2',
         'gunicorn',
         # Development-only, but required
         # TODO: starting with v0.5.0, django-minio-storage requires v7


### PR DESCRIPTION
There is a breaking change in the latest release of `django-storages` that is causing CI to fail. For now, I've pinned it to the last working version in order to get CI unblocked while I debug this further.