### PR TITLE
Remove obsolete/not-applicable TODO

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -54,8 +54,6 @@ class DandiMixin(ConfigMixin):
         # Authentication
         configuration.AUTHENTICATION_BACKENDS += ['guardian.backends.ObjectPermissionBackend']
         configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += [
-            # TODO: remove TokenAuthentication, it is only here to support
-            # the setTokenHack login workaround
             'rest_framework.authentication.TokenAuthentication',
         ]
 


### PR DESCRIPTION
The comment used to correspond to reality, and was needed for some ad-hoc manual invocation to setTokenHack but it was removed in 984451c822525343a6f54bffad4c8fa39a68ac78 AKA `v0.1.37~27^2~9^2~79^2`
a few years ago.  Now this is the correct specification of DRF