### PR TITLE
Add calculate_sha256 management command to trigger (re)computation for a blob

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,node_modules,dist,venv,.venv,.mypy_cache,.tox,yarn.lock,CHANGELOG.md,./htmlcov,*.pyc,*.log
+skip = .git,node_modules,dist,venv,.venv,.mypy_cache,.tox,yarn.lock,CHANGELOG.md,./htmlcov,*.pyc,*.log,build,venvs
 # Disabled until https://github.com/codespell-project/codespell/issues/2727
 # got answer/re-solution
 # dictionary = .codespell_dict

--- a/dandiapi/api/management/commands/calculate_sha256.py
+++ b/dandiapi/api/management/commands/calculate_sha256.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import djclick as click
+
+from dandiapi.api.models import Asset
+from dandiapi.api.tasks import calculate_sha256 as do_calculate_sha256
+
+
+@click.command()
+@click.option('--blob-id', 'blob_id', help='Blob ID')
+@click.option('--asset-id', 'asset_id', help='Asset ID')
+def calculate_sha256(asset_id: str | None = None, blob_id: str | None = None):
+    """Trigger computation of sha256 for a blob
+
+    Either blob-id or asset-id should be provided.
+    """
+    if not asset_id and not blob_id:
+        raise ValueError('Provide either asset_id or blob_id')
+
+    if asset_id and blob_id:
+        raise ValueError('Provide only asset_id or blob_id, not both')
+
+    if not blob_id:
+        assert asset_id
+        asset = Asset.objects.get(asset_id=asset_id)
+        blob_id = asset.blob_id
+
+    do_calculate_sha256(blob_id=blob_id)

--- a/dandiapi/api/management/commands/calculate_sha256.py
+++ b/dandiapi/api/management/commands/calculate_sha256.py
@@ -10,18 +10,16 @@ from dandiapi.api.tasks import calculate_sha256 as do_calculate_sha256
 @click.option('--blob-id', 'blob_id', help='Blob ID')
 @click.option('--asset-id', 'asset_id', help='Asset ID')
 def calculate_sha256(asset_id: str | None = None, blob_id: str | None = None):
-    """Trigger computation of sha256 for a blob
+    """Trigger computation of sha256 for a blob.
 
     Either blob-id or asset-id should be provided.
     """
     if not asset_id and not blob_id:
         raise ValueError('Provide either asset_id or blob_id')
 
-    if asset_id and blob_id:
-        raise ValueError('Provide only asset_id or blob_id, not both')
-
-    if not blob_id:
-        assert asset_id
+    if asset_id:
+        if blob_id:
+            raise ValueError('Provide only asset_id or blob_id, not both')
         asset = Asset.objects.get(asset_id=asset_id)
         blob_id = asset.blob_id
 

--- a/dandiapi/api/management/commands/calculate_sha256.py
+++ b/dandiapi/api/management/commands/calculate_sha256.py
@@ -14,12 +14,14 @@ def calculate_sha256(asset_id: str | None = None, blob_id: str | None = None):
 
     Either blob-id or asset-id should be provided.
     """
+    # Handle mutually exclusive option failure cases.
     if not asset_id and not blob_id:
         raise ValueError('Provide either asset_id or blob_id')
+    if asset_id and blob_id:
+        raise ValueError('Provide only asset_id or blob_id, not both')
 
+    # Make sure we have a good blob_id to work with.
     if asset_id:
-        if blob_id:
-            raise ValueError('Provide only asset_id or blob_id, not both')
         asset = Asset.objects.get(asset_id=asset_id)
         blob_id = asset.blob_id
 


### PR DESCRIPTION
Added ability to specify either blob id (where it applies) or asset id since that is the id we typically know for which a blob lacks sha256.

Refs:
- https://github.com/dandi/dandi-archive/issues/471
- https://github.com/dandi/dandi-archive/issues/1578

- #1937 

has a chance to properly address the underlying issue but IMHO having an interface to trigger such a task manually could still be valuable e.g. in case of that automation failing to perform for some reason etc.