### PR TITLE
Don't use filesystem APIs to manipulate URLs

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os.path
 from uuid import uuid4
 
 from django.conf import settings
@@ -1351,7 +1350,7 @@ def test_asset_download(api_client, storage, version, asset):
     download = requests.get(download_url, timeout=5)
     cd_header = download.headers.get('Content-Disposition')
 
-    assert cd_header == f'attachment; filename="{os.path.basename(asset.path)}"'
+    assert cd_header == f'attachment; filename="{asset.path.split("/")[-1]}"'
 
     with asset.blob.blob.file.open('rb') as reader:
         assert download.content == reader.read()
@@ -1397,7 +1396,7 @@ def test_asset_download_embargo(
     download = requests.get(download_url, timeout=5)
     cd_header = download.headers.get('Content-Disposition')
 
-    assert cd_header == f'attachment; filename="{os.path.basename(asset.path)}"'
+    assert cd_header == f'attachment; filename="{asset.path.split("/")[-1]}"'
 
     with asset.embargoed_blob.blob.file.open('rb') as reader:
         assert download.content == reader.read()
@@ -1432,7 +1431,7 @@ def test_asset_direct_download(api_client, storage, version, asset):
     download = requests.get(download_url, timeout=5)
     cd_header = download.headers.get('Content-Disposition')
 
-    assert cd_header == f'attachment; filename="{os.path.basename(asset.path)}"'
+    assert cd_header == f'attachment; filename="{asset.path.split("/")[-1]}"'
 
     with asset.blob.blob.file.open('rb') as reader:
         assert download.content == reader.read()
@@ -1464,7 +1463,7 @@ def test_asset_direct_download_head(api_client, storage, version, asset):
     download = requests.get(download_url, timeout=5)
     cd_header = download.headers.get('Content-Disposition')
 
-    assert cd_header == f'attachment; filename="{os.path.basename(asset.path)}"'
+    assert cd_header == f'attachment; filename="{asset.path.split("/")[-1]}"'
 
     with asset.blob.blob.file.open('rb') as reader:
         assert download.content == reader.read()

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import uuid
 
 from django.core.files.base import ContentFile
@@ -538,7 +537,7 @@ def test_upload_validate_wrong_size(api_client, user, upload):
     api_client.force_authenticate(user=user)
 
     wrong_content = b'not 100 bytes'
-    upload.blob.save(os.path.basename(upload.blob.name), ContentFile(wrong_content))
+    upload.blob.save(upload.blob.name.split('/')[-1], ContentFile(wrong_content))
 
     resp = api_client.post(f'/api/uploads/{upload.upload_id}/validate/')
     assert resp.status_code == 400

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -22,7 +22,6 @@ except ImportError:
     # This should only be used for type interrogation, never instantiation
     MinioStorage = type('FakeMinioStorage', (), {})
 
-import os.path
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -146,7 +145,7 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
         serializer.is_valid(raise_exception=True)
         content_disposition = serializer.validated_data['content_disposition']
         content_type = asset.metadata.get('encodingFormat', 'application/octet-stream')
-        asset_basename = os.path.basename(asset.path)
+        asset_basename = asset.path.split('/')[-1]
 
         if content_disposition == 'attachment':
             return HttpResponseRedirect(

--- a/dandiapi/zarr/models.py
+++ b/dandiapi/zarr/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
@@ -12,9 +11,6 @@ from rest_framework.exceptions import ValidationError
 
 from dandiapi.api.models import Dandiset
 from dandiapi.api.storage import get_embargo_storage, get_storage
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 logger = logging.getLogger(name=__name__)
 
@@ -103,7 +99,7 @@ class ZarrArchive(BaseZarrArchive):
     storage = get_storage()
     dandiset = models.ForeignKey(Dandiset, related_name='zarr_archives', on_delete=models.CASCADE)
 
-    def s3_path(self, zarr_path: str | Path):
+    def s3_path(self, zarr_path: str) -> str:
         """Generate a full S3 object path from a path in this zarr_archive."""
         return (
             f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}{settings.DANDI_ZARR_PREFIX_NAME}/'
@@ -117,7 +113,7 @@ class EmbargoedZarrArchive(BaseZarrArchive):
         Dandiset, related_name='embargoed_zarr_archives', on_delete=models.CASCADE
     )
 
-    def s3_path(self, zarr_path: str | Path):
+    def s3_path(self, zarr_path: str) -> str:
         """Generate a full S3 object path from a path in this zarr_archive."""
         return (
             f'{settings.DANDI_DANDISETS_EMBARGO_BUCKET_PREFIX}{settings.DANDI_ZARR_PREFIX_NAME}/'

--- a/dandiapi/zarr/tests/test_zarr.py
+++ b/dandiapi/zarr/tests/test_zarr.py
@@ -237,7 +237,7 @@ def test_zarr_rest_delete_file(
         f'/api/zarr/{zarr_archive.zarr_id}/files/', [{'path': str(zarr_file.path)}]
     )
     assert resp.status_code == 204
-    assert not zarr_archive.storage.exists(zarr_archive.s3_path(zarr_file.path))
+    assert not zarr_archive.storage.exists(zarr_archive.s3_path(str(zarr_file.path)))
 
     # Assert zarr is back in pending state
     zarr_archive.refresh_from_db()
@@ -336,7 +336,7 @@ def test_zarr_rest_delete_multiple_files(
 
     # Assert not found
     for file in zarr_files:
-        assert not zarr_archive.storage.exists(zarr_archive.s3_path(file))
+        assert not zarr_archive.storage.exists(zarr_archive.s3_path(str(file.path)))
 
     ingest_zarr_archive(zarr_archive.zarr_id)
     zarr_archive.refresh_from_db()
@@ -369,7 +369,7 @@ def test_zarr_rest_delete_missing_file(
     assert resp.json() == [
         f'File test-prefix/test-zarr/{zarr_archive.zarr_id}/does/not/exist does not exist.'
     ]
-    assert zarr_archive.storage.exists(zarr_archive.s3_path(zarr_file.path))
+    assert zarr_archive.storage.exists(zarr_archive.s3_path(str(zarr_file.path)))
 
     # Ingest
     zarr_archive.status = ZarrArchiveStatus.UPLOADED


### PR DESCRIPTION
Following #1743, this removes the remaining uses of the filesystem APIs `os.path` and `pathlib` (which are platform-dependent and contain methods for local filesystem manipulation) to process URLs.

The `zarr_checksum` package still has this confusion in its `ZarrArchiveFile` class, but attempts to refactor some of that code failed due to other issues with it. So, the `ZarrArchiveFile.path` field is just cast to a `str` when interfacing with local application code.