### PR TITLE
Fix lint errors

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -139,11 +139,7 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
         citation = f'{name} ({year}). (Version {version}) [Data set]. DANDI archive. {url}'
         if 'contributor' in metadata and isinstance(metadata['contributor'], list):
             cl = '; '.join(
-                [
-                    val['name']
-                    for val in metadata['contributor']
-                    if 'includeInCitation' in val and val['includeInCitation']
-                ]
+                [val['name'] for val in metadata['contributor'] if val.get('includeInCitation')]
             )
             if cl:
                 citation = (

--- a/dandiapi/api/views/auth.py
+++ b/dandiapi/api/views/auth.py
@@ -109,10 +109,10 @@ def user_questionnaire_form_view(request: HttpRequest) -> HttpResponse:
         user_metadata.save(update_fields=['questionnaire_form'])
 
         # Save first and last name if applicable
-        if 'First Name' in req_body and req_body['First Name']:
+        if req_body.get('First Name'):
             user.first_name = req_body['First Name']
             user.save(update_fields=['first_name'])
-        if 'Last Name' in req_body and req_body['Last Name']:
+        if req_body.get('Last Name'):
             user.last_name = req_body['Last Name']
             user.save(update_fields=['last_name'])
 

--- a/dandiapi/zarr/models.py
+++ b/dandiapi/zarr/models.py
@@ -16,7 +16,7 @@ from dandiapi.api.storage import get_embargo_storage, get_storage
 if TYPE_CHECKING:
     from pathlib import Path
 
-logger = logging.Logger(name=__name__)
+logger = logging.getLogger(name=__name__)
 
 
 # The status of the zarr ingestion (checksums, size, file count)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ exclude = [
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+[tool.ruff.lint]
 select = ["ALL"]
 ignore = [
   # Incompatible with formatter
@@ -55,7 +57,7 @@ ignore = [
   "PTH119", # TODO: re-enable this when it's fixed
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "scripts/**" = [
   "INP001", # File is part of an implicit namespace package
 ]


### PR DESCRIPTION
I noticed a few linting errors popping up in CI. This PR fixes them, in three bits:
1. Update pyproject.toml to use the correct ruff config section names.
2. Eliminate some explicit dictionary key checks in favor of `dict.get()`.
3. Use `logging.getLogger()` in place of directly instantiating a `Logger` object.

I believe (1) and (2) are fine (though I'd appreciate validation); (3) might be trickier: although the change I made is a best practice (even recommended directly by the [docs for the `logging` module](https://docs.python.org/3/library/logging.html#logger-objects)), it does represent a semantic change in the codebase.

Let me know if I should peel off one or more of these commits into separate PRs--glad to do so if it makes reviewing/merging easier.