### PR TITLE
Upgrade `dandischema` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'dandischema~=0.8.2',
+        'dandischema~=0.8.4',
         'django~=4.1.0',
         'django-admin-display',
         # TODO: unpin allauth when https://github.com/girder/django-composed-configuration/pull/189


### PR DESCRIPTION
Fixes #1702. 

#1702 was fixed in `dandischema` a while back with https://github.com/dandi/dandi-schema/pull/167 and a new version of `dandischema` was released, but we never bumped the version of `dandischema` in dandi-archive. 

Note this does not solve the underlying fake doi injection issue, but it will fix DOI creation on dandiarchive.org. As part of this, I will query for all published dandisets that do not have a DOI due to this bug and re-run the DOI generation on them.