### PR TITLE
Use correct asset download URL for external services

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -370,6 +370,7 @@ const updating = ref(false);
 // Computed
 const owners = computed(() => store.owners?.map((u) => u.username) || null);
 const currentDandiset = computed(() => store.dandiset);
+const embargoed = computed(() => currentDandiset.value && currentDandiset.value.dandiset.embargo_status === 'EMBARGOED');
 const splitLocation = computed(() => location.value.split('/'));
 const isAdmin = computed(() => dandiRest.user?.admin || false);
 const isOwner = computed(() => !!(
@@ -384,11 +385,16 @@ function getExternalServices(path: AssetPath) {
           && _path.aggregate_size <= service.maxsize
   );
 
+  const baseApiUrl = process.env.VUE_APP_DANDI_API_ROOT;
+  const assetURL = () => (embargoed.value
+    ? `${baseApiUrl}assets/${path.asset?.asset_id}/download/`
+    : trimEnd((path.asset as AssetFile).url, '/'));
+
   return EXTERNAL_SERVICES
     .filter((service) => servicePredicate(service, path))
     .map((service) => ({
       name: service.name,
-      url: `${service.endpoint}${trimEnd((path.asset as AssetFile).url, '/')}`,
+      url: `${service.endpoint}${assetURL()}`,
     }));
 }
 

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -370,7 +370,7 @@ const updating = ref(false);
 // Computed
 const owners = computed(() => store.owners?.map((u) => u.username) || null);
 const currentDandiset = computed(() => store.dandiset);
-const embargoed = computed(() => currentDandiset.value && currentDandiset.value.dandiset.embargo_status === 'EMBARGOED');
+const embargoed = computed(() => currentDandiset.value?.dandiset.embargo_status === 'EMBARGOED');
 const splitLocation = computed(() => location.value.split('/'));
 const isAdmin = computed(() => dandiRest.user?.admin || false);
 const isOwner = computed(() => !!(


### PR DESCRIPTION
When an external service is called from the file browser, the asset URL used is always the S3 URL, even in the case of an owner browsing an embargoed Dandiset. In the latter case, the S3 URL, which is _not_ presigned, does not allow general access to the asset, causing the external service to fail when it tries to retrieve the data.

This PR modifies the generation of that asset URL to emit the S3 URL for open Dandiset assets, and the internal DANDI API asset URL (which redirects to the correct presigned S3 URL) for embargoed Dandiset assets. (Note that the target external service must still authenticate to the DANDI server in order for this redirection to succeed; that in turn requires a design that supports using DANDI API keys, etc.)