### PR TITLE
Require v0.60.0 of `dandi-cli`

### DIFF
--- a/dandiapi/api/tests/test_info.py
+++ b/dandiapi/api/tests/test_info.py
@@ -13,7 +13,7 @@ def test_rest_info(api_client):
         'schema_version': settings.DANDI_SCHEMA_VERSION,
         'schema_url': schema_url,
         'version': __version__,
-        'cli-minimal-version': '0.51.0',
+        'cli-minimal-version': '0.60.0',
         'cli-bad-versions': [],
         'services': {
             'api': {'url': f'{settings.DANDI_API_URL}/api'},

--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -62,7 +62,7 @@ def info_view(self):
             'schema_version': settings.DANDI_SCHEMA_VERSION,
             'schema_url': schema_url,
             'version': __version__,
-            'cli-minimal-version': '0.51.0',
+            'cli-minimal-version': '0.60.0',
             'cli-bad-versions': [],
             'services': {
                 'api': {'url': api_url},


### PR DESCRIPTION
This PR changes the `cli-minimal-version` to v0.60.0, which is the first version of the CLI that uses Pydantic 2.