### PR TITLE
Rate limit assets list endpoint for unauthenticated users

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -36,6 +36,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import NotAuthenticated, NotFound, PermissionDenied
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle, BaseThrottle
 from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
 from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSetMixin
 
@@ -81,6 +82,12 @@ class AssetViewSet(DetailSerializerMixin, GenericViewSet):
 
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = AssetFilter
+
+    def get_throttles(self) -> list[BaseThrottle]:
+        if self.action == 'list':
+            throttles = [*self.throttle_classes, AnonRateThrottle]
+            return [throttle() for throttle in throttles]
+        return super().get_throttles()
 
     def raise_if_unauthorized(self):
         # We need to check the dandiset to see if it's embargoed, and if so whether or not the


### PR DESCRIPTION
This PR adds a rate limit of 60 requests per minute to the asset list endpoint for unauthenticated users. Logged-in users are not rate-limited. This is a short-term fix for #1891.