### PR TITLE
File page index fix

### DIFF
--- a/web/src/components/FileBrowser/FileBrowserPagination.vue
+++ b/web/src/components/FileBrowser/FileBrowserPagination.vue
@@ -19,10 +19,9 @@
       <v-icon>mdi-chevron-left</v-icon>
     </v-btn>
     <v-text-field
-      v-model="pageInput"
+      v-model.number="pageInput"
       hide-details
       single-line
-      type="number"
       dense
       style="max-width: 5%;"
       class="pa-0 mx-2 my-0"
@@ -33,6 +32,7 @@
       :rules="[pageIsValid]"
       @change="emit('changePage', pageInput)"
     />
+
     <span>of {{ pageCount }}</span>
     <v-btn
       class="mx-2"
@@ -54,7 +54,8 @@
 </template>
 
 <script setup lang="ts">
-import { toRefs } from 'vue';
+import { toRef } from 'vue';
+import { useRoute } from 'vue-router/composables';
 
 const props = defineProps({
   page: {
@@ -67,12 +68,14 @@ const props = defineProps({
   },
 });
 
+const route = useRoute();
+
 function pageIsValid(page: number): boolean {
   return page > 0 && page <= props.pageCount;
 }
 
 const emit = defineEmits(['changePage']);
 
-const { page: pageInput } = toRefs(props);
+const pageInput = Number(route.query.page) || toRef(props, 'page');
 
 </script>

--- a/web/src/components/FileBrowser/FileBrowserPagination.vue
+++ b/web/src/components/FileBrowser/FileBrowserPagination.vue
@@ -31,6 +31,7 @@
       :max="pageCount"
       :maxlength="pageCount"
       :rules="[pageIsValid]"
+      @change="emit('changePage', pageInput)"
     />
     <span>of {{ pageCount }}</span>
     <v-btn
@@ -53,7 +54,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { toRefs } from 'vue';
 
 const props = defineProps({
   page: {
@@ -72,15 +73,6 @@ function pageIsValid(page: number): boolean {
 
 const emit = defineEmits(['changePage']);
 
-// Note: the v-textfield `v-model` returns a string value despite its type being 'number', so
-// we have to handle converting back and forth below.
-const pageInput = ref(props.page.toString());
+const { page: pageInput } = toRefs(props);
 
-watch(() => props.page, (newPage) => { pageInput.value = newPage.toString(); });
-watch(pageInput, (newPage) => {
-  const page = Number(newPage);
-  if (page > 0 && page <= props.pageCount) {
-    emit('changePage', page);
-  }
-});
 </script>

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -246,7 +246,7 @@
         v-if="currentDandiset.asset_count"
         :page="page"
         :page-count="pages"
-        @changePage="page = $event;"
+        @changePage="changePage($event)"
       />
     </v-container>
   </div>
@@ -502,7 +502,7 @@ watch(location, () => {
   if (existingLocation === location.value) { return; }
   router.push({
     ...route,
-    query: { location: location.value },
+    query: { location: location.value, page: String(page.value) },
   } as RawLocation);
 });
 
@@ -517,9 +517,13 @@ watch(() => route.query, (newRouteQuery) => {
   // Retrieve with new location
   getItems();
 }, { immediate: true });
-
-// fetch new page of items when a new one is selected
-watch(page, getItems);
+const changePage = (newPage: number) => {
+  page.value = newPage;
+  router.push({
+    ...route,
+    query: { location: location.value, page: String(page.value) },
+  } as RawLocation);
+};
 
 // Fetch dandiset if necessary
 onMounted(() => {

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -437,9 +437,10 @@ function showDelete(item: AssetPath) {
 async function getItems() {
   updating.value = true;
   let resp;
+  const currentPage = Number(route.query.page) || page.value;
   try {
     resp = await dandiRest.assetPaths(
-      props.identifier, props.version, location.value, page.value, FILES_PER_PAGE,
+      props.identifier, props.version, location.value, currentPage, FILES_PER_PAGE,
     );
   } catch (e) {
     if (axios.isAxiosError(e) && e.response?.status === 404) {

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -518,13 +518,14 @@ watch(() => route.query, (newRouteQuery) => {
   // Retrieve with new location
   getItems();
 }, { immediate: true });
-const changePage = (newPage: number) => {
+
+function changePage(newPage: number) {
   page.value = newPage;
   router.push({
     ...route,
     query: { location: location.value, page: String(page.value) },
   } as RawLocation);
-};
+}
 
 // Fetch dandiset if necessary
 onMounted(() => {


### PR DESCRIPTION
Closes #1677 
This PR adds the page index value to the route query.
Please also note that I removed a few watch statements in favor of reactive values as the watch statements were causing multiple calls with the added query value. I think its generally good practice to avoid watches when possible.