### PR TITLE
Remove unnecessary atomic decorators from tasks

### DIFF
--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -103,12 +103,12 @@ def _publish_dandiset(dandiset_id: int) -> None:
 
     Calling `_lock_dandiset_for_publishing()` is a precondition for calling this function.
     """
-    old_version: Version = Version.objects.select_for_update().get(
-        dandiset_id=dandiset_id,
-        version='draft',
-    )
-
     with transaction.atomic():
+        old_version: Version = Version.objects.select_for_update().get(
+            dandiset_id=dandiset_id,
+            version='draft',
+        )
+
         if old_version.status != Version.Status.PUBLISHING:
             raise DandisetNotLocked(
                 'Dandiset must be in PUBLISHING state. Call `_lock_dandiset_for_publishing()` '

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -1,6 +1,5 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
-from django.db.transaction import atomic
 
 from dandiapi.api.doi import delete_doi
 from dandiapi.api.manifests import (
@@ -33,7 +32,6 @@ def calculate_sha256(blob_id: str) -> None:
 
 
 @shared_task(soft_time_limit=180)
-@atomic
 def write_manifest_files(version_id: int) -> None:
     version: Version = Version.objects.get(id=version_id)
     logger.info('Writing manifests for version %s:%s', version.dandiset.identifier, version.version)
@@ -46,7 +44,6 @@ def write_manifest_files(version_id: int) -> None:
 
 
 @shared_task(soft_time_limit=10)
-@atomic
 def validate_asset_metadata_task(asset_id: int) -> None:
     from dandiapi.api.services.metadata import validate_asset_metadata
 
@@ -56,7 +53,6 @@ def validate_asset_metadata_task(asset_id: int) -> None:
 
 
 @shared_task(soft_time_limit=30)
-@atomic
 def validate_version_metadata_task(version_id: int) -> None:
     from dandiapi.api.services.metadata import validate_version_metadata
 
@@ -78,7 +74,6 @@ def unembargo_dandiset_task(dandiset_id: int):
 
 
 @shared_task
-@atomic
 def publish_dandiset_task(dandiset_id: int):
     from dandiapi.api.services.publish import _publish_dandiset
 


### PR DESCRIPTION
I don't think the `atomic` decorator actually does anything for these task functions, but please correct me if I'm missing something @danlamanna @AlmightyYakob. 
Any complex operations that do need to be atomic are already wrapped in an `atomic` block inside the service layer functions that the tasks are calling.