### PR TITLE
Prevent CHANGELOG.md from triggering staging deploy

### DIFF
--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths-ignore:
       - "web/**"
+      - "CHANGELOG.md"
 
 concurrency:
   # If this workflow is already running, cancel it to avoid a scenario


### PR DESCRIPTION
After #1679, the staging deploy that occurs during a release merge gets interrupted by a second staging deploy triggered by `auto`'s push to master containing the updated `CHANGELOG.md`.

This PR prevents that second deploy from running, avoiding a spurious deploy failure that happens when the first deploy is canceled.

Thanks to @mvandenburgh for helping me debug this problem.