### PR TITLE
Design doc - Publish Dandisets that contain Zarr archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,5 @@ dmypy.json
 
 # Editor settings
 .vscode
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -125,5 +125,3 @@ dmypy.json
 
 # Editor settings
 .vscode
-
-.DS_Store

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -27,27 +27,16 @@ Reuse a Zarr archive in more than one Dandiset.
 
 Allow for a Zarr archive that is uploaded as part of an original Dandiset to be packaged in a new Dandiset without duplicating the Zarr archive.  The new Dandiset could be created by potentially different authors and could contain additional raw and/or analyzed data.  This feature has been previously implemented for other asset types with [add_asset_to_dandiset.py](https://gist.github.com/satra/29404d965226e4c99fb48e7502953503#file-add_asset_to_dandiset-py).  Further details of this feature request have been previously documented in #1792.
 
-## MVP User requirements (Target date: April 30, 2024)
+## Requirements (Target date: April 30, 2024)
 
 1. Publish Dandisets that contain Zarr archives.
-1. The published Dandisets must be immutable and accessible.
-1. The draft version of the Dandiset should be mutable.
-1. Minimize storage costs in the design.
+2. If the same Zarr archive is uploaded to multiple Dandisets, then the Zarr archive should not be re-uploaded.
 
-## MVP+1 User requirements
+## Implementation details
 
-1. Support linking of a Zarr asset to multiple Dandisets
-
-## MVP Technical specifications
-
-1. Support versioning of Zarr archives.
-1. Create a unique web address for each published version of the Zarr archive.
-1. Provide access to the Zarr archive versions through the web app and command line interface.
-1. TODO: add additional specifications
-
-## MVP+1 Technical specifications
-
-1. TODO
+1. Design a lightweight object to version Zarr archives.
+    1. For a candidate implementation see https://github.com/dandi/zarr-manifests/.
+2. Minimize storage costs in the design.
 
 ## Potential solutions
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -36,7 +36,7 @@ Allow for a Zarr archive that is uploaded as part of an original Dandiset to be 
 
 ## MVP+1 User requirements
 
-1. Support linking of a Zarr asset to multiple Dandisets - [dandi-archive/issues/1792](https://github.com/dandi/dandi-archive/issues/1792)
+1. Support linking of a Zarr asset to multiple Dandisets
 
 ## MVP Technical specifications
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -30,7 +30,7 @@ Allow for a Zarr archive that is uploaded as part of an original Dandiset to be 
 ## Requirements (Target date: April 30, 2024)
 
 1. Publish Dandisets that contain Zarr archives.
-2. If the same Zarr archive is uploaded to multiple Dandisets, then the Zarr archive should not be re-uploaded.
+2. If the same Zarr archive is uploaded to multiple Dandisets, then the Zarr archive should not be re-uploaded.  This requirement would mirror the behavior of non-Zarr asset blobs.
 
 ## Implementation details
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -51,21 +51,22 @@ Allow for a Zarr archive that is uploaded as part of an original Dandiset to be 
 
 ## Potential solutions
 
-1. Implement a Django backend for Zarr
-    1. Stores data in a Postgres database that references the Zarr chunks in S3.
-
 1. Earthmover's [Arraylake](https://earthmover.io/blog/arraylake-beta-launch)
-    - Notes
-        - Edits of the Zarr archive must happen through the Arraylake Python API, and thus the `dandi-cli` should be updated.
-    - Questions
-        - Egress costs?
-        - Formal testing of Python API and infrastructure to ensure data integrity?
+    1. Notes
+        1. Edits of the Zarr archive must happen through the Arraylake Python API, and thus the `dandi-cli` should be updated.
+    2. Questions
+        1. Egress costs?
+        2. Formal testing of Python API and infrastructure to ensure data integrity?
 
-1. Create manifest file with paths and version IDs for each chunk for a specific version of the Zarr archive.
-    1. Steps
+2. Create manifest file with paths and version IDs for each chunk for a specific version of the Zarr archive.
+    1. Candidate implementation - https://github.com/dandi/zarr-manifests/
+    2. Steps
         1. Initiate S3 bucket versioning
-    1. Questions
+    3. Questions
         1. Store the manifest file in a database instead of S3 for improved performance?
-    1. Constraints
+    4. Constraints
         1. If the Zarr archive must be re-chunked then the user would need to upload the entire Zarr archive.
-        1. Garbage collection would need to be updated.
+        2. Garbage collection would need to be updated.
+
+3. Implement a Django backend for Zarr
+    1. Stores data in a Postgres database that references the Zarr chunks in S3.

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -20,7 +20,7 @@ The publishing procedure would follow the description found in the [publish-1 de
 ## MVP User requirements (Target date: April 30, 2024)
 
 1. Publish Dandisets that contain Zarr archives.
-1. The published Dandisets must be immutable and accesible.
+1. The published Dandisets must be immutable and accessible.
 1. The draft version of the Dandiset should be mutable.
 1. Minimize storage costs in the design.
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -30,7 +30,9 @@ The publishing procedure would follow the description found in the [publish-1 de
 
 ## MVP Technical specifications
 
-1. TODO
+1. Support versioning of Zarr archives.
+1. Create a unique web address for each published version of the Zarr archive.
+1. Provide access to the Zarr archive versions through the web app and command line interface.
 
 ## MVP+1 Technical specifications
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -1,26 +1,24 @@
-# Publish Dandisets with Zarr assets
+# Publish Dandisets with Zarr archives
 
-This document describes the current implementation of publishing Dandisets with Zarr assets, a future use case, and the associated requirements.
+This document describes the current implementation of publishing Dandisets with Zarr archives, a desired use case, and the associated requirements of this use case.
 
 ## Current implementation
 
-Currently when a blob asset is updated, a new version (i.e. a copy) is uploaded to S3.  Zarr assets are too large to create multiple copies, so the upload occurs once and it is edited in place.  This design means that the Zarr archive would be immutable once published.  So currently the system is designed to not publish Dandisets that contain Zarr asset(s).
+Currently when a blob asset is updated, a new version (i.e. a copy) is uploaded to S3.  Zarr archives are too large so multiple copies should not be created.  A Zarr archive is uploaded once and it is edited in place.  This design means that the Zarr archive is immutable once the Dandiset is published.  For more details, see the [zarr-support-3 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/zarr-support-3.md).
 
 ## Use case 1
 
-Publish Dandisets with Zarr asset(s) following the general publishing procedure described in the [publish-1 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/publish-1.md).
+Publish Dandisets with Zarr archive(s) following the general publishing procedure described in the [publish-1 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/publish-1.md).  A modified publishing procedure that includes Zarr archive(s) is summarized below.
 
-### Steps
-
-1. User uploads a new Dandiset which includes Zarr asset(s).
-2. User uploads an updated Zarr asset in the `Draft` version of the Dandiset.  
+1. User uploads a new Dandiset which includes Zarr archive(s).
+2. User uploads an updated Zarr archive in the `Draft` version of the Dandiset.  
 3. User publishes the Dandiset and thereby creates a new version of the Dandiset.
 4. User repeats steps 2 and 3.
 
 ## MVP Requirements (Target date: April 30, 2024)
 
 1. Permit versioning of Zarr archives without creating a copy of the entire Zarr archive
-1. Permit publishing of Dandisets with Zarr assets
+1. Permit publishing of Dandisets with Zarr archives
 1. Minimize storage costs in the design
 
 ## MVP+1 Requirements
@@ -28,7 +26,4 @@ Publish Dandisets with Zarr asset(s) following the general publishing procedure 
 1. Permit linking of a Zarr asset to multiple Dandisets - [dandi-archive/issues/1792](https://github.com/dandi/dandi-archive/issues/1792)
 
 
-- Zarrbargo - Zarr interacts with embargo.  Hide and unhide for all subfiles.
-- Copy on write happens because of publishing
-- Zarr related copies, copies on writes
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -1,4 +1,4 @@
-# Support updates to Zarr archives after publishing the corresponding Dandiset
+# Publish Dandisets that contain Zarr archives, and support updates to the Zarr archive after publishing the Dandiset
 
 This document describes the current implementation of publishing Dandisets with Zarr archives, a desired use case, and the associated requirements of this use case.
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -17,15 +17,22 @@ The publishing procedure would follow the description found in the [publish-1 de
 3. User publishes the Dandiset and thereby creates a new immutable version of the Dandiset.
 4. User repeats steps 2 and 3.
 
-## MVP Requirements (Target date: April 30, 2024)
+## MVP User requirements (Target date: April 30, 2024)
 
-1. Support versioning of Zarr archives without creating a copy of the entire Zarr archive.
-1. Support publishing immutable versions of Dandisets with Zarr archives, where the Zarr archives are potentially updated between versions.
+1. Publish Dandisets that contain Zarr archives.
+1. The published Dandisets must be immutable and accesible.
+1. The draft version of the Dandiset should be mutable.
 1. Minimize storage costs in the design.
 
-## MVP+1 Requirements
+## MVP+1 User requirements
 
 1. Support linking of a Zarr asset to multiple Dandisets - [dandi-archive/issues/1792](https://github.com/dandi/dandi-archive/issues/1792)
 
+## MVP Technical specifications
 
+1. TODO
+
+## MVP+1 Technical specifications
+
+1. TODO
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -17,6 +17,11 @@ The publishing procedure would follow the description found in the [publish-1 de
 3. User publishes the Dandiset and thereby creates a new immutable version of the Dandiset.
 4. User repeats steps 2 and 3.
 
+## Use case 2
+
+Upload a Zarr archive to an embargoed Dandiset. 
+
+
 ## MVP User requirements (Target date: April 30, 2024)
 
 1. Publish Dandisets that contain Zarr archives.

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -13,9 +13,9 @@ Publish a Dandiset containing a Zarr archive(s), and subsequently update the Zar
 The publishing procedure would follow the description found in the [publish-1 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/publish-1.md).  A modified publishing procedure that includes Zarr archive(s) is summarized below.
 
 1. User uploads a new Dandiset which includes a Zarr archive(s).
-2. User uploads an updated Zarr archive(s) to the `Draft` version of the Dandiset.  
-3. User publishes the Dandiset and thereby creates a new immutable version of the Dandiset.
-4. User repeats steps 2 and 3.
+1. User publishes the Dandiset and thereby creates a new immutable version of the Dandiset.
+1. User uploads an updated Zarr archive(s) to the `Draft` version of the Dandiset.
+1. User repeats steps 2 and 3.
 
 ## Use case 2
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -1,6 +1,7 @@
 # Publishing Dandisets that contain Zarr archives
 
 This document describes the current implementation of publishing Dandisets with Zarr archives, desired use cases, and the associated requirements.
+Note that once the requirements for `Use case 1` are implemented, then `Use cases 2-3` will be capable.
 
 ## Current implementation
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -36,3 +36,23 @@ The publishing procedure would follow the description found in the [publish-1 de
 
 1. TODO
 
+## Potential solutions
+
+1. Implement a Django backend for Zarr
+    1. Stores data in a Postgres database that references the Zarr chunks in S3.
+
+1. Earthmover's [Arraylake](https://earthmover.io/blog/arraylake-beta-launch)
+    - Notes
+        - Edits of the Zarr archive must happen through the Arraylake Python API, and thus the `dandi-cli` should be updated.
+    - Questions
+        - Egress costs?
+        - Formal testing of Python API and infrastructure to ensure data integrity?
+
+1. Create manifest file with paths and version IDs for each chunk for a specific version of the Zarr archive.
+    1. Steps
+        1. Initiate S3 bucket versioning
+    1. Questions
+        1. Store the manifest file in a database instead of S3 for improved performance?
+    1. Constraints
+        1. If the Zarr archive must be re-chunked then the user would need to upload the entire Zarr archive.
+        1. Garbage collection would need to be updated.

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -43,6 +43,7 @@ Allow for a Zarr archive that is uploaded as part of an original Dandiset to be 
 1. Support versioning of Zarr archives.
 1. Create a unique web address for each published version of the Zarr archive.
 1. Provide access to the Zarr archive versions through the web app and command line interface.
+1. TODO: add additional specifications
 
 ## MVP+1 Technical specifications
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -1,29 +1,31 @@
-# Publish Dandisets with Zarr archives
+# Support updates to Zarr archives after publishing the corresponding Dandiset
 
 This document describes the current implementation of publishing Dandisets with Zarr archives, a desired use case, and the associated requirements of this use case.
 
 ## Current implementation
 
-Currently when a blob asset is updated, a new version (i.e. a copy) is uploaded to S3.  Zarr archives are too large so multiple copies should not be created.  A Zarr archive is uploaded once and it is edited in place.  This design means that the Zarr archive is immutable once the Dandiset is published.  For more details, see the [zarr-support-3 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/zarr-support-3.md).
+When a blob asset is updated, a new version (i.e. a copy) is uploaded to the S3 bucket.  Zarr archives are too large so multiple copies should not be created.  A Zarr archive is uploaded once and it is updated in place.  This design means that the Zarr archive is immutable once the Dandiset is published, so that the published Dandiset is immutable.  For more details, see the [zarr-support-3 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/zarr-support-3.md).
 
 ## Use case 1
 
-Publish Dandisets with Zarr archive(s) following the general publishing procedure described in the [publish-1 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/publish-1.md).  A modified publishing procedure that includes Zarr archive(s) is summarized below.
+Publish a Dandiset containing a Zarr archive(s), and subsequently update the Zarr archive(s).
 
-1. User uploads a new Dandiset which includes Zarr archive(s).
-2. User uploads an updated Zarr archive in the `Draft` version of the Dandiset.  
-3. User publishes the Dandiset and thereby creates a new version of the Dandiset.
+The publishing procedure would follow the description found in the [publish-1 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/publish-1.md).  A modified publishing procedure that includes Zarr archive(s) is summarized below.
+
+1. User uploads a new Dandiset which includes a Zarr archive(s).
+2. User uploads an updated Zarr archive(s) to the `Draft` version of the Dandiset.  
+3. User publishes the Dandiset and thereby creates a new immutable version of the Dandiset.
 4. User repeats steps 2 and 3.
 
 ## MVP Requirements (Target date: April 30, 2024)
 
-1. Permit versioning of Zarr archives without creating a copy of the entire Zarr archive
-1. Permit publishing of Dandisets with Zarr archives
-1. Minimize storage costs in the design
+1. Support versioning of Zarr archives without creating a copy of the entire Zarr archive.
+1. Support publishing immutable versions of Dandisets with Zarr archives, where the Zarr archives are potentially updated between versions.
+1. Minimize storage costs in the design.
 
 ## MVP+1 Requirements
 
-1. Permit linking of a Zarr asset to multiple Dandisets - [dandi-archive/issues/1792](https://github.com/dandi/dandi-archive/issues/1792)
+1. Support linking of a Zarr asset to multiple Dandisets - [dandi-archive/issues/1792](https://github.com/dandi/dandi-archive/issues/1792)
 
 
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -1,6 +1,6 @@
 # Publish Dandisets that contain Zarr archives, and support updates to the Zarr archive after publishing the Dandiset
 
-This document describes the current implementation of publishing Dandisets with Zarr archives, a desired use case, and the associated requirements of this use case.
+This document describes the current implementation of publishing Dandisets with Zarr archives, desired use cases, and the associated requirements.
 
 ## Current implementation
 
@@ -21,6 +21,11 @@ The publishing procedure would follow the description found in the [publish-1 de
 
 Upload a Zarr archive to an embargoed Dandiset. 
 
+## Use case 3
+
+Reuse a Zarr archive in more than one Dandiset.
+
+Allow for a Zarr archive that is uploaded as part of an original Dandiset to be packaged in a new Dandiset without duplicating the Zarr archive.  The new Dandiset could be created by potentially different authors and could contain additional raw and/or analyzed data.  This feature has been previously implemented for other asset types with [add_asset_to_dandiset.py](https://gist.github.com/satra/29404d965226e4c99fb48e7502953503#file-add_asset_to_dandiset-py).  Further details of this feature request have been previously documented in [dandi-archive #1792](https://github.com/dandi/dandi-archive/issues/1792).
 
 ## MVP User requirements (Target date: April 30, 2024)
 

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -1,0 +1,34 @@
+# Publish Dandisets with Zarr assets
+
+This document describes the current implementation of publishing Dandisets with Zarr assets, a future use case, and the associated requirements.
+
+## Current implementation
+
+Currently when a blob asset is updated, a new version (i.e. a copy) is uploaded to S3.  Zarr assets are too large to create multiple copies, so the upload occurs once and it is edited in place.  This design means that the Zarr archive would be immutable once published.  So currently the system is designed to not publish Dandisets that contain Zarr asset(s).
+
+## Use case 1
+
+Publish Dandisets with Zarr asset(s) following the general publishing procedure described in the [publish-1 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/publish-1.md).
+
+### Steps
+
+1. User uploads a new Dandiset which includes Zarr asset(s).
+2. User uploads an updated Zarr asset in the `Draft` version of the Dandiset.  
+3. User publishes the Dandiset and thereby creates a new version of the Dandiset.
+4. User repeats steps 2 and 3.
+
+## MVP Requirements (Target date: April 30, 2024)
+
+1. Permit versioning of Zarr archives without creating a copy of the entire Zarr archive
+1. Permit publishing of Dandisets with Zarr assets
+1. Minimize storage costs in the design
+
+## MVP+1 Requirements
+
+1. Permit linking of a Zarr asset to multiple Dandisets - [dandi-archive/issues/1792](https://github.com/dandi/dandi-archive/issues/1792)
+
+
+- Zarrbargo - Zarr interacts with embargo.  Hide and unhide for all subfiles.
+- Copy on write happens because of publishing
+- Zarr related copies, copies on writes
+

--- a/doc/design/zarr-publish-1.md
+++ b/doc/design/zarr-publish-1.md
@@ -4,7 +4,7 @@ This document describes the current implementation of publishing Dandisets with 
 
 ## Current implementation
 
-When a blob asset is updated, a new version (i.e. a copy) is uploaded to the S3 bucket.  Zarr archives are too large so multiple copies should not be created.  A Zarr archive is uploaded once and it is updated in place.  This design means that the Zarr archive is immutable once the Dandiset is published, so that the published Dandiset is immutable.  For more details, see the [zarr-support-3 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/zarr-support-3.md).
+When a blob asset is updated, a new version (i.e. a copy) is uploaded to the S3 bucket.  Zarr archives are too large so multiple copies should not be created.  A Zarr archive is uploaded once and it is updated in place.  This design means that the Zarr archive is immutable once the Dandiset is published, so that the published Dandiset is immutable. Currently, a Dandiset cannot be published if it contains a Zarr asset.  For more details, see the [zarr-support-3 design doc](https://github.com/dandi/dandi-archive/blob/master/doc/design/zarr-support-3.md).
 
 ## Use case 1
 


### PR DESCRIPTION
- [ ] Define user requirements
  - [x] Update design doc based on 2024-01-26 discussion @kabilar 
- [ ] Define technical specifications @waxlamp @kabilar 
- [ ] Prototype and evaluate tradeoffs of potential solutions
  - [ ] Pure DANDI side based on zarr manifest files
    - [x] Create manifest files with paths and version IDs for each chunk for a specific version of the Zarr archive @yarikoptic
       - [x] Implemented in this repo: https://github.com/dandi/zarr-manifests/  with more complete copy at https://datasets.datalad.org/?dir=/dandi/zarr-manifests/zarr-manifests-v2-sorted 
     - [x] Demonstrate use in dandidav: planned in https://github.com/dandi/dandidav/issues/43
    - [ ] Work out design for support in dandi-archive to adopt such an approach
  - [ ] Explore Arraylake @waxlamp 