### PR TITLE
Remove n+1 queries when using full_metadata

### DIFF
--- a/dandiapi/api/copy.py
+++ b/dandiapi/api/copy.py
@@ -48,7 +48,7 @@ class CopyObjectPart:
     dest_key: str
 
     # Whether or not to include the byte range in the request
-    # (exlcuded for single part copies)
+    # (excluded for single part copies)
     include_range: bool = True
 
     @property

--- a/dandiapi/api/manifests.py
+++ b/dandiapi/api/manifests.py
@@ -86,7 +86,9 @@ def write_dandiset_jsonld(version: Version):
 
 def write_assets_jsonld(version: Version):
     # Use full metadata when writing externally
-    assets_metadata = (asset.full_metadata for asset in version.assets.iterator())
+    assets_metadata = (
+        asset.full_metadata for asset in version.assets.select_related('blob', 'zarr').iterator()
+    )
     with streaming_file_upload(assets_jsonld_path(version)) as stream:
         stream.write('[')
         for i, obj in enumerate(assets_metadata):
@@ -120,7 +122,12 @@ def write_assets_yaml(version: Version):
         _yaml_dump_sequence_from_generator(
             stream,
             # Use full metadata when writing externally
-            (asset.full_metadata for asset in version.assets.order_by('created').iterator()),
+            (
+                asset.full_metadata
+                for asset in version.assets.select_related('blob', 'zarr')
+                .order_by('created')
+                .iterator()
+            ),
         )
 
 

--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -81,7 +81,9 @@ def version_aggregate_assets_summary(version: Version) -> None:
     version.metadata['assetsSummary'] = aggregate_assets_summary(
         (
             asset.full_metadata
-            for asset in version.assets.filter(status=Asset.Status.VALID).iterator()
+            for asset in version.assets.filter(status=Asset.Status.VALID)
+            .select_related('blob', 'zarr')
+            .iterator()
         )
     )
 

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -203,7 +203,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         for version in versions:
             version: Version
 
-            # Annnotate with total size and asset count (with default)
+            # Annotate with total size and asset count (with default)
             stats = version_stats.get(version.id, {'total_size': 0, 'num_assets': 0})
             version.total_size = stats['total_size']
             version.num_assets = stats['num_assets']

--- a/doc/design/publish-1.md
+++ b/doc/design/publish-1.md
@@ -116,7 +116,7 @@ This involves digesting the Version metadata into something that can be used by 
 See the doi-generation-1.md design document for more details.
 
 4. For every draft Asset in the draft Version, the required publish metadata fields are injected, turning those Assets into published Assets.
-Published Assets, e.g. Asssets that already have those fields from previous publishes, _are skipped_.
+Published Assets, e.g. Assets that already have those fields from previous publishes, _are skipped_.
 Because they describe Assets that have already been published in a past version, there is no reason to re-publish them.
 
 5. Associate all of the publish Assets, new and old, with the new published Version.


### PR DESCRIPTION
`full_metadata` can require reaching into the `blob` and `zarr` which can be costly for bigger versions.