### PR TITLE
Return 401 on unauthenticated embargo dandiset list

### DIFF
--- a/dandiapi/api/services/dandiset/exceptions.py
+++ b/dandiapi/api/services/dandiset/exceptions.py
@@ -5,3 +5,10 @@ from dandiapi.api.services.exceptions import DandiError
 
 class DandisetAlreadyExistsError(DandiError):
     http_status_code = status.HTTP_400_BAD_REQUEST
+
+
+class UnauthorizedEmbargoAccess(DandiError):
+    http_status_code = status.HTTP_401_UNAUTHORIZED
+    message = (
+        'Authentication credentials must be provided when attempting to access embargoed dandisets'
+    )

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -22,6 +22,7 @@ from dandiapi.api.asset_paths import get_root_paths_many
 from dandiapi.api.mail import send_ownership_change_emails
 from dandiapi.api.models import Dandiset, Version
 from dandiapi.api.services.dandiset import create_dandiset, delete_dandiset
+from dandiapi.api.services.dandiset.exceptions import UnauthorizedEmbargoAccess
 from dandiapi.api.services.embargo import unembargo_dandiset
 from dandiapi.api.views.common import DANDISET_PK_PARAM, DandiPagination
 from dandiapi.api.views.serializers import (
@@ -118,6 +119,10 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             show_draft: bool = query_serializer.validated_data['draft']
             show_empty: bool = query_serializer.validated_data['empty']
             show_embargoed: bool = query_serializer.validated_data['embargoed']
+
+            # Return early if attempting to access embargoed data without authentication
+            if show_embargoed and not self.request.user.is_authenticated:
+                raise UnauthorizedEmbargoAccess()
 
             if not show_draft:
                 # Only include dandisets that have more than one version, i.e. published dandisets.

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -173,7 +173,7 @@ class DandisetDetailSerializer(DandisetSerializer):
 class DandisetQueryParameterSerializer(serializers.Serializer):
     draft = serializers.BooleanField(default=True)
     empty = serializers.BooleanField(default=True)
-    embargoed = serializers.BooleanField(default=True)
+    embargoed = serializers.BooleanField(default=False)
     user = serializers.CharField(required=False)
 
 


### PR DESCRIPTION
Fixes #1788

This slightly changes the way the API behaves, aside from the stated goal. Previously, we defaulted to a value of `true` when `embargoed` was not specified. This PR changes that default to `false`, as otherwise, any un-authenticated users would need to always explicitly pass `embargoed=false` when calling the dandiset list endpoint.

cc @yarikoptic 