### PR TITLE
Approval view: automatically redirect back to page after authentication

### DIFF
--- a/dandiapi/api/views/dashboard.py
+++ b/dandiapi/api/views/dashboard.py
@@ -4,7 +4,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import Exists, OuterRef
-from django.http.response import HttpResponseRedirect
+from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_http_methods
 from django.views.generic.base import TemplateView
@@ -77,10 +77,10 @@ class DashboardView(DashboardMixin, TemplateView):
 
 
 @require_http_methods(['GET', 'POST'])
-def user_approval_view(request, username: str):
+def user_approval_view(request: HttpRequest, username: str):
     # Redirect user to login if they're not authenticated
     if not request.user.is_authenticated:
-        return HttpResponseRedirect(redirect_to=settings.LOGIN_URL)
+        return HttpResponseRedirect(redirect_to=f'{settings.LOGIN_URL}?next={request.path}')
 
     # If they are authenticated but are not a superuser, deny access
     if not request.user.is_superuser:


### PR DESCRIPTION
Fixes #1701 

This is a follow on to #1781. After that PR, accessing the user approval pages while unauthenticated results in a redirect to the login endpoint, which subsequently redirects to github; but, github redirects the user back to the root path `/` because it doesn't know where the user came from. They allow specifying an optional `next` query parameter, which github will respect and redirect the user to if it's supplied, so I updated the redirect to do that here.