### PR TITLE
Add tooltips to describe FileBrowserView action icons

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -149,6 +149,7 @@
                     icon
                     :href="inlineURI(item.asset.asset_id)"
                     target="_blank"
+                    title="View asset"
                   >
                     <v-icon color="primary">
                       mdi-eye
@@ -160,6 +161,7 @@
                   <v-btn
                     icon
                     :href="downloadURI(item.asset.asset_id)"
+                    title="Download asset"
                   >
                     <v-icon color="primary">
                       mdi-download
@@ -173,6 +175,7 @@
                     :href="assetMetadataURI(item.asset.asset_id)"
                     target="_blank"
                     rel="noopener"
+                    title="View asset metadata"
                   >
                     <v-icon color="primary">
                       mdi-information
@@ -190,6 +193,7 @@
                         v-if="item.services && item.services.length"
                         color="primary"
                         icon
+                        title="Open in external service"
                         v-bind="attrs"
                         v-on="on"
                       >

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -151,6 +151,7 @@
                         icon
                         :href="inlineURI(item.asset.asset_id)"
                         target="_blank"
+                        rel="noreferrer"
                         v-bind="attrs"
                         v-on="on"
                       >
@@ -188,7 +189,7 @@
                         icon
                         :href="assetMetadataURI(item.asset.asset_id)"
                         target="_blank"
-                        rel="noopener"
+                        rel="noreferrer"
                         v-bind="attrs"
                         v-on="on"
                       >
@@ -242,7 +243,7 @@
                         :key="el.name"
                         :href="el.url"
                         target="_blank"
-                        rel="noopener"
+                        rel="noreferrer"
                       >
                         <v-list-item-title class="font-weight-light">
                           {{ el.name }}

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -145,42 +145,60 @@
                 </v-list-item-action>
 
                 <v-list-item-action v-if="item.asset">
-                  <v-btn
-                    icon
-                    :href="inlineURI(item.asset.asset_id)"
-                    target="_blank"
-                    title="View asset"
-                  >
-                    <v-icon color="primary">
-                      mdi-eye
-                    </v-icon>
-                  </v-btn>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        icon
+                        :href="inlineURI(item.asset.asset_id)"
+                        target="_blank"
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        <v-icon color="primary">
+                          mdi-eye
+                        </v-icon>
+                      </v-btn>
+                    </template>
+                    <span>View asset in browser</span>
+                  </v-tooltip>
                 </v-list-item-action>
 
                 <v-list-item-action v-if="item.asset">
-                  <v-btn
-                    icon
-                    :href="downloadURI(item.asset.asset_id)"
-                    title="Download asset"
-                  >
-                    <v-icon color="primary">
-                      mdi-download
-                    </v-icon>
-                  </v-btn>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        icon
+                        :href="downloadURI(item.asset.asset_id)"
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        <v-icon color="primary">
+                          mdi-download
+                        </v-icon>
+                      </v-btn>
+                    </template>
+                    <span>Download asset</span>
+                  </v-tooltip>
                 </v-list-item-action>
 
                 <v-list-item-action v-if="item.asset">
-                  <v-btn
-                    icon
-                    :href="assetMetadataURI(item.asset.asset_id)"
-                    target="_blank"
-                    rel="noopener"
-                    title="View asset metadata"
-                  >
-                    <v-icon color="primary">
-                      mdi-information
-                    </v-icon>
-                  </v-btn>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        icon
+                        :href="assetMetadataURI(item.asset.asset_id)"
+                        target="_blank"
+                        rel="noopener"
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        <v-icon color="primary">
+                          mdi-information
+                        </v-icon>
+                      </v-btn>
+                    </template>
+                    <span>View asset metadata</span>
+                  </v-tooltip>
                 </v-list-item-action>
 
                 <v-list-item-action v-if="item.asset">


### PR DESCRIPTION
This splits out a contribution from #1666 that adds tooltips to the file browser view's action icons.

(attn: @magland)