### PR TITLE
Convert `rest.ts` to composition API

### DIFF
--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -94,7 +94,7 @@
     <div v-if="!insideIFrame">
       <template v-if="loggedIn">
         <v-btn
-          :disabled="!dandiRest.user?.approved"
+          :disabled="!user?.approved"
           :to="{ name: 'createDandiset' }"
           exact
           class="mx-3"
@@ -139,6 +139,7 @@ import {
   loggedIn as loggedInFunc,
   insideIFrame as insideIFrameFunc,
   dandiRest,
+  user,
 } from '@/rest';
 import {
   dandiAboutUrl, dandiDocumentationUrl, dandiHelpUrl, dandihubUrl,

--- a/web/src/components/AppBar/UserMenu.vue
+++ b/web/src/components/AppBar/UserMenu.vue
@@ -21,17 +21,17 @@
     >
       <v-list-item>
         <v-list-item-content>
-          <span v-if="dandiRest.user">
+          <span v-if="user">
             You are logged in as <a
-              :href="`https://github.com/${dandiRest.user.username}`"
+              :href="`https://github.com/${user.username}`"
               target="_blank"
               rel="noopener"
-              v-text="dandiRest.user.username"
+              v-text="user.username"
             />.
           </span>
         </v-list-item-content>
       </v-list-item>
-      <ApiKeyItem v-if="dandiRest.user?.approved" />
+      <ApiKeyItem v-if="user?.approved" />
       <v-list-item @click="logout">
         <v-list-item-content>
           Logout
@@ -47,10 +47,9 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-import { user as userFunc, dandiRest } from '@/rest';
+import { user, dandiRest } from '@/rest';
 import ApiKeyItem from '@/components/AppBar/ApiKeyItem.vue';
 
-const user = computed(userFunc);
 const userInitials = computed(() => {
   if (user.value) {
     const { name } = user.value;

--- a/web/src/components/DLP/DandisetOwnersDialog.vue
+++ b/web/src/components/DLP/DandisetOwnersDialog.vue
@@ -214,7 +214,7 @@
 <script lang="ts">
 import { debounce } from 'lodash';
 
-import { dandiRest } from '@/rest';
+import { dandiRest, user } from '@/rest';
 import { useDandisetStore } from '@/stores/dandiset';
 import type { Ref } from 'vue';
 import {
@@ -285,7 +285,6 @@ export default defineComponent({
       }
     }
 
-    const user = computed(() => dandiRest.user);
     function ownerIsCurrentUser(owner: User) {
       return user.value && user.value.username === owner.username;
     }
@@ -334,10 +333,10 @@ export default defineComponent({
       if (currentDandiset.value?.dandiset) {
         const owner = owners.value
           ?.map((u: User) => u.username)
-          .includes(dandiRest.user!.username);
+          .includes(user.value!.username);
 
         // If necessary, open display and return. Otherwise, proceed to save.
-        if (!adminWarningDisplay.value && dandiRest.user?.admin && !owner) {
+        if (!adminWarningDisplay.value && user.value?.admin && !owner) {
           adminWarningDisplay.value = true;
           return;
         }

--- a/web/src/components/Meditor/localStorage.ts
+++ b/web/src/components/Meditor/localStorage.ts
@@ -1,33 +1,33 @@
-import { dandiRest } from '@/rest';
+import { user } from '@/rest';
 import type { DandiModel } from './types';
 // eslint-disable-next-line import/no-cycle
 import type { MeditorTransaction } from './transactions';
 
 function getModelLocalStorage(identifier: string) {
-  const model = localStorage.getItem(`${dandiRest.user?.username}-${identifier}-model`);
+  const model = localStorage.getItem(`${user.value?.username}-${identifier}-model`);
   return model ? JSON.parse(model) : null;
 }
 
 function setModelLocalStorage(identifier: string, model: DandiModel) {
-  localStorage.setItem(`${dandiRest.user?.username}-${identifier}-model`, JSON.stringify(model));
+  localStorage.setItem(`${user.value?.username}-${identifier}-model`, JSON.stringify(model));
 }
 
 function getTransactionsLocalStorage(identifier: string) {
-  const model = localStorage.getItem(`${dandiRest.user?.username}-${identifier}-transactions`);
+  const model = localStorage.getItem(`${user.value?.username}-${identifier}-transactions`);
   return model ? JSON.parse(model) : null;
 }
 
 function setTransactionsLocalStorage(identifier: string, model: MeditorTransaction[]) {
-  localStorage.setItem(`${dandiRest.user?.username}-${identifier}-transactions`, JSON.stringify(model));
+  localStorage.setItem(`${user.value?.username}-${identifier}-transactions`, JSON.stringify(model));
 }
 
 function getTransactionPointerLocalStorage(identifier: string) {
-  const model = localStorage.getItem(`${dandiRest.user?.username}-${identifier}-transactionPointer`);
+  const model = localStorage.getItem(`${user.value?.username}-${identifier}-transactionPointer`);
   return model ? JSON.parse(model) : null;
 }
 
 function setTransactionPointerLocalStorage(identifier: string, transactionPointer: number) {
-  localStorage.setItem(`${dandiRest.user?.username}-${identifier}-transactionPointer`, JSON.stringify(transactionPointer));
+  localStorage.setItem(`${user.value?.username}-${identifier}-transactionPointer`, JSON.stringify(transactionPointer));
 }
 
 function dataInLocalStorage(identifier: string) {
@@ -39,9 +39,9 @@ function dataInLocalStorage(identifier: string) {
 }
 
 function clearLocalStorage(identifier: string) {
-  localStorage.removeItem(`${dandiRest.user?.username}-${identifier}-model`);
-  localStorage.removeItem(`${dandiRest.user?.username}-${identifier}-transactions`);
-  localStorage.removeItem(`${dandiRest.user?.username}-${identifier}-transactionPointer`);
+  localStorage.removeItem(`${user.value?.username}-${identifier}-model`);
+  localStorage.removeItem(`${user.value?.username}-${identifier}-transactions`);
+  localStorage.removeItem(`${user.value?.username}-${identifier}-transactionPointer`);
 }
 
 export {

--- a/web/src/components/Search/forms/GenotypeForm.vue
+++ b/web/src/components/Search/forms/GenotypeForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { debounce } from 'lodash';
-import { dandiRest } from '@/rest';
+import { client } from '@/rest';
 import { searchParameters } from '../store';
 
 const searchTerm = ref<string | null>(null);
@@ -9,7 +9,7 @@ const options = ref<string[]>([]);
 const loading = ref<boolean>(false);
 async function populateGenotypeList(newSearchTerm: string) {
   loading.value = true;
-  const genotypes: string[] = (await dandiRest.client.get('/search/genotypes', { params: { genotype: newSearchTerm } })).data;
+  const genotypes: string[] = (await client.get('/search/genotypes', { params: { genotype: newSearchTerm } })).data;
   options.value = genotypes.filter((g) => g.includes(newSearchTerm));
   loading.value = false;
 }

--- a/web/src/components/Search/forms/SpeciesForm.vue
+++ b/web/src/components/Search/forms/SpeciesForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import { dandiRest } from '@/rest';
+import { client } from '@/rest';
 import { searchParameters } from '../store';
 
 const searchTerm = ref<string | null>(null);
@@ -8,7 +8,7 @@ const options = ref<string[]>([]);
 const loading = ref<boolean>(false);
 async function populateSpeciesList(newSearchTerm: string = '') {
   loading.value = true;
-  const species: string[] = (await dandiRest.client.get('/search/species', { params: { species: newSearchTerm } })).data;
+  const species: string[] = (await client.get('/search/species', { params: { species: newSearchTerm } })).data;
   options.value = species;
   loading.value = false;
 }

--- a/web/src/components/UserStatusBanner.vue
+++ b/web/src/components/UserStatusBanner.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts">
-import { dandiRest } from '@/rest';
+import { user } from '@/rest';
 import type { ComputedRef } from 'vue';
 import { computed, defineComponent } from 'vue';
 
@@ -30,8 +30,7 @@ export default defineComponent({
   components: { },
   setup() {
     const bannerInfo: ComputedRef<StatusBanner|null> = computed(() => {
-      const { user } = dandiRest;
-      switch (user?.status) {
+      switch (user.value?.status) {
         case 'PENDING':
           return {
             text: 'Your DANDI account is currently pending approval. Please allow up to 2 business days for approval and contact the DANDI admins at help@dandiarchive.org if you have any questions.',

--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -1,12 +1,23 @@
-import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import axios from 'axios';
-import Vue from 'vue';
-import { mapState } from 'pinia';
+import { ref } from 'vue';
 import OAuthClient from '@girder/oauth-client';
 import type {
-  Asset, Dandiset, Paginated, User, Version, Info, AssetPath, Zarr, DandisetSearchResult,
+  Asset,
+  Dandiset,
+  Paginated,
+  User,
+  Version,
+  Info,
+  AssetPath,
+  Zarr,
+  DandisetSearchResult,
 } from '@/types';
-import type { Dandiset as DandisetMetadata, DandisetContributors, Organization } from '@/types/schema';
+import type {
+  Dandiset as DandisetMetadata,
+  DandisetContributors,
+  Organization,
+} from '@/types/schema';
 // eslint-disable-next-line import/no-cycle
 import { useDandisetStore } from '@/stores/dandiset';
 import qs from 'querystring';
@@ -28,242 +39,248 @@ try {
     oauthClient = new OAuthClient(
       new URL(import.meta.env.VITE_APP_OAUTH_API_ROOT),
       import.meta.env.VITE_APP_OAUTH_CLIENT_ID,
-      { redirectUrl: new URL(window.location.origin) },
+      { redirectUrl: new URL(window.location.origin) }
     );
   }
 } catch (e) {
   oauthClient = null;
 }
 
-const dandiRest = new Vue({
-  data(): { client: AxiosInstance, user: User | null } {
-    return {
-      client,
-      user: null,
-    };
-  },
-  computed: {
-    ...mapState(useDandisetStore, ['schemaVersion']),
-  },
-  methods: {
-    async restoreLogin() {
-      if (!oauthClient) {
-        return;
-      }
-      await oauthClient.maybeRestoreLogin();
-      if (!oauthClient.isLoggedIn) {
-        return;
-      }
+const user = ref<User | null>(null);
 
-      try {
-        // Fetch user
-        this.user = await this.me();
-      } catch (e) {
-        // A status of 401 indicates login failed, so the exception should be suppressed.
-        if (axios.isAxiosError(e) && e.response?.status === 401) {
-          await oauthClient.logout();
-        } else {
-          // Any other kind of exception indicates an error that shouldn't occur
-          throw e;
-        }
-      }
-    },
-    async login() {
-      if (oauthClient) {
-        await oauthClient.redirectToLogin();
-      }
-    },
-    async logout() {
-      if (oauthClient) {
+const dandiRest = {
+  async restoreLogin() {
+    if (!oauthClient) {
+      return;
+    }
+    await oauthClient.maybeRestoreLogin();
+    if (!oauthClient.isLoggedIn) {
+      return;
+    }
+
+    try {
+      // Fetch user
+      user.value = await this.me();
+    } catch (e) {
+      // A status of 401 indicates login failed, so the exception should be suppressed.
+      if (axios.isAxiosError(e) && e.response?.status === 401) {
         await oauthClient.logout();
-        this.user = null;
-        localStorage.clear();
-      }
-    },
-    async me(): Promise<User> {
-      const { data: user } = await client.get('users/me/');
-      user.approved = user.status === 'APPROVED';
-      return user;
-    },
-    async newApiKey(): Promise<string> {
-      const { data } = await client.post('auth/token/');
-      return data;
-    },
-    async getApiKey(): Promise<string> {
-      try {
-        const { data } = await client.get('auth/token/');
-        return data;
-      } catch (e) {
-        // If the request returned 404, the user doesn't have an API key yet
-        if (axios.isAxiosError(e) && e.response?.status === 404) {
-          // Create a new API key
-          const data = await this.newApiKey();
-          return data;
-        }
+      } else {
+        // Any other kind of exception indicates an error that shouldn't occur
         throw e;
       }
-    },
-    async assets(identifier: string, version: string, config?: AxiosRequestConfig)
-      : Promise<Paginated<Asset> | null> {
-      try {
-        const {
-          data,
-        } = await client.get(`dandisets/${identifier}/versions/${version}/assets`, config);
+    }
+  },
+  async login() {
+    if (oauthClient) {
+      await oauthClient.redirectToLogin();
+    }
+  },
+  async logout() {
+    if (oauthClient) {
+      await oauthClient.logout();
+      user.value = null;
+      localStorage.clear();
+    }
+  },
+  async me(): Promise<User> {
+    const { data: user } = await client.get('users/me/');
+    user.approved = user.status === 'APPROVED';
+    return user;
+  },
+  async newApiKey(): Promise<string> {
+    const { data } = await client.post('auth/token/');
+    return data;
+  },
+  async getApiKey(): Promise<string> {
+    try {
+      const { data } = await client.get('auth/token/');
+      return data;
+    } catch (e) {
+      // If the request returned 404, the user doesn't have an API key yet
+      if (axios.isAxiosError(e) && e.response?.status === 404) {
+        // Create a new API key
+        const data = await this.newApiKey();
         return data;
-      } catch (error) {
-        if (axios.isAxiosError(error) && error.response && error.response.status === 404) {
-          return null;
-        }
-        throw error;
       }
-    },
-    async zarr({ dandiset }: { dandiset?: string }) : Promise<Paginated<Zarr>> {
-      const params: { dandiset?: string } = {};
-      if (dandiset !== undefined) {
-        params.dandiset = dandiset;
-      }
-
-      const resp = await client.get('zarr/', {
-        params,
-      });
-
-      return resp.data;
-    },
-    async assetPaths(
-      identifier: string,
-      version: string,
-      location: string,
-      page: number,
-      page_size: number,
-    ): Promise<{ count: number, results: AssetPath[] }> {
-      const {
-        data,
-      } = await client.get(`dandisets/${identifier}/versions/${version}/assets/paths/`, {
-        params: {
-          path_prefix: location,
-          page,
-          page_size,
-        },
-      });
-      const { count, results } = data;
-      return { count, results };
-    },
-    async versions(identifier: string, params?: any): Promise<Paginated<Version> | null> {
-      try {
-        const { data } = await client.get(`dandisets/${identifier}/versions/`, { params });
-        return data;
-      } catch (error) {
-        if (axios.isAxiosError(error) && error.response && error.response.status === 404) {
-          return null;
-        }
-        if (axios.isAxiosError(error) && error.message === 'Network Error') {
-          return null;
-        }
-        throw error;
-      }
-    },
-    async specificVersion(identifier: string, version: string): Promise<Version | null> {
-      try {
-        const { data } = await client.get(`dandisets/${identifier}/versions/${version}/info/`);
-        return data;
-      } catch (error) {
-        if (axios.isAxiosError(error) && error.response && error.response.status === 404) {
-          return null;
-        }
-        throw error;
-      }
-    },
-    async mostRecentVersion(identifier: string) {
-      // Look up the last version using page filters
-      const versions = await this.versions(identifier, { page_size: 1, order: '-created' });
-      if (versions === null) {
+      throw e;
+    }
+  },
+  async assets(
+    identifier: string,
+    version: string,
+    config?: AxiosRequestConfig
+  ): Promise<Paginated<Asset> | null> {
+    try {
+      const { data } = await client.get(
+        `dandisets/${identifier}/versions/${version}/assets`,
+        config
+      );
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response && error.response.status === 404) {
         return null;
       }
-      return versions.results[0];
-    },
-    async dandisets(params?: any): Promise<AxiosResponse<Paginated<Dandiset>>> {
-      const response = await client.get('dandisets/', { params });
-      return response;
-    },
-    async createDandiset(
-      name: string, metadata: Partial<DandisetMetadata>, config: AxiosRequestConfig = {},
-    ): Promise<AxiosResponse<Dandiset>> {
-      const { schemaVersion } = this;
-      return client.post('dandisets/', { name, metadata: { name, schemaVersion, ...metadata } }, config);
-    },
-    async createEmbargoedDandiset(name: string, metadata: Partial<DandisetMetadata>, awardNumber: Organization['awardNumber']) {
-      // add NIH award number as a contributor in the new dandiset's metadata
-      const award: Organization = {
-        name: 'National Institutes of Health (NIH)',
-        schemaKey: 'Organization',
-        awardNumber,
-        roleName: ['dcite:Funder'],
-      };
-      const contributor: DandisetContributors = [...(metadata.contributor || []), award];
-
-      const params = { embargo: true };
-
-      return this.createDandiset(name, { ...metadata, contributor }, { params });
-    },
-    async saveDandiset(
-      identifier: string, version: string, metadata: any,
-    ): Promise<AxiosResponse<Version>> {
-      return client.put(`dandisets/${identifier}/versions/${version}/`, {
-        name: metadata.name,
-        metadata,
-      });
-    },
-    async searchDandisets(
-      parameters: Record<string, any>,
-    ): Promise<Paginated<DandisetSearchResult>> {
-      const { data } = await client.get('/dandisets/search', {
-        params: { ...parameters },
-        paramsSerializer: (params) => qs.stringify(params),
-      });
-      return data;
-    },
-    async owners(identifier: string): Promise<AxiosResponse<User[]>> {
-      return client.get(`dandisets/${identifier}/users/`);
-    },
-    async setOwners(identifier: string, owners: User[]) {
-      return client.put(`dandisets/${identifier}/users/`, owners);
-    },
-    async searchUsers(username: string): Promise<User[]> {
-      const { data } = await client.get('users/search/', { params: { username } });
-      return data;
-    },
-    async publish(identifier: string): Promise<Version> {
-      const { data } = await client.post(`dandisets/${identifier}/versions/draft/publish/`);
-      return data;
-    },
-    async unembargo(identifier: string): Promise<AxiosResponse> {
-      return client.post(`dandisets/${identifier}/unembargo/`);
-    },
-    async info(): Promise<Info> {
-      const { data } = await client.get('info/');
-      return data;
-    },
-    async stats() {
-      const { data } = await client.get('stats/');
-      return data;
-    },
-    assetManifestURI(identifier: string, version: string) {
-      return `${dandiApiRoot}dandisets/${identifier}/versions/${version}/assets/`;
-    },
-    assetDownloadURI(identifier: string, version: string, uuid: string) {
-      return `${dandiApiRoot}assets/${uuid}/download/`;
-    },
-    assetInlineURI(identifier: string, version: string, uuid: string) {
-      return `${dandiApiRoot}assets/${uuid}/download?content_disposition=inline`;
-    },
-    assetMetadataURI(identifier: string, version: string, uuid: string) {
-      return `${dandiApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}`;
-    },
-    async deleteAsset(identifier: string, version: string, uuid: string): Promise<AxiosResponse> {
-      return client.delete(`${dandiApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/`);
-    },
+      throw error;
+    }
   },
-});
+  async zarr({ dandiset }: { dandiset?: string }): Promise<Paginated<Zarr>> {
+    const params: { dandiset?: string } = {};
+    if (dandiset !== undefined) {
+      params.dandiset = dandiset;
+    }
+
+    const resp = await client.get('zarr/', {
+      params,
+    });
+
+    return resp.data;
+  },
+  async assetPaths(
+    identifier: string,
+    version: string,
+    location: string,
+    page: number,
+    page_size: number
+  ): Promise<{ count: number; results: AssetPath[] }> {
+    const { data } = await client.get(`dandisets/${identifier}/versions/${version}/assets/paths/`, {
+      params: {
+        path_prefix: location,
+        page,
+        page_size,
+      },
+    });
+    const { count, results } = data;
+    return { count, results };
+  },
+  async versions(identifier: string, params?: any): Promise<Paginated<Version> | null> {
+    try {
+      const { data } = await client.get(`dandisets/${identifier}/versions/`, { params });
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response && error.response.status === 404) {
+        return null;
+      }
+      if (axios.isAxiosError(error) && error.message === 'Network Error') {
+        return null;
+      }
+      throw error;
+    }
+  },
+  async specificVersion(identifier: string, version: string): Promise<Version | null> {
+    try {
+      const { data } = await client.get(`dandisets/${identifier}/versions/${version}/info/`);
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response && error.response.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  },
+  async mostRecentVersion(identifier: string) {
+    // Look up the last version using page filters
+    const versions = await this.versions(identifier, { page_size: 1, order: '-created' });
+    if (versions === null) {
+      return null;
+    }
+    return versions.results[0];
+  },
+  async dandisets(params?: any): Promise<AxiosResponse<Paginated<Dandiset>>> {
+    const response = await client.get('dandisets/', { params });
+    return response;
+  },
+  async createDandiset(
+    name: string,
+    metadata: Partial<DandisetMetadata>,
+    config: AxiosRequestConfig = {}
+  ): Promise<AxiosResponse<Dandiset>> {
+    const store = useDandisetStore();
+    const { schemaVersion } = store;
+    return client.post(
+      'dandisets/',
+      { name, metadata: { name, schemaVersion, ...metadata } },
+      config
+    );
+  },
+  async createEmbargoedDandiset(
+    name: string,
+    metadata: Partial<DandisetMetadata>,
+    awardNumber: Organization['awardNumber']
+  ) {
+    // add NIH award number as a contributor in the new dandiset's metadata
+    const award: Organization = {
+      name: 'National Institutes of Health (NIH)',
+      schemaKey: 'Organization',
+      awardNumber,
+      roleName: ['dcite:Funder'],
+    };
+    const contributor: DandisetContributors = [...(metadata.contributor || []), award];
+
+    const params = { embargo: true };
+
+    return this.createDandiset(name, { ...metadata, contributor }, { params });
+  },
+  async saveDandiset(
+    identifier: string,
+    version: string,
+    metadata: any
+  ): Promise<AxiosResponse<Version>> {
+    return client.put(`dandisets/${identifier}/versions/${version}/`, {
+      name: metadata.name,
+      metadata,
+    });
+  },
+  async searchDandisets(parameters: Record<string, any>): Promise<Paginated<DandisetSearchResult>> {
+    const { data } = await client.get('/dandisets/search', {
+      params: { ...parameters },
+      paramsSerializer: (params) => qs.stringify(params),
+    });
+    return data;
+  },
+  async owners(identifier: string): Promise<AxiosResponse<User[]>> {
+    return client.get(`dandisets/${identifier}/users/`);
+  },
+  async setOwners(identifier: string, owners: User[]) {
+    return client.put(`dandisets/${identifier}/users/`, owners);
+  },
+  async searchUsers(username: string): Promise<User[]> {
+    const { data } = await client.get('users/search/', { params: { username } });
+    return data;
+  },
+  async publish(identifier: string): Promise<Version> {
+    const { data } = await client.post(`dandisets/${identifier}/versions/draft/publish/`);
+    return data;
+  },
+  async unembargo(identifier: string): Promise<AxiosResponse> {
+    return client.post(`dandisets/${identifier}/unembargo/`);
+  },
+  async info(): Promise<Info> {
+    const { data } = await client.get('info/');
+    return data;
+  },
+  async stats() {
+    const { data } = await client.get('stats/');
+    return data;
+  },
+  assetManifestURI(identifier: string, version: string) {
+    return `${dandiApiRoot}dandisets/${identifier}/versions/${version}/assets/`;
+  },
+  assetDownloadURI(identifier: string, version: string, uuid: string) {
+    return `${dandiApiRoot}assets/${uuid}/download/`;
+  },
+  assetInlineURI(identifier: string, version: string, uuid: string) {
+    return `${dandiApiRoot}assets/${uuid}/download?content_disposition=inline`;
+  },
+  assetMetadataURI(identifier: string, version: string, uuid: string) {
+    return `${dandiApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}`;
+  },
+  async deleteAsset(identifier: string, version: string, uuid: string): Promise<AxiosResponse> {
+    return client.delete(
+      `${dandiApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/`
+    );
+  },
+};
 
 // This is done with an interceptor because the value of
 // oauthClient.authHeaders is initialized asynchronously,
@@ -278,12 +295,12 @@ client.interceptors.request.use((config) => ({
   },
 }));
 
-const user = () => dandiRest.user;
-const loggedIn = () => !!user();
+const loggedIn = () => !!user.value;
 const insideIFrame = (): boolean => window.self !== window.top;
 const cookiesEnabled = (): boolean => navigator.cookieEnabled;
 
 export {
+  client,
   dandiRest,
   loggedIn,
   user,

--- a/web/src/stores/dandiset.ts
+++ b/web/src/stores/dandiset.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import RefParser from '@apidevtools/json-schema-ref-parser';
 
 // eslint-disable-next-line import/no-cycle
-import { dandiRest } from '@/rest';
+import { dandiRest, user } from '@/rest';
 import type { User, Version } from '@/types';
 import { draftVersion } from '@/utils/constants';
 
@@ -26,18 +26,16 @@ export const useDandisetStore = defineStore('dandiset', {
     version: (state) => (state.dandiset ? state.dandiset.version : draftVersion),
     schemaVersion: (state) => state.schema?.properties.schemaVersion.default,
     userCanModifyDandiset: (state) => {
-      const user = dandiRest?.user as User | null;
-
       // published versions are never editable, and logged out users can never edit a dandiset
       if (state.dandiset?.metadata?.version !== draftVersion || !user) {
         return false;
       }
       // if they're an admin, they can edit any dandiset
-      if (user.admin) {
+      if (user.value?.admin) {
         return true;
       }
       // otherwise check if they are an owner
-      return !!(state.owners?.find((owner) => owner.username === user.username));
+      return !!(state.owners?.find((owner) => owner.username === user.value?.username));
     },
   },
   actions: {

--- a/web/src/views/DandisetLandingView/DandisetOwners.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwners.vue
@@ -94,7 +94,7 @@
 </template>
 
 <script setup lang="ts">
-import { dandiRest, loggedIn } from '@/rest';
+import { loggedIn, user } from '@/rest';
 import { useDandisetStore } from '@/stores/dandiset';
 import DandisetOwnersDialog from '@/components/DLP/DandisetOwnersDialog.vue';
 import { computed, ref } from 'vue';
@@ -105,13 +105,13 @@ const ownerDialog = ref(false);
 const owners = computed(() => store.owners);
 
 const manageOwnersDisabled = computed(() => {
-  if (dandiRest.user?.admin) {
+  if (user.value?.admin) {
     return false;
   }
-  if (!dandiRest.user || !owners.value) {
+  if (!user.value || !owners.value) {
     return true;
   }
-  return !owners.value.find((owner) => owner.username === dandiRest.user?.username);
+  return !owners.value.find((owner) => owner.username === user.value?.username);
 });
 const limitedOwners = computed(() => {
   if (!owners.value) {

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -354,7 +354,7 @@ import moment from 'moment';
 
 import type { RawLocation } from 'vue-router';
 import { useRoute } from 'vue-router/composables';
-import { dandiRest, loggedIn as loggedInFunc, user as userFunc } from '@/rest';
+import { dandiRest, loggedIn as loggedInFunc, user } from '@/rest';
 import { useDandisetStore } from '@/stores/dandiset';
 import router from '@/router';
 import type { User, Version } from '@/types';
@@ -404,7 +404,6 @@ const otherVersions: ComputedRef<Version[]|undefined> = computed(
   ).sort(sortVersions),
 );
 
-const user: ComputedRef<User|null> = computed(userFunc);
 const loggedIn: ComputedRef<boolean> = computed(loggedInFunc);
 
 const isOwner: ComputedRef<boolean> = computed(

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -263,7 +263,7 @@ import filesize from 'filesize';
 import { trimEnd } from 'lodash';
 import axios from 'axios';
 
-import { dandiRest } from '@/rest';
+import { dandiRest, user } from '@/rest';
 import { useDandisetStore } from '@/stores/dandiset';
 import type { AssetFile, AssetPath } from '@/types';
 import FileBrowserPagination from '@/components/FileBrowser/FileBrowserPagination.vue';
@@ -372,9 +372,9 @@ const owners = computed(() => store.owners?.map((u) => u.username) || null);
 const currentDandiset = computed(() => store.dandiset);
 const embargoed = computed(() => currentDandiset.value?.dandiset.embargo_status === 'EMBARGOED');
 const splitLocation = computed(() => location.value.split('/'));
-const isAdmin = computed(() => dandiRest.user?.admin || false);
+const isAdmin = computed(() => user.value?.admin || false);
 const isOwner = computed(() => !!(
-  dandiRest.user && owners.value?.includes(dandiRest.user?.username)
+  user.value && owners.value?.includes(user.value?.username)
 ));
 const itemsNotFound = computed(() => items.value && !items.value.length);
 


### PR DESCRIPTION
The `rest` module seems to be blocking the upgrade to Vue 3; in Vue 2, it was possible to initialize a Vue object as follows:
```javascript
const dandiRest = new Vue({
	data() {
		return { user: null }
	},
	...
});
```

And then access a data object like this:

```javascript
console.log(dandiRest.user)
```

But, the equivalent Vue 3 code doesn't work:

```javascript
const dandiRest = Vue.createApp({
	data() {
		return { user: null }
	},
	...
});

console.log(dandiRest.user) // doesn't work
```

I'm not sure what the issue is or how it was changed, but I can't even find the docs that specified this behavior for Vue 2. I'd be curious to hear if anyone has any ideas why that is. But regardless, converting to Composition API avoids this issue and is also something we've planned for a long time, so I just went ahead and did that.

Fixes #1267 