### PR TITLE
Increase task timeouts for manifests/asset summaries

### DIFF
--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -32,7 +32,7 @@ def calculate_sha256(blob_id: str) -> None:
     asset_blob.save()
 
 
-@shared_task(soft_time_limit=60)
+@shared_task(soft_time_limit=180)
 @atomic
 def write_manifest_files(version_id: int) -> None:
     version: Version = Version.objects.get(id=version_id)

--- a/dandiapi/api/tasks/scheduled.py
+++ b/dandiapi/api/tasks/scheduled.py
@@ -43,7 +43,7 @@ def throttled_iterator(iterable: Iterable, max_per_second: int = 100) -> Iterabl
         time.sleep(1 / max_per_second)
 
 
-@shared_task(soft_time_limit=10)
+@shared_task(soft_time_limit=60)
 def aggregate_assets_summary_task(version_id: int):
     version = Version.objects.get(id=version_id)
     version_aggregate_assets_summary(version)


### PR DESCRIPTION
The length of these tasks has started creeping up (especially for dandiset 26). Increasing these timeouts in response to sentry timeout errors.