### PR TITLE
Fix S101 Use of `assert` detected

### DIFF
--- a/dandiapi/api/asset_paths.py
+++ b/dandiapi/api/asset_paths.py
@@ -214,8 +214,10 @@ def _delete_asset_paths(asset: Asset, version: Version):
 
     # Ensure integrity
     leaf.refresh_from_db()
-    assert leaf.aggregate_size == 0
-    assert leaf.aggregate_files == 0
+    if leaf.aggregate_size != 0:
+        raise RuntimeError('Remaining non-zero aggregate_size')
+    if leaf.aggregate_files != 0:
+        raise RuntimeError('Remaining non-zero aggregate_files')
 
     # Delete leaf node and any other paths with no contained files
     AssetPath.objects.filter(aggregate_files=0).delete()

--- a/dandiapi/api/services/asset/__init__.py
+++ b/dandiapi/api/services/asset/__init__.py
@@ -52,10 +52,10 @@ def change_asset(
     Returns a tuple of the asset, and whether or not it was changed. When changing an asset, a new
     asset is created automatically.
     """
-    assert (
-        new_asset_blob or new_zarr_archive
-    ), 'One of new_zarr_archive or new_asset_blob must be given to change_asset_metadata'
-    assert 'path' in new_metadata, 'Path must be present in new_metadata'
+    if not new_asset_blob and not new_zarr_archive:
+        raise ValueError('One of new_zarr_archive or new_asset_blob must be given')
+    if 'path' not in new_metadata:
+        raise ValueError('Path must be present in new_metadata')
 
     if not user.has_perm('owner', version.dandiset):
         raise DandisetOwnerRequiredError
@@ -103,10 +103,12 @@ def add_asset_to_version(
     metadata: dict,
 ) -> Asset:
     """Create an asset, adding it to a version."""
-    assert (
-        asset_blob or zarr_archive
-    ), 'One of zarr_archive or asset_blob must be given to add_asset_to_version'
-    assert 'path' in metadata, 'Path must be present in metadata'
+    if not asset_blob and not zarr_archive:
+        raise RuntimeError(
+            'One of zarr_archive or asset_blob must be given to add_asset_to_version'
+        )
+    if 'path' not in metadata:
+        raise RuntimeError('Path must be present in metadata')
 
     if not user.has_perm('owner', version.dandiset):
         raise DandisetOwnerRequiredError

--- a/dandiapi/api/services/embargo/__init__.py
+++ b/dandiapi/api/services/embargo/__init__.py
@@ -32,8 +32,8 @@ def _unembargo_asset(asset: Asset):
             ),
         )
 
-        # Assert files are equal
-        assert resp.etag == asset.embargoed_blob.etag
+        if resp.etag != asset.embargoed_blob.etag:
+            raise RuntimeError('ETag mismatch between copied object and original embargoed object')
 
         # Assign blob (changing only blob)
         asset.blob = AssetBlob(

--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -26,8 +26,10 @@ def publish_asset(*, asset: Asset) -> None:
         # Lock asset to ensure it doesn't change out from under us while publishing
         locked_asset = Asset.objects.select_for_update().get(id=asset.id)
 
-        assert not locked_asset.published, 'asset is already published'
-        assert locked_asset.status == Asset.Status.VALID, 'asset is not VALID'
+        if locked_asset.published:
+            raise RuntimeError('Asset is already published')
+        if locked_asset.status != Asset.Status.VALID:
+            raise RuntimeError('Asset does not have VALID status')
 
         # Publish the asset
         locked_asset.metadata = asset.published_metadata()


### PR DESCRIPTION
In non-test parts of the codebase, `assert` shouldn't be used. See https://docs.astral.sh/ruff/rules/assert/ for rationale.