### PR TITLE
Remove explicit dependency on `pydantic`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 # This file is only for use by Heroku, with the old pip resolver
 idna>=2.5,<3
-# To address an odd case of email-validator not being installed
-# see https://github.com/dandi/dandi-api/pull/405
-pydantic[email]
 .

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         'drf-extensions',
         'drf-yasg',
         'jsonschema',
-        'pydantic',
         'boto3[s3]',
         'more_itertools',
         'requests',


### PR DESCRIPTION
We don't use pydantic directly anywhere. Also, dandischema lists the `pydantic[email]` extra as a dependency now, so we can remove it from `requirements.txt` as well.