### PR TITLE
Optimize asset list endpoint

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -1539,4 +1539,5 @@ def test_asset_rest_glob(api_client, asset_factory, version, glob_pattern, expec
         {'glob': glob_pattern},
     )
 
-    assert expected_paths == [asset['path'] for asset in resp.json()['results']]
+    # Sort both lists before comparing since ordering is not considered
+    assert sorted(expected_paths) == sorted([asset['path'] for asset in resp.json()['results']])


### PR DESCRIPTION
Closes #1891

The existing asset list endpoint is inefficient with how it queries the database, resulting in unnecessarily long response times from that endpoint. This is improved in the following ways:
* Paginate and fetch IDs of desired assets first, before doing left joins
* Remove duplicate queries as a result of class inheritance
* Remove extra query in `raise_if_unauthorized` method

The results of these improvements are shown below. Note that these are the times for the SQL queries themselves, not the overall page load, as that can be inflated by the amount of data returned, and isn't useful for this discussion.

| Operation | Original (ms) | Improved (ms) | Speedup |
| --- | --- | --- | --- |
| No filters | 300 | 30 | 10x |
| Ordering only | 295 | 92 | 3.2x |
| Path filter only | 235 | 75 | 3.1x |
| Ordering + path filter | 240 | 140 | 1.7x |


A couple things to note going forward:
* The `count` query (the query that returns the total number of hits from which you're returning a single page) is usually _slower_ than the query of interest itself, which makes sense. We may want to rethink the structure of our API respones if further optimization is desired, as if we were to remove this count, we would see a pretty widespread 2x speedup.
* The structure of the asset list endpoint is getting pretty involved at this point, as is the rest of the asset endpoints. We may want to consider a refactor of that file in the future.