### PR TITLE
adjust neurosift service endpoint URL, passing additional info

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -381,7 +381,6 @@ const itemsNotFound = computed(() => items.value && !items.value.length);
 function serviceURL(endpoint: string, data: {
   dandisetId: string,
   dandisetVersion: string,
-  assetId: string,
   assetUrl: string,
   assetDandiUrl: string,
   assetS3Url: string,
@@ -389,7 +388,6 @@ function serviceURL(endpoint: string, data: {
   return endpoint
     .replaceAll('$dandiset_id$', data.dandisetId)
     .replaceAll('$dandiset_version$', data.dandisetVersion)
-    .replaceAll('$asset_id$', data.assetId)
     .replaceAll('$asset_url$', data.assetUrl)
     .replaceAll('$asset_dandi_url$', data.assetUrl)
     .replaceAll('$asset_s3_url$', data.assetUrl);
@@ -420,7 +418,6 @@ function getExternalServices(path: AssetPath, info: {dandisetId: string, dandise
       url: serviceURL(service.endpoint, {
         dandisetId: info.dandisetId,
         dandisetVersion: info.dandisetVersion,
-        assetId: path.asset?.asset_id || '',
         assetUrl,
         assetDandiUrl,
         assetS3Url,

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -378,7 +378,7 @@ const isOwner = computed(() => !!(
 ));
 const itemsNotFound = computed(() => items.value && !items.value.length);
 
-function filterServiceEndpoint(endpoint: string, o: {
+function serviceURL(endpoint: string, data: {
   dandisetId: string,
   dandisetVersion: string,
   assetId: string,
@@ -387,12 +387,12 @@ function filterServiceEndpoint(endpoint: string, o: {
   assetS3Url: string,
 }) {
   return endpoint
-    .replace(/\$dandiset_id\$/g, o.dandisetId)
-    .replace(/\$dandiset_version\$/g, o.dandisetVersion)
-    .replace(/\$asset_id\$/g, o.assetId)
-    .replace(/\$asset_url\$/g, o.assetUrl)
-    .replace(/\$asset_dandi_url\$/g, o.assetUrl)
-    .replace(/\$asset_s3_url\$/g, o.assetUrl);
+    .replace(/\$dandiset_id\$/g, data.dandisetId)
+    .replace(/\$dandiset_version\$/g, data.dandisetVersion)
+    .replace(/\$asset_id\$/g, data.assetId)
+    .replace(/\$asset_url\$/g, data.assetUrl)
+    .replace(/\$asset_dandi_url\$/g, data.assetUrl)
+    .replace(/\$asset_s3_url\$/g, data.assetUrl);
 }
 
 function getExternalServices(path: AssetPath, info: {dandisetId: string, dandisetVersion: string}) {
@@ -417,7 +417,7 @@ function getExternalServices(path: AssetPath, info: {dandisetId: string, dandise
     .filter((service) => servicePredicate(service, path))
     .map((service) => ({
       name: service.name,
-      url: filterServiceEndpoint(service.endpoint, {
+      url: serviceURL(service.endpoint, {
         dandisetId: info.dandisetId,
         dandisetVersion: info.dandisetVersion,
         assetId: path.asset?.asset_id || '',

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -387,12 +387,12 @@ function serviceURL(endpoint: string, data: {
   assetS3Url: string,
 }) {
   return endpoint
-    .replace(/\$dandiset_id\$/g, data.dandisetId)
-    .replace(/\$dandiset_version\$/g, data.dandisetVersion)
-    .replace(/\$asset_id\$/g, data.assetId)
-    .replace(/\$asset_url\$/g, data.assetUrl)
-    .replace(/\$asset_dandi_url\$/g, data.assetUrl)
-    .replace(/\$asset_s3_url\$/g, data.assetUrl);
+    .replaceAll('$dandiset_id$', data.dandisetId)
+    .replaceAll('$dandiset_version$', data.dandisetVersion)
+    .replaceAll('$asset_id$', data.assetId)
+    .replaceAll('$asset_url$', data.assetUrl)
+    .replaceAll('$asset_dandi_url$', data.assetUrl)
+    .replaceAll('$asset_s3_url$', data.assetUrl);
 }
 
 function getExternalServices(path: AssetPath, info: {dandisetId: string, dandisetVersion: string}) {


### PR DESCRIPTION
This adjusts the external endpoint URL for neurosift such that it:
* always provides the version of the asset URL that includes that asset ID (rather than just doing this for embargoed dandisets)
* provides the dandiset ID and version

This is information I would like to have access to on the neurosift end.

I tried to do this in the most straightforward way I could -- if adjustments are needed in the future I think it wouldn't be a problem since it only affects the one file. But if there is a better way @waxlamp, feel free to suggest.

The other external services should work the same as they did before.

I realize that this is related to https://github.com/dandi/dandi-archive/pull/1655 but I wanted to start from the latest commit that includes the other related changes from https://github.com/dandi/dandi-archive/pull/1692