### PR TITLE
Add a Nix Flake for native build dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706211182,
+        "narHash": "sha256-Fh4w+m6jt1TdSkAIYvuYxjrpuWO0I76sRPOjEYdqaNY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8cc42008aa3b1cba810b1bbe3745619214c6359d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "DANDI native build dev environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+
+  outputs = { self, nixpkgs }:
+    let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    in
+    {
+      devShells.x86_64-linux.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          # Python 3.11
+          python311Packages.python
+
+          # Docker and Docker Compose
+          docker
+
+          # Postgres stuff
+          postgresql
+          libpqxx
+        ];
+
+        shellHook = ''
+          source ./venv/bin/activate
+          source ./dev/export-env.sh
+        '';
+      };
+    };
+}


### PR DESCRIPTION
This PR makes it much easier for anyone running NixOS, or using the Nix package manager, to spin up a dev shell for running DANDI in native mode. For people not using those platforms, this will have zero impact.