### PR TITLE
Improve file browser view action icons

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -149,6 +149,7 @@
                     icon
                     :href="inlineURI(item.asset.asset_id)"
                     target="_blank"
+                    title="View asset"
                   >
                     <v-icon color="primary">
                       mdi-eye
@@ -160,6 +161,7 @@
                   <v-btn
                     icon
                     :href="downloadURI(item.asset.asset_id)"
+                    title="Download asset"
                   >
                     <v-icon color="primary">
                       mdi-download
@@ -173,6 +175,7 @@
                     :href="assetMetadataURI(item.asset.asset_id)"
                     target="_blank"
                     rel="noopener"
+                    title="View asset metadata"
                   >
                     <v-icon color="primary">
                       mdi-information
@@ -190,6 +193,7 @@
                         v-if="item.services && item.services.length"
                         color="primary"
                         icon
+                        title="Open in external service"
                         v-bind="attrs"
                         v-on="on"
                       >

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -150,17 +150,15 @@
                       <v-btn
                         icon
                         :href="inlineURI(item.asset.asset_id)"
-                        target="_blank"
-                        rel="noreferrer"
                         v-bind="attrs"
                         v-on="on"
                       >
                         <v-icon color="primary">
-                          mdi-open-in-new
+                          mdi-open-in-app
                         </v-icon>
                       </v-btn>
                     </template>
-                    <span>Open asset in new window</span>
+                    <span>Open asset in browser</span>
                   </v-tooltip>
                 </v-list-item-action>
 

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -151,6 +151,7 @@
                         icon
                         :href="inlineURI(item.asset.asset_id)"
                         target="_blank"
+                        rel="noreferrer"
                         v-bind="attrs"
                         v-on="on"
                       >
@@ -188,7 +189,7 @@
                         icon
                         :href="assetMetadataURI(item.asset.asset_id)"
                         target="_blank"
-                        rel="noopener"
+                        rel="noreferrer"
                         v-bind="attrs"
                         v-on="on"
                       >
@@ -242,7 +243,7 @@
                         :key="el.name"
                         :href="el.url"
                         target="_blank"
-                        rel="noopener"
+                        rel="noreferrer"
                       >
                         <v-list-item-title class="font-weight-light">
                           {{ el.name }}

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -156,11 +156,11 @@
                         v-on="on"
                       >
                         <v-icon color="primary">
-                          mdi-eye
+                          mdi-open-in-new
                         </v-icon>
                       </v-btn>
                     </template>
-                    <span>View asset in browser</span>
+                    <span>Open asset in new window</span>
                   </v-tooltip>
                 </v-list-item-action>
 

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -145,42 +145,60 @@
                 </v-list-item-action>
 
                 <v-list-item-action v-if="item.asset">
-                  <v-btn
-                    icon
-                    :href="inlineURI(item.asset.asset_id)"
-                    target="_blank"
-                    title="View asset"
-                  >
-                    <v-icon color="primary">
-                      mdi-eye
-                    </v-icon>
-                  </v-btn>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        icon
+                        :href="inlineURI(item.asset.asset_id)"
+                        target="_blank"
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        <v-icon color="primary">
+                          mdi-eye
+                        </v-icon>
+                      </v-btn>
+                    </template>
+                    <span>View asset in browser</span>
+                  </v-tooltip>
                 </v-list-item-action>
 
                 <v-list-item-action v-if="item.asset">
-                  <v-btn
-                    icon
-                    :href="downloadURI(item.asset.asset_id)"
-                    title="Download asset"
-                  >
-                    <v-icon color="primary">
-                      mdi-download
-                    </v-icon>
-                  </v-btn>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        icon
+                        :href="downloadURI(item.asset.asset_id)"
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        <v-icon color="primary">
+                          mdi-download
+                        </v-icon>
+                      </v-btn>
+                    </template>
+                    <span>Download asset</span>
+                  </v-tooltip>
                 </v-list-item-action>
 
                 <v-list-item-action v-if="item.asset">
-                  <v-btn
-                    icon
-                    :href="assetMetadataURI(item.asset.asset_id)"
-                    target="_blank"
-                    rel="noopener"
-                    title="View asset metadata"
-                  >
-                    <v-icon color="primary">
-                      mdi-information
-                    </v-icon>
-                  </v-btn>
+                  <v-tooltip top>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        icon
+                        :href="assetMetadataURI(item.asset.asset_id)"
+                        target="_blank"
+                        rel="noopener"
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        <v-icon color="primary">
+                          mdi-information
+                        </v-icon>
+                      </v-btn>
+                    </template>
+                    <span>View asset metadata</span>
+                  </v-tooltip>
                 </v-list-item-action>
 
                 <v-list-item-action v-if="item.asset">

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -209,22 +209,13 @@
                   >
                     <template #activator="{ on, attrs }">
                       <v-btn
-                        v-if="item.services && item.services.length"
                         color="primary"
-                        icon
-                        title="Open in external service"
+                        x-small
+                        :disabled="!item.services || !item.services.length"
                         v-bind="attrs"
                         v-on="on"
                       >
-                        <v-icon>mdi-dots-vertical</v-icon>
-                      </v-btn>
-                      <v-btn
-                        v-else
-                        color="primary"
-                        disabled
-                        icon
-                      >
-                        <v-icon>mdi-dots-vertical</v-icon>
+                        Open With <v-icon small>mdi-menu-down</v-icon>
                       </v-btn>
                     </template>
                     <v-list


### PR DESCRIPTION
This PR improves the presentation of the file browser view icons:
- replace the "eyeball" icon with an "open in app" icon
- replace the triple dot menu with an explicit button-based dropdown menu

The open in app icon makes more sense for what that button does. And the explicit dropdown uses standard language for "open an external program", and makes the presence of those integrations more discoverable.

This was inspired by discussions on #1666.

Depends on #1845.

(attn: @magland)