### PR TITLE
Update our instructions for installation to state newer versions of python and dandi-cli

### DIFF
--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -102,10 +102,10 @@
               <v-list>
                 <v-list-item>
                   Install the Python client (DANDI CLI)
-                  in a Python 3.7+ environment using command:
+                  in a Python 3.8+ environment using command:
                 </v-list-item>
                 <v-list-item>
-                  <kbd>pip install "dandi>=0.13.0"</kbd>
+                  <kbd>pip install "dandi>=0.60.0"</kbd>
                 </v-list-item>
               </v-list>
             </v-expansion-panel-content>


### PR DESCRIPTION
@dandi/archive-maintainers is there an easy way to avoid hardcoding dandi-cli version here and take it from `cli-minimal-version` of https://github.com/dandi/dandi-archive/blob/HEAD/dandiapi/api/views/info.py#L65 ?

Change is "inspired" by a user who pointed me to that line which didn't work on his mac with OSX having python 3.7 systemwide