### PR TITLE
Fix race condition in sha256 calculation task

### DIFF
--- a/dandiapi/api/tasks/__init__.py
+++ b/dandiapi/api/tasks/__init__.py
@@ -32,8 +32,7 @@ def calculate_sha256(blob_id: str) -> None:
 
     # TODO: Run dandi-cli validation
 
-    asset_blob.sha256 = sha256
-    asset_blob.save()
+    AssetBlob.objects.filter(blob_id=blob_id).update(sha256=sha256)
 
 
 @shared_task(soft_time_limit=180)


### PR DESCRIPTION
The `asset_blob` could potentially change out from under us in the time it takes to calculate the SHA256, so using an UPDATE here is safer.