### PR TITLE
Change asset path collation to "C"

### DIFF
--- a/dandiapi/api/migrations/0006_asset_path_collation.py
+++ b/dandiapi/api/migrations/0006_asset_path_collation.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             model_name='asset',
             name='path',
             field=models.CharField(
-                db_collation='C.utf8',
+                db_collation='C',
                 max_length=512,
                 validators=[dandiapi.api.models.asset.validate_asset_path],
             ),

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -134,7 +134,7 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
         INVALID = 'Invalid'
 
     asset_id = models.UUIDField(unique=True, default=uuid.uuid4)
-    path = models.CharField(max_length=512, validators=[validate_asset_path], db_collation='C.utf8')
+    path = models.CharField(max_length=512, validators=[validate_asset_path], db_collation='C')
     blob = models.ForeignKey(
         AssetBlob, related_name='assets', on_delete=models.CASCADE, null=True, blank=True
     )


### PR DESCRIPTION
Follow up to #1885 

While the `C.utf8` collation seemed to work locally and in CI, that collation doesn't seem to exist in the production database, and so that migration failed in production. However the basic `C` collation _is_ present across all of these environments (all postgres environments, detailed [here](https://www.postgresql.org/docs/current/collation.html#:~:text=On%20all%20platforms%2C%20the%20collations%20named%20default%2C%20C%2C%20and%20POSIX%20are%20available)) and as far as I can tell, seems to operate in largely the same way. If/when we upgrade our database version in heroku, we could perhaps change _back_ to `C.utf8`, if it mattered. 

This fix modifies the last migration, since the deployment failed in staging/production. If I were to create a new migration, I believe it would again fail, since it would have to first apply the failing migration to reach the fix.