### PR TITLE
Optimize dandiset owner PUT endpoint

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -372,7 +372,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             serializer = UserSerializer(data=request.data, many=True)
             serializer.is_valid(raise_exception=True)
 
-            def get_user_or_400(username):
+            def get_user_or_400(username: str) -> User:
                 try:
                     return (
                         SocialAccount.objects.select_related('user')

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -374,13 +374,11 @@ class DandisetViewSet(ReadOnlyModelViewSet):
 
             def get_user_or_400(username):
                 try:
-                    return User.objects.alias(
-                        social_account_username=Subquery(
-                            SocialAccount.objects.filter(user_id=OuterRef('id')).values(
-                                'extra_data__login'
-                            )[:1]
-                        )
-                    ).get(social_account_username=username)
+                    return (
+                        SocialAccount.objects.select_related('user')
+                        .get(extra_data__login=username)
+                        .user
+                    )
                 except ObjectDoesNotExist:
                     try:
                         return User.objects.get(username=username)

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -1,6 +1,5 @@
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Max, OuterRef, Subquery, Sum
 from django.db.models.functions import Coalesce
 from django.db.models.query_utils import Q
@@ -372,25 +371,31 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             serializer = UserSerializer(data=request.data, many=True)
             serializer.is_valid(raise_exception=True)
 
-            def get_user_or_400(username: str) -> User:
-                try:
-                    return (
-                        SocialAccount.objects.select_related('user')
-                        .get(extra_data__login=username)
-                        .user
-                    )
-                except ObjectDoesNotExist:
-                    try:
-                        return User.objects.get(username=username)
-                    except ObjectDoesNotExist:
-                        raise ValidationError(f'User {username} not found')
-
-            owners = [
-                get_user_or_400(username=owner['username']) for owner in serializer.validated_data
-            ]
-            if len(owners) < 1:
+            # Ensure not all owners removed
+            if not serializer.validated_data:
                 raise ValidationError('Cannot remove all draft owners')
 
+            # Get all owners that have the provided username in one of the two possible locations
+            usernames = [owner['username'] for owner in serializer.validated_data]
+            user_owners = list(User.objects.filter(username__in=usernames))
+            socialaccount_owners = list(
+                SocialAccount.objects.select_related('user').filter(extra_data__login__in=usernames)
+            )
+
+            # Check that all owners were found
+            if len(user_owners) + len(socialaccount_owners) < len(usernames):
+                username_set = {
+                    *(user.username for user in user_owners),
+                    *(owner.extra_data['login'] for owner in socialaccount_owners),
+                }
+
+                # Raise exception on first username in list that's not found
+                for username in usernames:
+                    if username not in username_set:
+                        raise ValidationError(f'User {username} not found')
+
+            # All owners found
+            owners = user_owners + [acc.user for acc in socialaccount_owners]
             removed_owners, added_owners = dandiset.set_owners(owners)
             dandiset.save()
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,9 @@ setup(
         'dandischema~=0.8.4',
         'django~=4.1.0',
         'django-admin-display',
-        'django-allauth',
+        # Require 0.58.0 as it is the first version to support postgres' native
+        # JSONField for SocialAccount.extra_data
+        'django-allauth>=0.58.0',
         'django-click',
         'django-configurations[database,email]',
         'django-extensions',


### PR DESCRIPTION
Now that django-allauth uses a regular JSONField for `SocialAccount.extra_data`, we can optimize the dandisets owner PUT endpoint to be more efficient and do less SQL queries. See release notes for allauth here https://github.com/pennersr/django-allauth/blob/main/ChangeLog.rst#0580-2023-10-26