### PR TITLE
DEVELOPMENT.md: set email to the one known to git

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,10 +6,10 @@ This is the simplest configuration for developers to start with.
 ### Initial Setup
 1. Run `docker-compose run --rm django ./manage.py migrate`
 2. Run `docker-compose run --rm django ./manage.py createcachetable`
-3. Run `docker-compose run --rm django ./manage.py createsuperuser`
+3. Run `docker-compose run --rm django ./manage.py createsuperuser --email $(git config user.email)`
    and follow the prompts to create your own user.
-   Set your username to your email to ensure parity with how GitHub logins work.
-4. Run `docker-compose run --rm django ./manage.py create_dev_dandiset --owner your.email@example.com`
+   We set your username to your git email to ensure parity with how GitHub logins work.
+4. Run `docker-compose run --rm django ./manage.py create_dev_dandiset --owner $(git config user.email)`
    to create a dummy dandiset to start working with.
 
 ### Run Application
@@ -45,8 +45,8 @@ but allows developers to run Python code on their native system.
 7. Run `source ./dev/export-env.sh`
 8. Run `./manage.py migrate`
 9. Run `./manage.py createcachetable`
-10. Run `./manage.py createsuperuser` and follow the prompts to create your own user
-11. Run `./manage.py create_dev_dandiset --owner your.email@example.com`
+10. Run `./manage.py createsuperuser --email $(git config user.email)` and follow the prompts.
+11. Run `./manage.py create_dev_dandiset --owner $(git config user.email)`
    to create a dummy dandiset to start working with.
 
 ### Run Application
@@ -122,7 +122,7 @@ to call.
 
 ### Creating a Token
 Visit the URL `/admin` with a web browser, logging
-in with the credentials entered during the `createsuperuser` setup step..
+in with the credentials entered during the `createsuperuser` setup step.
 Then go to `/swagger` and use `GET /auth/token` end-point.
 
 ### Supplying the Token
@@ -137,7 +137,7 @@ For frequent deployment administration tasks, `django-extensions` provides a con
 ### create_dev_dandiset
 
 ```
-python manage.py create_dev_dandiset --owner your.email@example.com --name My Dummy Dandiset
+python manage.py create_dev_dandiset --owner $(git config user.email) --name My Dummy Dandiset
 ```
 
 This creates a dummy dandiset with valid metadata and a single dummy asset.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ This is the simplest configuration for developers to start with.
 3. Run `docker-compose run --rm django ./manage.py createsuperuser`
    and follow the prompts to create your own user.
    Set your username to your email to ensure parity with how GitHub logins work.
-4. Run `docker-compose run --rm django ./manage.py create_dev_dandiset --owner your.email@email.com`
+4. Run `docker-compose run --rm django ./manage.py create_dev_dandiset --owner your.email@example.com`
    to create a dummy dandiset to start working with.
 
 ### Run Application
@@ -46,7 +46,7 @@ but allows developers to run Python code on their native system.
 8. Run `./manage.py migrate`
 9. Run `./manage.py createcachetable`
 10. Run `./manage.py createsuperuser` and follow the prompts to create your own user
-11. Run `./manage.py create_dev_dandiset --owner your.email@email.com`
+11. Run `./manage.py create_dev_dandiset --owner your.email@example.com`
    to create a dummy dandiset to start working with.
 
 ### Run Application
@@ -137,7 +137,7 @@ For frequent deployment administration tasks, `django-extensions` provides a con
 ### create_dev_dandiset
 
 ```
-python manage.py create_dev_dandiset --owner your.email@email.com --name My Dummy Dandiset
+python manage.py create_dev_dandiset --owner your.email@example.com --name My Dummy Dandiset
 ```
 
 This creates a dummy dandiset with valid metadata and a single dummy asset.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,7 +8,7 @@ This is the simplest configuration for developers to start with.
 2. Run `docker-compose run --rm django ./manage.py createcachetable`
 3. Run `docker-compose run --rm django ./manage.py createsuperuser --email $(git config user.email)`
    and follow the prompts to create your own user.
-   We set your username to your git email to ensure parity with how GitHub logins work.
+   This sets your username to your git email to ensure parity with how GitHub logins work. You can also replace the command substitution expression with a literal email address, or omit the `--email` option entirely to run the command in interactive mode.
 4. Run `docker-compose run --rm django ./manage.py create_dev_dandiset --owner $(git config user.email)`
    to create a dummy dandiset to start working with.
 


### PR DESCRIPTION
While following some instructions like this I would prefer to just be able to copy/paste and not follow unnecessary interactive prompts.

In the beginning of the doc we recommend to use the same email as for github which is likely to be the one configured in git. Hence I decided to just query `git`.

One other aspect I am fixing -- I am adding explicitly the email to `createsuperuser` so me/developer does not need to think twice to enter some other email from what I just entered interactively.

Sits on top of #1827 