### PR TITLE
Run all linting commands, even if some of them fail

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 
 [testenv:lint]
 package = skip
+ignore_errors = True
 deps =
     codespell~=2.0
     ruff


### PR DESCRIPTION
Without the `ignore_errors` configuration option set to `True`, Tox exits as soon as any command in the list fails. In the case of the lint tests, we would like to continue running the commands, since they are essentially independent tests.

This was masking formatting errors whenever the `check` command was failing, preventing us from knowing that we should fix those.

(attn: @marySalvi)