### PR TITLE
Improve Swagger documentation for /dandisets/ query params

### DIFF
--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -180,17 +180,15 @@ class DandisetDetailSerializer(DandisetSerializer):
 class DandisetQueryParameterSerializer(serializers.Serializer):
     draft = serializers.BooleanField(
         default=True,
-        help_text="Whether to include dandisets that only have draft "
+        help_text='Whether to include dandisets that only have draft '
         "versions (i.e., haven't been published yet).",
     )
-    empty = serializers.BooleanField(
-        default=True, help_text="Whether to include empty dandisets."
-    )
+    empty = serializers.BooleanField(default=True, help_text='Whether to include empty dandisets.')
     embargoed = serializers.BooleanField(
-        default=False, help_text="Whether to include embargoed dandisets."
+        default=False, help_text='Whether to include embargoed dandisets.'
     )
     user = serializers.ChoiceField(
-        choices=["me"],
+        choices=['me'],
         required=False,
         help_text='Set this value to "me" to only return dandisets owned by the current user.',
     )

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -178,10 +178,22 @@ class DandisetDetailSerializer(DandisetSerializer):
 
 
 class DandisetQueryParameterSerializer(serializers.Serializer):
-    draft = serializers.BooleanField(default=True)
-    empty = serializers.BooleanField(default=True)
-    embargoed = serializers.BooleanField(default=False)
-    user = serializers.CharField(required=False)
+    draft = serializers.BooleanField(
+        default=True,
+        help_text="Whether to include dandisets that only have draft "
+        "versions (i.e., haven't been published yet).",
+    )
+    empty = serializers.BooleanField(
+        default=True, help_text="Whether to include empty dandisets."
+    )
+    embargoed = serializers.BooleanField(
+        default=False, help_text="Whether to include embargoed dandisets."
+    )
+    user = serializers.ChoiceField(
+        choices=["me"],
+        required=False,
+        help_text='Set this value to "me" to only return dandisets owned by the current user.',
+    )
 
 
 class DandisetSearchQueryParameterSerializer(DandisetQueryParameterSerializer):


### PR DESCRIPTION
As @jwodder mentions [here](https://github.com/dandi/dandi-cli/issues/1413#issuecomment-1969007877), the Swagger page is unclear about some of the query parameters for the `/dandisets/` endpoint. This PR adds some help_text for them, which will be rendered on the Swagger UI.

I also changed the `user` query parameter to be a `ChoiceField` over a `CharField`, as it has only one possible value, "me"(or two if you count `null`/missing). This improves the Swagger interface by making it a dropdown select instead of a freeform textbox.