### PR TITLE
For staging environment, include dynamic text for `dandi download` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,4 @@ dmypy.json
 # End of https://www.gitignore.io/api/django
 
 # Editor settings
-.vscode
+.vscode 

--- a/.gitignore
+++ b/.gitignore
@@ -124,4 +124,3 @@ dmypy.json
 
 # Editor settings
 .vscode
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,5 @@ dmypy.json
 # End of https://www.gitignore.io/api/django
 
 # Editor settings
-.vscode 
+.vscode
+.idea/

--- a/web/src/components/FileBrowser/FileUploadInstructions.vue
+++ b/web/src/components/FileBrowser/FileUploadInstructions.vue
@@ -22,7 +22,7 @@
             width="60%"
             class="white--text pl-2 py-1 text-left"
           >
-            <div>> dandi download https://dandiarchive.org/dandiset/{{ dandisetIdentifier }}/draft</div>
+            <div>{{ downloadCommand }}</div>
             <div>> cd {{ dandisetIdentifier }}</div>
             <div>> dandi organize &lt;source_folder&gt; -f dry</div>
             <div>> dandi organize &lt;source_folder&gt;</div>
@@ -53,4 +53,16 @@ import { useDandisetStore } from '@/stores/dandiset';
 
 const store = useDandisetStore();
 const dandisetIdentifier = computed(() => store.dandiset?.dandiset.identifier);
+
+const downloadCommand = computed(() => {
+  const baseUrl = import.meta.env.VITE_APP_DANDI_API_ROOT === 'https://api-staging.dandiarchive.org/api/'
+    ? 'https://gui-staging.dandiarchive.org/dandiset/'
+    : 'https://dandiarchive.org/dandiset/';
+
+  return dandisetIdentifier.value
+    ? `> dandi download ${baseUrl}${dandisetIdentifier.value}/draft`
+    : ''; // Empty string just as a fallback in case store.dandiset? is undefined
+});
 </script>
+
+

--- a/web/src/components/FileBrowser/FileUploadInstructions.vue
+++ b/web/src/components/FileBrowser/FileUploadInstructions.vue
@@ -64,5 +64,3 @@ const downloadCommand = computed(() => {
     : ''; // Empty string just as a fallback in case store.dandiset? is undefined
 });
 </script>
-
-

--- a/web/src/components/FileBrowser/FileUploadInstructions.vue
+++ b/web/src/components/FileBrowser/FileUploadInstructions.vue
@@ -22,7 +22,7 @@
             width="60%"
             class="white--text pl-2 py-1 text-left"
           >
-            <div>{{ downloadCommand }}</div>
+            <div>> {{ downloadCommand }}</div>
             <div>> cd {{ dandisetIdentifier }}</div>
             <div>> dandi organize &lt;source_folder&gt; -f dry</div>
             <div>> dandi organize &lt;source_folder&gt;</div>
@@ -59,6 +59,6 @@ if (dandisetIdentifier.value === undefined) {
 }
 
 const downloadCommand = computed(() => {
-  return `> dandi download ${window.location.origin}/dandiset/${dandisetIdentifier.value}/draft`
+  return `dandi download ${window.location.origin}/dandiset/${dandisetIdentifier.value}/draft`
 });
 </script>

--- a/web/src/components/FileBrowser/FileUploadInstructions.vue
+++ b/web/src/components/FileBrowser/FileUploadInstructions.vue
@@ -55,12 +55,8 @@ const store = useDandisetStore();
 const dandisetIdentifier = computed(() => store.dandiset?.dandiset.identifier);
 
 const downloadCommand = computed(() => {
-  const baseUrl = import.meta.env.VITE_APP_DANDI_API_ROOT === 'https://api-staging.dandiarchive.org/api/'
-    ? 'https://gui-staging.dandiarchive.org/dandiset/'
-    : 'https://dandiarchive.org/dandiset/';
-
   return dandisetIdentifier.value
-    ? `> dandi download ${baseUrl}${dandisetIdentifier.value}/draft`
+    ? `> dandi download ${window.location.origin}/dandiset/${dandisetIdentifier.value}/draft`
     : ''; // Empty string just as a fallback in case store.dandiset? is undefined
 });
 </script>

--- a/web/src/components/FileBrowser/FileUploadInstructions.vue
+++ b/web/src/components/FileBrowser/FileUploadInstructions.vue
@@ -54,9 +54,11 @@ import { useDandisetStore } from '@/stores/dandiset';
 const store = useDandisetStore();
 const dandisetIdentifier = computed(() => store.dandiset?.dandiset.identifier);
 
