### PR TITLE
Remove pinning on django-storages[boto3]

### DIFF
--- a/dandiapi/api/copy.py
+++ b/dandiapi/api/copy.py
@@ -8,10 +8,10 @@ from django.conf import settings
 from dandiapi.api.storage import get_boto_client
 
 try:
-    from storages.backends.s3boto3 import S3Boto3Storage
+    from storages.backends.s3 import S3Storage
 except ImportError:
     # This should only be used for type interrogation, never instantiation
-    S3Boto3Storage = type('FakeS3Boto3Storage', (), {})
+    S3Storage = type('FakeS3Storage', (), {})
 try:
     from minio_storage.storage import MinioStorage
 except ImportError:

--- a/dandiapi/api/management/commands/cleanup_blobs.py
+++ b/dandiapi/api/management/commands/cleanup_blobs.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 import djclick as click
-from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.s3 import S3Storage
 
 from dandiapi.api.models.upload import AssetBlob
 
@@ -8,7 +8,7 @@ BUCKET = settings.DANDI_DANDISETS_BUCKET_NAME
 
 
 def s3_client():
-    storage = S3Boto3Storage(bucket_name=BUCKET)
+    storage = S3Storage(bucket_name=BUCKET)
     return storage.connection.meta.client
 
 

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -12,10 +12,10 @@ from dandiapi.api.services.asset.exceptions import DraftDandisetNotModifiable
 from dandiapi.zarr.models import ZarrArchive
 
 try:
-    from storages.backends.s3boto3 import S3Boto3Storage
+    from storages.backends.s3 import S3Storage
 except ImportError:
     # This should only be used for type interrogation, never instantiation
-    S3Boto3Storage = type('FakeS3Boto3Storage', (), {})
+    S3Storage = type('FakeS3Storage', (), {})
 try:
     from minio_storage.storage import MinioStorage
 except ImportError:

--- a/dandiapi/conftest.py
+++ b/dandiapi/conftest.py
@@ -4,7 +4,7 @@ from minio_storage.storage import MinioStorage
 import pytest
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
-from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.s3 import S3Storage
 
 from dandiapi.api.storage import create_s3_storage
 from dandiapi.api.tests.factories import (
@@ -84,7 +84,7 @@ def authenticated_api_client(user) -> APIClient:
 # storage fixtures are copied from django-s3-file-field test fixtures
 
 
-def base_s3boto3_storage_factory(bucket_name: str) -> 'S3Boto3Storage':
+def base_s3boto3_storage_factory(bucket_name: str) -> 'S3Storage':
     return create_s3_storage(bucket_name)
 
 
@@ -109,12 +109,12 @@ def embargoed_minio_storage_factory() -> MinioStorage:
 
 
 @pytest.fixture
-def s3boto3_storage() -> 'S3Boto3Storage':
+def s3boto3_storage() -> 'S3Storage':
     return s3boto3_storage_factory()
 
 
 @pytest.fixture
-def embargoed_s3boto3_storage() -> 'S3Boto3Storage':
+def embargoed_s3boto3_storage() -> 'S3Storage':
     return s3boto3_storage_factory()
 
 
@@ -132,7 +132,7 @@ def embargoed_minio_storage() -> MinioStorage:
 def storage(request, settings) -> Storage:
     storage_factory = request.param
     if storage_factory == s3boto3_storage_factory:
-        settings.DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        settings.DEFAULT_FILE_STORAGE = 'storages.backends.s3.S3Storage'
         settings.AWS_S3_ACCESS_KEY_ID = settings.MINIO_STORAGE_ACCESS_KEY
         settings.AWS_S3_SECRET_ACCESS_KEY = settings.MINIO_STORAGE_SECRET_KEY
         settings.AWS_S3_REGION_NAME = 'test-region'

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'django-composed-configuration[prod]>=0.22.0',
         # pin directly to a version since we're extending the private multipart interface
         'django-s3-file-field[boto3]==0.3.2',
-        'django-storages[boto3]>=1.14.2',
+        'django-storages[s3]>=1.14.2',
         'gunicorn',
         # Development-only, but required
         # TODO: starting with v0.5.0, django-minio-storage requires v7

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,7 @@ setup(
         'django-composed-configuration[prod]>=0.22.0',
         # pin directly to a version since we're extending the private multipart interface
         'django-s3-file-field[boto3]==0.3.2',
-        # TODO: unpin this when dandi is updating for breaking changes
-        'django-storages[boto3]<=1.13.2',
+        'django-storages[boto3]>=1.14.2',
         'gunicorn',
         # Development-only, but required
         # TODO: starting with v0.5.0, django-minio-storage requires v7


### PR DESCRIPTION
The bug that mandated pinning this dependency (#1691) has been fixed in the latest release of `django-storages` ([here's the changelog entry](https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#s3)), so we can remove the pinning.

Additionally, the latest minor release of `django-storages` also deprecates `storages.backends.s3boto3.S3Boto3Storage` in favor of `storages.backends.s3.S3Storage`, as well as changes the install extra from `[boto3]` to `[s3]`, ([changelog entry](https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#s3-2)), so I went ahead and made those changes here as well.