### PR TITLE
Remove `requirements.txt` file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-# This file is only for use by Heroku, with the old pip resolver
-idna>=2.5,<3
-.


### PR DESCRIPTION
This was added a few years ago to work around issues with Heroku using an older pip version. This should no longer be the case, so we can remove this and let Heroku use setup.py for dependency management only.