### PR TITLE
Always rebuild and deploy the frontend

### DIFF
--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 publish = "dist"
 command = "yarn run build"
+ignore = "false"
 
 # Staging
 [context.master.environment]


### PR DESCRIPTION
Setting the `ignore` value to `false` means that the `false` program (which always exits with non-zero code) will cause Netlify to always rebuild the frontend, even if there are no changes to the code. We want to do this because in fact the *git tag* that is installed as part of our deployment process *always* changes, and we need to reflect that version number in the frontend application itself.

Closes #1089 