+if (dandisetIdentifier.value === undefined) {
+  throw new Error('store.dandiset must be defined');
+}
+
 const downloadCommand = computed(() => {
-  return dandisetIdentifier.value
-    ? `> dandi download ${window.location.origin}/dandiset/${dandisetIdentifier.value}/draft`
-    : ''; // Empty string just as a fallback in case store.dandiset? is undefined
+  return `> dandi download ${window.location.origin}/dandiset/${dandisetIdentifier.value}/draft`
 });
 </script>

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -124,10 +124,12 @@ function formatDownloadCommand(identifier: string, version: string): string {
   if (version === 'draft') {
     return `dandi download ${window.location.origin}/dandiset/${identifier}/draft`;
   }
+  const isDandiDomain = window.location.origin === 'https://dandiarchive.org';
   if (!version) {
-    return `dandi download DANDI:${identifier}`;
+    return isDandiDomain ? `dandi download DANDI:${identifier}` : `dandi download ${window.location.origin}/dandiset/${identifier}`;
   }
-  return `dandi download DANDI:${identifier}/${version}`;
+  // For other specific versions
+  return isDandiDomain ? `dandi download DANDI:${identifier}/${version}` : `dandi download ${window.location.origin}/dandiset/${identifier}/${version}`;
 }
 
 const store = useDandisetStore();

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -122,10 +122,7 @@ import CopyText from '@/components/CopyText.vue';
 
 function formatDownloadCommand(identifier: string, version: string): string {
   if (version === 'draft') {
-    const baseUrl = import.meta.env.VITE_APP_DANDI_API_ROOT === 'https://api-staging.dandiarchive.org/api/'
-      ? 'https://gui-staging.dandiarchive.org/dandiset/'
-      : 'https://dandiarchive.org/dandiset/';
-    return `dandi download ${baseUrl}${identifier}/draft`;
+    return `dandi download ${window.location.origin}/dandiset/${identifier}/draft`;
   }
   if (!version) {
     return `dandi download DANDI:${identifier}`;

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -127,14 +127,11 @@ function formatDownloadCommand(identifier: string, version: string): string {
       : 'https://dandiarchive.org/dandiset/';
     return `dandi download ${baseUrl}${identifier}/draft`;
   }
-
   if (!version) {
     return `dandi download DANDI:${identifier}`;
   }
-
   return `dandi download DANDI:${identifier}/${version}`;
 }
-
 
 const store = useDandisetStore();
 

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -122,13 +122,19 @@ import CopyText from '@/components/CopyText.vue';
 
 function formatDownloadCommand(identifier: string, version: string): string {
   if (version === 'draft') {
-    return `dandi download https://dandiarchive.org/dandiset/${identifier}/draft`;
+    const baseUrl = import.meta.env.VITE_APP_DANDI_API_ROOT === 'https://api-staging.dandiarchive.org/api/'
+      ? 'https://gui-staging.dandiarchive.org/dandiset/'
+      : 'https://dandiarchive.org/dandiset/';
+    return `dandi download ${baseUrl}${identifier}/draft`;
   }
+
   if (!version) {
     return `dandi download DANDI:${identifier}`;
   }
+
   return `dandi download DANDI:${identifier}/${version}`;
 }
+
 
 const store = useDandisetStore();
 

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -120,16 +120,16 @@ import { computed, ref } from 'vue';
 import { useDandisetStore } from '@/stores/dandiset';
 import CopyText from '@/components/CopyText.vue';
 
-function formatDownloadCommand(identifier: string, version: string): string {
-  if (version === 'draft') {
-    return `dandi download ${window.location.origin}/dandiset/${identifier}/draft`;
-  }
-  const isDandiDomain = window.location.origin === 'https://dandiarchive.org';
-  if (!version) {
-    return isDandiDomain ? `dandi download DANDI:${identifier}` : `dandi download ${window.location.origin}/dandiset/${identifier}`;
-  }
-  // For other specific versions
-  return isDandiDomain ? `dandi download DANDI:${identifier}/${version}` : `dandi download ${window.location.origin}/dandiset/${identifier}/${version}`;
+function downloadCommand(identifier: string, version: string): string {
+  // Use the special 'DANDI:' url prefix if appropriate.
+  const generalUrl = `${window.location.origin}/dandiset/${identifier}`;
+  const dandiUrl = `DANDI:${identifier}`;
+  const url = window.location.origin == 'https://dandiarchive.org' ? dandiUrl : generalUrl;
+
+  // Prepare a url suffix to specify a specific version (or not).
+  const versionPath = version ? `/${version}` : '';
+
+  return `dandi download ${url}${versionPath}`;
 }
 
 const store = useDandisetStore();
@@ -149,7 +149,7 @@ const availableVersions = computed(
 );
 
 const defaultDownloadText = computed(
-  () => (identifier.value ? formatDownloadCommand(identifier.value, currentVersion.value) : ''),
+  () => (identifier.value ? downloadCommand(identifier.value, currentVersion.value) : ''),
 );
 
 const customDownloadText = computed(() => {
@@ -157,11 +157,11 @@ const customDownloadText = computed(() => {
     return '';
   }
   if (selectedDownloadOption.value === 'draft') {
-    return formatDownloadCommand(identifier.value, 'draft');
+    return downloadCommand(identifier.value, 'draft');
   } if (selectedDownloadOption.value === 'latest') {
-    return formatDownloadCommand(identifier.value, '');
+    return downloadCommand(identifier.value, '');
   } if (selectedDownloadOption.value === 'other') {
-    return formatDownloadCommand(
+    return downloadCommand(
       identifier.value,
       availableVersions.value[selectedVersion.value].version,
     );


### PR DESCRIPTION
When using `gui-staging.dandiarchive.org`, a minor inconsistency was observed where the CLI command was incorrect.

This PR makes a simple fix to render the appropriate text depending on if the user is using staging or production.

Closes #1553 

Cc @kabilar