### PR TITLE
Fix documentation for server downtime message var

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -40,5 +40,5 @@ yarn migrate 0.5.1
 
 ### Environment Variables
 
-- VUE_APP_SERVER_DOWNTIME_MESSAGE
+- VITE_APP_SERVER_DOWNTIME_MESSAGE
   - A custom error message displayed when the backend server can't be reached.


### PR DESCRIPTION
When https://github.com/dandi/dandi-archive/pull/1725 was merged, the name of the server downtime env var was never changed in `web/README.md`. This PR fixes that.