### PR TITLE
Always pull postgres image for local docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   postgres:
     image: postgres:latest
+    pull_policy: always
     command: postgres -c log_lock_waits=on -c log_min_duration_statement=100
     environment:
       POSTGRES_DB: django


### PR DESCRIPTION
In the process of submitting a recent PR, I ran into test failures that only occurred in CI and not locally. This was due to an out of date postgres image locally, which it turns out was over a year old.

This PR adds `pull_policy: always` to the postgres docker-compose service, to prevent this from occuring.