### PR TITLE
Boost dandischema to 0.10.1 which released 0.6.7 schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'dandischema~=0.9.0',
+        'dandischema~=0.10.1',
         'django~=4.1.0',
         'django-admin-display',
         # Require 0.58.0 as it is the first version to support postgres' native


### PR DESCRIPTION
without this now dandi-cli tests failing since would use fresh dandischema which would produce records in 0.6.7 schema. AFAIK, since just patch version increment probably no adjustment needed on dandi-archive side, but let's see if tests (and/or @satra or @bendichter) say otherwise

relevant change to schema:
- Add ResourceType enum and associate with Resource model https://github.com/dandi/dandi-schema/pull/232 ([@bendichter](https://github.com/bendichter) [@pre-commit-ci[bot]](https://github.com/pre-commit-ci%5Bbot%5D))

and then also 0.10.0 had change to functionality:
- Remove Zarr checksum code https://github.com/dandi/dandi-schema/pull/217 ([@jwodder](https://github.com/jwodder))

but I hope (tests will show?) that this functionality was not used here