### PR TITLE
Update `django-composed-configuration`

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -39,13 +39,6 @@ class DandiMixin(ConfigMixin):
             'dandiapi.zarr.apps.ZarrConfig',
         ] + configuration.INSTALLED_APPS
 
-        # TODO: remove this when the upstream fix is merged
-        # (https://github.com/girder/django-composed-configuration/pull/189)
-        if 'allauth.account.middleware.AccountMiddleware' not in configuration.MIDDLEWARE:
-            configuration.MIDDLEWARE += [
-                'allauth.account.middleware.AccountMiddleware',
-            ]
-
         # Install guardian
         configuration.INSTALLED_APPS += ['guardian']
 

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,6 @@ setup(
         'dandischema~=0.8.4',
         'django~=4.1.0',
         'django-admin-display',
-        # TODO: unpin allauth when https://github.com/girder/django-composed-configuration/pull/189
-        # is merged and released
-        'django-allauth>=0.56.1',
         'django-allauth',
         'django-click',
         'django-configurations[database,email]',

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         # TODO: unpin allauth when https://github.com/girder/django-composed-configuration/pull/189
         # is merged and released
         'django-allauth>=0.56.1',
+        'django-allauth',
         'django-click',
         'django-configurations[database,email]',
         'django-extensions',
@@ -63,7 +64,7 @@ setup(
         's3-log-parse',
         'zarr-checksum>=0.2.8',
         # Production-only
-        'django-composed-configuration[prod]>=0.22.0',
+        'django-composed-configuration[prod]>=0.23.0',
         # pin directly to a version since we're extending the private multipart interface
         'django-s3-file-field[boto3]==0.3.2',
         'django-storages[s3]>=1.14.2',
@@ -79,7 +80,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            'django-composed-configuration[dev]>=0.22.0',
+            'django-composed-configuration[dev]>=0.23.0',
             'django-debug-toolbar',
             'django-s3-file-field[minio]',
             'ipython',


### PR DESCRIPTION
This reverts the change in this PR https://github.com/dandi/dandi-archive/pull/1678, now that the relevant fix has been upstreamed to composed configuration.