### PR TITLE
Boost dandischema to 0.9.* series so we get support for pydantic 2.0 and schema 0.6.5

### DIFF
--- a/dandiapi/api/services/version/metadata.py
+++ b/dandiapi/api/services/version/metadata.py
@@ -43,6 +43,6 @@ def _normalize_version_metadata(
     }
     # Run the version_metadata through the pydantic model to automatically include any boilerplate
     # like the access or repository fields
-    return PydanticDandiset.model_construct(
-        **version_metadata
-    ).model_dump(mode='json',exclude_none=True)
+    return PydanticDandiset.model_construct(**version_metadata).model_dump(
+        mode='json', exclude_none=True
+    )

--- a/dandiapi/api/services/version/metadata.py
+++ b/dandiapi/api/services/version/metadata.py
@@ -43,4 +43,6 @@ def _normalize_version_metadata(
     }
     # Run the version_metadata through the pydantic model to automatically include any boilerplate
     # like the access or repository fields
-    return PydanticDandiset.unvalidated(**version_metadata).json_dict()
+    return PydanticDandiset.model_construct(
+        **version_metadata
+    ).model_dump(mode='json',exclude_none=True)

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -292,7 +292,8 @@ def test_validate_version_metadata_no_assets(
     assert draft_version.validation_errors == [
         {
             'field': 'assetsSummary',
-            'message': 'A Dandiset containing no files or zero bytes is not publishable',
+            'message': 'Value error, '
+                       'A Dandiset containing no files or zero bytes is not publishable',
         }
     ]
 

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -153,7 +153,7 @@ def test_validate_asset_metadata_no_digest(draft_asset: Asset):
 
     assert draft_asset.status == Asset.Status.INVALID
     assert draft_asset.validation_errors == [
-        {'field': 'digest', 'message': 'A non-zarr asset must have a sha2_256.'}
+        {'field': 'digest', 'message': 'Value error, A non-zarr asset must have a sha2_256.'}
     ]
 
 

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -293,7 +293,7 @@ def test_validate_version_metadata_no_assets(
         {
             'field': 'assetsSummary',
             'message': 'Value error, '
-                       'A Dandiset containing no files or zero bytes is not publishable',
+            'A Dandiset containing no files or zero bytes is not publishable',
         }
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'dandischema~=0.8.4',
+        'dandischema~=0.9.0',
         'django~=4.1.0',
         'django-admin-display',
         # Require 0.58.0 as it is the first version to support postgres' native

--- a/web/src/components/Meditor/types.ts
+++ b/web/src/components/Meditor/types.ts
@@ -65,7 +65,7 @@ export const isJSONSchema = (schema: JSONSchemaUnionType): schema is JSONSchema7
 
 export const isBasicSchema = (schema: JSONSchemaUnionType): schema is BasicSchema => (
   isJSONSchema(schema)
-  && isBasicType(schema.type)
+  && (isBasicType(schema.type) || schema.type === undefined)
 );
 
 export const isObjectSchema = (schema: JSONSchemaUnionType): schema is ObjectSchema => (

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -181,7 +181,7 @@ const descriptionMaxLength: ComputedRef<number> = computed(
   () => store.schema.properties.description.maxLength,
 );
 const dandiLicenses: ComputedRef<LicenseType[]> = computed(
-  () => store.schema.definitions.LicenseType.enum,
+  () => store.schema.$defs.LicenseType.enum,
 );
 
 if (!loggedIn()) {


### PR DESCRIPTION
Closes #1820 

TODOs
- [x] address fails in e2e tests and investigate if any other changes possibly needed in frontend due to slight changes in the schema (between 0.6.4 and 0.6.6 of https://github.com/dandi/schema/tree/master/releases; documentation of those changes at the top posts of https://github.com/dandi/dandi-schema/pull/203 and https://github.com/dandi/dandi-schema/pull/218). Extra notes from @candleindark :
   - context.json should be the same as before.
   - All other files are generated by Pydantic V2 with a small modification from the default behavior, and they are compliant with JSON Schema Draft 2020-12 (https://docs.pydantic.dev/latest/concepts/json_schema/ for details)
   - The small modification in behavior  is documented in point `#2` in "Additional notes regarding changes entailed by Pydantic V2" in the top post of https://github.com/dandi/dandi-schema/pull/203.
- [x] I expect dandi-cli tests to pass but might fail. 
- [x] test against version in https://github.com/dandi/dandi-cli/pull/1381 in TEMP commit (it was 150297c3f91a08b0748f57824aded1df93228a4e commit, now gone)
- [x] Remove TEMP commit(s)