### PR TITLE
Fix PTH118 `os.path.join()` should be replaced by `Path` with `/` operator

### DIFF
--- a/dandiapi/api/asset_paths.py
+++ b/dandiapi/api/asset_paths.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
 from django.db import IntegrityError, transaction
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 def extract_paths(path: str) -> list[str]:
     nodepaths: list[str] = path.split('/')
     for i in range(len(nodepaths))[1:]:
-        nodepaths[i] = os.path.join(nodepaths[i - 1], nodepaths[i])
+        nodepaths[i] = f'{nodepaths[i - 1]}/{nodepaths[i]}'
 
     return nodepaths
 

--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -1,5 +1,3 @@
-import os
-
 from django.conf import settings
 from drf_yasg.utils import no_body, swagger_auto_schema
 from rest_framework import serializers
@@ -56,7 +54,7 @@ class ApiInfoSerializer(serializers.Serializer):
 )
 @api_view()
 def info_view(self):
-    api_url = os.path.join(settings.DANDI_API_URL, 'api')
+    api_url = f'{settings.DANDI_API_URL}/api'
     serializer = ApiInfoSerializer(
         data={
             'schema_version': settings.DANDI_SCHEMA_VERSION,


### PR DESCRIPTION
The actual problem here is inappropriate use of `os.path.join` for joining components of a URL (which should always use `/`, not an OS-dependent delimiter).

Joining the components with f-strings matches the way other parts of the code create URLs.

Future work could use some URL library to manipulate URLs, but that's out of scope of this fix.