### PR TITLE
Revert "Temporarily disable staging deploy on merge to `master`"

### DIFF
--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -1,13 +1,12 @@
 name: Deploy backend to staging
 
 on:
-  # TODO: temporariliy disable deploy on push to `master` until embargo redesign is ready
-  # push:
-  #   branches:
-  #     - master
-  #   paths-ignore:
-  #     - "web/**"
-  #     - "CHANGELOG.md"
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "web/**"
+      - "CHANGELOG.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This reverts commit df7d85798ad8ddddf3ecf370e045597e78a36ac5.

We can re-enable automatic staging deploys now that #1890 is merged and deployed.