### PR TITLE
Revert "Skip broken dandi-cli tests" - fixed up in dandi-cli 0.57.0

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run dandi-api tests in dandi-cli
         run: |
-          python -m pytest --dandi-api -k "not test_update_dandiset_from_doi" \
+          python -m pytest --dandi-api \
             "$pythonLocation/lib/python${{ matrix.python }}/site-packages/dandi"
         env:
           DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"


### PR DESCRIPTION
This reverts commit 56969e5ea371191a199cba2bc9dbfb8ece28f5e8.

That test was adjusted for becoming compatible with recent python/vcr and marked xfailed on older ones. See
https://github.com/dandi/dandi-cli/pull/1337
which was released in dandi-cli 0.57.0 .

As such, custom skip is no longer needed here.