### PR TITLE
Fix G004 Logging statement uses f-string

### DIFF
--- a/dandiapi/analytics/tasks/__init__.py
+++ b/dandiapi/analytics/tasks/__init__.py
@@ -93,7 +93,7 @@ def process_s3_log_file_task(bucket: LogBucket, s3_log_key: str) -> None:
             log.save()
         except IntegrityError as e:
             if 'unique_name_embargoed' in str(e):
-                logger.info(f'Already processed log file {s3_log_key}, embargo: {embargoed}')
+                logger.info('Already processed log file %s, embargo: %s', s3_log_key, embargoed)
             return
 
         # note this task is run serially per log file. this is to avoid the contention between

--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -92,7 +92,7 @@ def build_registered_message(user: User, socialaccount: SocialAccount):
 
 
 def send_registered_notice_email(user: User, socialaccount: SocialAccount):
-    logger.info(f'Sending registration message to {user}')
+    logger.info('Sending registration message to %s', user)
     messages = [build_registered_message(user, socialaccount)]
     with mail.get_connection() as connection:
         connection.send_messages(messages)
@@ -112,7 +112,7 @@ def build_new_user_messsage(user: User, socialaccount: SocialAccount = None):
 
 
 def send_new_user_message_email(user: User, socialaccount: SocialAccount):
-    logger.info(f'Sending new user message for {user} to admins')
+    logger.info('Sending new user message for %s to admins', user)
     messages = [build_new_user_messsage(user, socialaccount)]
     with mail.get_connection() as connection:
         connection.send_messages(messages)
@@ -133,7 +133,7 @@ def build_approved_user_message(user: User, socialaccount: SocialAccount = None)
 
 
 def send_approved_user_message(user: User, socialaccount: SocialAccount):
-    logger.info(f'Sending approved user message to {user}')
+    logger.info('Sending approved user message to %s', user)
     messages = [build_approved_user_message(user, socialaccount)]
     with mail.get_connection() as connection:
         connection.send_messages(messages)
@@ -154,7 +154,7 @@ def build_rejected_user_message(user: User, socialaccount: SocialAccount = None)
 
 
 def send_rejected_user_message(user: User, socialaccount: SocialAccount):
-    logger.info(f'Sending rejected user message to {user}')
+    logger.info('Sending rejected user message to %s', user)
     messages = [build_rejected_user_message(user, socialaccount)]
     with mail.get_connection() as connection:
         connection.send_messages(messages)
@@ -170,7 +170,7 @@ def build_pending_users_message(users: Iterable[User]):
 
 
 def send_pending_users_message(users: Iterable[User]):
-    logger.info(f'Sending pending users message to admins at {ADMIN_EMAIL}')
+    logger.info('Sending pending users message to admins at %s', ADMIN_EMAIL)
     messages = [build_pending_users_message(users)]
     with mail.get_connection() as connection:
         connection.send_messages(messages)

--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -18,10 +18,10 @@ logger = get_task_logger(__name__)
 def calculate_sha256(blob_id: str) -> None:
     try:
         asset_blob = AssetBlob.objects.get(blob_id=blob_id)
-        logger.info(f'Found AssetBlob {blob_id}')
+        logger.info('Found AssetBlob %s', blob_id)
     except AssetBlob.DoesNotExist:
         asset_blob = EmbargoedAssetBlob.objects.get(blob_id=blob_id)
-        logger.info(f'Found EmbargoedAssetBlob {blob_id}')
+        logger.info('Found EmbargoedAssetBlob %s', blob_id)
 
     sha256 = asset_blob.blob.storage.sha256_checksum(asset_blob.blob.name)
 

--- a/dandiapi/api/user_migration.py
+++ b/dandiapi/api/user_migration.py
@@ -13,9 +13,9 @@ def copy_ownership(placeholder_user, user):
     from dandiapi.api.models import Dandiset
 
     owned_dandisets = get_objects_for_user(placeholder_user, 'owner', Dandiset)
-    logger.info(f'{placeholder_user} owns {owned_dandisets}')
+    logger.info('%s owns %s', placeholder_user, owned_dandisets)
     for dandiset in owned_dandisets:
-        logger.info(f'Moving ownership on {dandiset.identifier}')
+        logger.info('Moving ownership on %s', dandiset.identifier)
         assign_perm('owner', user, dandiset)
         remove_perm('owner', placeholder_user, dandiset)
 
@@ -31,10 +31,10 @@ def depose_placeholder(user):
         # No placeholder user, nothing to do
         return
 
-    logger.info(f'Replacing {placeholder_user} with {user}')
+    logger.info('Replacing %s with %s', placeholder_user, user)
     copy_ownership(placeholder_user, user)
     # The placeholder user has no further purpose, delete it
-    logger.info(f'Deleting {placeholder_user}')
+    logger.info('Deleting %s', placeholder_user)
     placeholder_user.delete()
 
 

--- a/dandiapi/zarr/tasks/__init__.py
+++ b/dandiapi/zarr/tasks/__init__.py
@@ -37,7 +37,7 @@ def ingest_zarr_archive(zarr_id: str, force: bool = False):
         delete_zarr_paths(zarr)
 
         # Instantiate updater and add files as they come in
-        logger.info(f'Computing checksum for zarr {zarr.zarr_id}...')
+        logger.info('Computing checksum for zarr %s...', zarr.zarr_id)
         storage_params = get_storage_params(zarr.storage)
         checksum = compute_zarr_checksum(
             yield_files_s3(

--- a/dandiapi/zarr/views/__init__.py
+++ b/dandiapi/zarr/views/__init__.py
@@ -279,7 +279,7 @@ class ZarrViewSet(ReadOnlyModelViewSet):
             serializer.is_valid(raise_exception=True)
 
             # Generate presigned urls
-            logger.info(f'Beginning upload to zarr archive {zarr_archive.zarr_id}')
+            logger.info('Beginning upload to zarr archive %s', zarr_archive.zarr_id)
             urls = zarr_archive.generate_upload_urls(serializer.validated_data)
 
             # Set status back to pending, since with these URLs the zarr could have been changed
@@ -287,7 +287,9 @@ class ZarrViewSet(ReadOnlyModelViewSet):
             zarr_archive.save()
 
         # Return presigned urls
-        logger.info(f'Presigned {len(urls)} URLs to upload to zarr archive {zarr_archive.zarr_id}')
+        logger.info(
+            'Presigned %d URLs to upload to zarr archive %s', len(urls), zarr_archive.zarr_id
+        )
         return Response(urls, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(


### PR DESCRIPTION
See https://docs.astral.sh/ruff/rules/logging-f-string/ for the basic rationale.

However, this is particularly relevant to the use of Sentry. By ensuring variable parts of the log message are always passed as parameters, it is much more likely that Sentry consolidate multiple events with different parameters into the same issue.