### PR TITLE
neurosift external service for .nwb.lindi.json

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -349,8 +349,15 @@ const EXTERNAL_SERVICES = [
     name: 'Neurosift',
     regex: /\.nwb$/,
     maxsize: Infinity,
-    endpoint: 'https://flatironinstitute.github.io/neurosift?p=/nwb&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
+    endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
   },
+
+  {
+    name: 'Neurosift',
+    regex: /\.nwb.lindi.json$/,
+    maxsize: Infinity,
+    endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&st=lindi&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
+  }
 ];
 type Service = typeof EXTERNAL_SERVICES[0];
 


### PR DESCRIPTION
Provides a neurosift external service button for .nwb.lindi.json files.

Also changes https://flatironinstitute.github.io/neurosift -> https://neurosift.app (note that currently github io gets redirected, so both work right now)

Example on staging site:
https://gui-staging.dandiarchive.org/dandiset/213569/draft/files?location=000946%2Fsub-BH494&page=1

[Link to LINDI project](https://github.com/neurodataWithoutBorders/lindi)

See discussion here: https://github.com/NeurodataWithoutBorders/lindi/pull/42

