### PR TITLE
Add a note to registration page that no account is necessary to access public data

### DIFF
--- a/dandiapi/api/templates/api/account/questionnaire_form.html
+++ b/dandiapi/api/templates/api/account/questionnaire_form.html
@@ -2,6 +2,7 @@
 
 {% block body %}
   <h5>Welcome to DANDI! Please take a moment to fill out this form.</h5>
+  <h6><b>Note:</b> no account is necessary to access public data!</h6>
   <form method="POST" class="col s12">
     {% csrf_token %}
     {{ form }}

--- a/dandiapi/api/templates/api/account/questionnaire_form.html
+++ b/dandiapi/api/templates/api/account/questionnaire_form.html
@@ -2,7 +2,7 @@
 
 {% block body %}
   <h5>Welcome to DANDI! Please take a moment to fill out this form.</h5>
-  <h6><b>Note:</b> no account is necessary to access public data!</h6>
+  <h6><b>Note:</b> No account is necessary to access public data!</h6>
   <form method="POST" class="col s12">
     {% csrf_token %}
     {{ form }}


### PR DESCRIPTION
I think we start to get an increasing number of registration requests from people who are not intending to upload data to DANDI.  This explicit message might help to avoid those registration requests.