### PR TITLE
Build project with `build` & `pyproject.toml`

### DIFF
--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -44,10 +44,12 @@ jobs:
         run: heroku plugins:install heroku-builds
 
       - name: Build app into tarball
-        run: python setup.py sdist --formats=gztar
+        run: |
+          pip install build
+          python -m build --sdist
 
       - name: Create Heroku Build
-        run: heroku builds:create -a dandi-api --source-tar=dist/$(python setup.py --fullname).tar.gz
+        run: heroku builds:create -a dandi-api --source-tar dist/*.tar.gz
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY  }}
           HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL  }}

--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -31,10 +31,12 @@ jobs:
         run: heroku plugins:install heroku-builds
 
       - name: Build app into tarball
-        run: python setup.py sdist --formats=gztar
+        run: |
+          pip install build
+          python -m build --sdist
 
       - name: Create Heroku Build
-        run: heroku builds:create -a dandi-api-staging --source-tar=dist/$(python setup.py --fullname).tar.gz
+        run: heroku builds:create -a dandi-api-staging --source-tar dist/*.tar.gz
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY  }}
           HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL  }}

--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -9,10 +9,11 @@ RUN apt-get update && \
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# Only copy the setup.py and setup.cfg, it will still force all install_requires to be installed,
+# Only copy the pyproject.toml, setup.py, and setup.cfg.  It will still force all install_requires to be installed,
 # but find_packages() will find nothing (which is fine). When Docker Compose mounts the real source
 # over top of this directory, the .egg-link in site-packages resolves to the mounted directory
 # and all package modules are importable.
+COPY ./pyproject.toml /opt/django-project/pyproject.toml
 COPY ./setup.cfg /opt/django-project/setup.cfg
 COPY ./setup.py /opt/django-project/setup.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
 [tool.mypy]
 ignore_missing_imports = true
 show_error_codes = true

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     description='',
     # Determine version with scm
     use_scm_version={'version_scheme': 'post-release'},
-    setup_requires=['setuptools_scm'],
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='Apache 2.0',


### PR DESCRIPTION
dandi-archive is currently building its tarballs via `python setup.py`, [which is deprecated](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html) and which is not the currently supported way to build with the `setuptools_scm` build-time requirement (used for storing the Git tag in the project version).

Indeed, [the latest "Deploy backend to production run"](https://github.com/dandi/dandi-archive/actions/runs/7546255291) has the following in the logs for the "Build app into tarball" step:

```
/usr/lib/python3/dist-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
  warnings.warn(
/home/runner/work/dandi-archive/dandi-archive/.eggs/setuptools_scm-8.0.4-py3.10.egg/setuptools_scm/_integration/setuptools.py:30: RuntimeWarning: 
ERROR: setuptools==59.6.0 is used in combination with setuptools_scm>=8.x

Your build configuration is incomplete and previously worked by accident!
setuptools_scm requires setuptools>=61

Suggested workaround if applicable:
 - migrating from the deprecated setup_requires mechanism to pep517/518
   and using a pyproject.toml to declare build dependencies
   which are reliably pre-installed before running the build tools
```