### PR TITLE
In 1.14.3 it became client_config and .config was announced deprecated

### DIFF
--- a/dandiapi/api/storage.py
+++ b/dandiapi/api/storage.py
@@ -155,7 +155,7 @@ class TimeoutS3Storage(S3Storage):
     def __init__(self, **settings):
         super().__init__(**settings)
 
-        self.config = self.config.merge(
+        self.client_config = self.client_config.merge(
             Config(connect_timeout=5, read_timeout=5, retries={'max_attempts': 2})
         )
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         # Production-only
         'django-composed-configuration[prod]>=0.23.0',
         'django-s3-file-field[s3]>=1.0.0',
-        'django-storages[s3]>=1.14.2',
+        'django-storages[s3]>=1.14.3',
         'gunicorn',
         # Development-only, but required
         'django-minio-storage',


### PR DESCRIPTION
and caused .config to become None

and I believe that caused our tests to start failing etc

If tests succeed, Closes #1940