### PR TITLE
Resolve remaining failures in #1823

### DIFF
--- a/dandiapi/api/services/version/metadata.py
+++ b/dandiapi/api/services/version/metadata.py
@@ -43,6 +43,6 @@ def _normalize_version_metadata(
     }
     # Run the version_metadata through the pydantic model to automatically include any boilerplate
     # like the access or repository fields
-    return PydanticDandiset.model_construct(
-        **version_metadata
-    ).model_dump(mode='json',exclude_none=True)
+    return PydanticDandiset.model_construct(**version_metadata).model_dump(
+        mode='json', exclude_none=True
+    )

--- a/dandiapi/api/services/version/metadata.py
+++ b/dandiapi/api/services/version/metadata.py
@@ -43,4 +43,6 @@ def _normalize_version_metadata(
     }
     # Run the version_metadata through the pydantic model to automatically include any boilerplate
     # like the access or repository fields
-    return PydanticDandiset.unvalidated(**version_metadata).json_dict()
+    return PydanticDandiset.model_construct(
+        **version_metadata
+    ).model_dump(mode='json',exclude_none=True)

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -262,7 +262,7 @@ def test_validate_version_metadata_no_assets(
         {
             'field': 'assetsSummary',
             'message': 'Value error, '
-                       'A Dandiset containing no files or zero bytes is not publishable',
+            'A Dandiset containing no files or zero bytes is not publishable',
         }
     ]
 

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -151,7 +151,7 @@ def test_validate_asset_metadata_no_digest(draft_asset: Asset):
 
     assert draft_asset.status == Asset.Status.INVALID
     assert draft_asset.validation_errors == [
-        {'field': 'digest', 'message': 'A non-zarr asset must have a sha2_256.'}
+        {'field': 'digest', 'message': 'Value error, A non-zarr asset must have a sha2_256.'}
     ]
 
 

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -261,7 +261,8 @@ def test_validate_version_metadata_no_assets(
     assert draft_version.validation_errors == [
         {
             'field': 'assetsSummary',
-            'message': 'A Dandiset containing no files or zero bytes is not publishable',
+            'message': 'Value error, '
+                       'A Dandiset containing no files or zero bytes is not publishable',
         }
     ]
 


### PR DESCRIPTION
This PR resolves the remaining failures in tests for backend in #1823 once https://github.com/dandi/dandi-schema/pull/218 is merged to the master of the `dandi-schema` repo, a new version of `dandi-schema` is published, and set to be used by `dandi-archive`.