### PR TITLE
Optimize dandiset listing endpoint

### DIFF
--- a/dandiapi/api/asset_paths.py
+++ b/dandiapi/api/asset_paths.py
@@ -31,16 +31,20 @@ def extract_paths(path: str) -> list[str]:
     return nodepaths
 
 
-def get_root_paths_many(versions: QuerySet[Version]) -> QuerySet[AssetPath]:
+def get_root_paths_many(versions: QuerySet[Version], join_assets=False) -> QuerySet[AssetPath]:
     """Return all root paths for all provided versions."""
+    qs = AssetPath.objects.get_queryset()
+
     # Use prefetch_related here instead of select_related,
     # as otherwise the resulting join is very large
-    qs = AssetPath.objects.prefetch_related(
-        'asset',
-        'asset__blob',
-        'asset__embargoed_blob',
-        'asset__zarr',
-    )
+    if join_assets:
+        qs = qs.prefetch_related(
+            'asset',
+            'asset__blob',
+            'asset__embargoed_blob',
+            'asset__zarr',
+        )
+
     return qs.filter(version__in=versions).exclude(path__contains='/').order_by('path')
 
 

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -178,7 +178,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             for entry in get_root_paths_many(versions=relevant_versions)
             .values('version_id')
             .annotate(total_size=Sum('aggregate_size'), num_assets=Sum('aggregate_files'))
-            .order_by('version_id')
+            .order_by()
         }
 
         def annotate_version(version: Version):


### PR DESCRIPTION
This reduces the load time of the dandiset listing endpoint by optimizing the `_get_dandiset_to_version_map` function. This means the search endpoint should also experience a slight performance improvement, since it also uses that function.

The optimization is accomplished with the following changes:
1. Removes an unnecessary query being made in the `get_root_paths_many` function
2. Shifts the version stats aggregation to be done in postgres, making it more efficient
3. Optimize the query for retrieving the latest version. Similar to the other optimized query, this leverages postgres aggregation to efficiently return the latest published versions for all relevant dandisets
4. Use two smaller queries instead of one union-ed query when retrieving drafts and published versions, to take advantage of the last published version optimization.