### PR TITLE
Remove unnecessary `noqa` directive

### DIFF
--- a/dandiapi/api/management/commands/migrate_published_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_published_version_metadata.py
@@ -26,7 +26,7 @@ def migrate_published_version_metadata(*, dandiset: str, published_version: str,
 
     try:
         metanew = migrate(metadata, to_version=to_version, skip_validation=False)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         click.echo(f'Failed to migrate {dandiset}/{published_version}')
         click.echo(e)
         raise click.Abort from e


### PR DESCRIPTION
Ruff [`0.4.2`](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#042) updates the `blind-except (BLE001)` rule to not trigger if an exception is raised from within the blind exception `except` block. 

This may still error locally if you have an older version of ruff, so I would recommend upgrading.