### PR TITLE
Clean up handling of missing `DOI_API_PREFIX` setting

### DIFF
--- a/dandiapi/api/doi.py
+++ b/dandiapi/api/doi.py
@@ -22,8 +22,7 @@ def _generate_doi_data(version: Version):
     from dandischema.datacite import to_datacite
 
     publish = settings.DANDI_DOI_PUBLISH
-    # Use the DANDI test datacite instance as a placeholder if PREFIX isn't set
-    prefix = settings.DANDI_DOI_API_PREFIX or '10.80507'
+    prefix = settings.DANDI_DOI_API_PREFIX
     dandiset_id = version.dandiset.identifier
     version_id = version.version
     doi = f'{prefix}/dandi.{dandiset_id}/{version_id}'

--- a/dandiapi/api/doi.py
+++ b/dandiapi/api/doi.py
@@ -21,8 +21,8 @@ def doi_configured() -> bool:
 def _generate_doi_data(version: Version):
     from dandischema.datacite import to_datacite
 
-    publish = settings.DANDI_DOI_PUBLISH
-    prefix = settings.DANDI_DOI_API_PREFIX
+    publish: bool = settings.DANDI_DOI_PUBLISH
+    prefix: str = settings.DANDI_DOI_API_PREFIX
     dandiset_id = version.dandiset.identifier
     version_id = version.version
     doi = f'{prefix}/dandi.{dandiset_id}/{version_id}'

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -110,7 +110,7 @@ class DandiMixin(ConfigMixin):
     DANDI_DOI_API_URL = values.URLValue(environ=True)
     DANDI_DOI_API_USER = values.Value(environ=True)
     DANDI_DOI_API_PASSWORD = values.Value(environ=True)
-    DANDI_DOI_API_PREFIX = values.Value(environ=True)
+    DANDI_DOI_API_PREFIX = values.Value(environ_required=True)
     DANDI_DOI_PUBLISH = values.BooleanValue(environ=True, default=False)
     DANDI_WEB_APP_URL = values.URLValue(environ_required=True)
     DANDI_API_URL = values.URLValue(environ_required=True)
@@ -151,6 +151,9 @@ class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
         'from dandiapi.api.mail import *',
     ]
 
+    # Use the DANDI test datacite instance as a placeholder
+    DANDI_DOI_API_PREFIX = '10.80507'
+
 
 class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
     DANDI_DANDISETS_BUCKET_NAME = 'test-dandiapi-dandisets'
@@ -161,6 +164,8 @@ class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
     DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME = 'test-embargo-dandiapi-dandisets-logs'
     DANDI_ZARR_PREFIX_NAME = 'test-zarr'
     DANDI_JUPYTERHUB_URL = 'https://hub.dandiarchive.org/'
+    # Use the DANDI test datacite instance as a placeholder
+    DANDI_DOI_API_PREFIX = '10.80507'
 
     # This makes the dandischema pydantic model allow URLs with localhost in them.
     DANDI_ALLOW_LOCALHOST_URLS = True


### PR DESCRIPTION
This setting should never be unset in a real deployment of DANDI, so silently replacing it with a default if it's missing is not ideal. 
Instead, this PR changes it so that things fail loudly and raise and error if this setting is not supplied in an env var. In dev/testing configurations it is still hardcoded to the placeholder value, but this is done at the Django setting layer instead of directly in the application code.