### PR TITLE
Fix invalid contributors causing crash

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -137,7 +137,7 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
         version = metadata['version']
         # If we can't find any contributors, use this citation format
         citation = f'{name} ({year}). (Version {version}) [Data set]. DANDI archive. {url}'
-        if 'contributor' in metadata and metadata['contributor']:
+        if 'contributor' in metadata and isinstance(metadata['contributor'], list):
             cl = '; '.join(
                 [
                     val['name']

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -1010,3 +1010,19 @@ def test_dandiset_rest_search_identifier(api_client, draft_version):
 
     assert results[0]['draft_version']['version'] == draft_version.version
     assert results[0]['draft_version']['name'] == draft_version.name
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    'contributors',
+    [None, 'string', 1, [], {}],
+)
+def test_dandiset_contact_person_malformed_contributors(api_client, draft_version, contributors):
+    draft_version.metadata['contributor'] = contributors
+    draft_version.save()
+
+    results = api_client.get(
+        f'/api/dandisets/{draft_version.dandiset.identifier}/',
+    )
+
+    assert results.data['draft_version']['dandiset']['contact_person'] == ''

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -10,11 +10,11 @@ from dandiapi.api.models import Asset, AssetBlob, AssetPath, Dandiset, Version
 from dandiapi.search.models import AssetSearch
 
 
-def extract_contact_person(version):
+def extract_contact_person(version: Version) -> str:
     """Extract a version's contact person from its metadata."""
     # TODO: move this logic into dandischema since it is schema-dependant
     contributors = version.metadata.get('contributor')
-    if contributors is not None:
+    if contributors is not None and isinstance(contributors, list):
         for contributor in contributors:
             name = contributor.get('name')
             role_names = contributor.get('roleName')


### PR DESCRIPTION
Currently, we assume that `Version.metadata['contributors']` is a list of JSON objects. This holds true for any metadata uploaded by the DANDI CLI, but there's nothing preventing users from uploading arbitrary JSON. Invalid metadata will be marked as invalid, but there's some places in the code where we assume it's valid anyway which results in a crash. This PR adds some additional checks to those places to avoid outright crashes.

Closes #1769 