### PR TITLE
Remove all-contributors auto plugin

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "git-tag",
-    "all-contributors",
     "conventional-commits",
     "first-time-contributor",
     "released"


### PR DESCRIPTION
This plugin is causing our release workflow to fail, and we don't use it anyway.