### PR TITLE
Only use custom pagination class for asset list endpoint

### DIFF
--- a/dandiapi/api/tests/test_pagination.py
+++ b/dandiapi/api/tests/test_pagination.py
@@ -4,65 +4,6 @@ import pytest
 
 
 @pytest.mark.django_db()
-def test_dandiset_pagination(api_client, dandiset_factory):
-    endpoint = '/api/dandisets/'
-    for _ in range(10):
-        dandiset_factory()
-
-    # First page
-    resp = api_client.get(endpoint, {'order': 'id', 'page_size': 5}).json()
-    assert resp['count'] == 10
-    assert resp['next'] is not None
-    page_one = resp['results']
-    assert len(page_one) == 5
-
-    # Second page
-    resp = api_client.get(endpoint, {'order': 'id', 'page_size': 5, 'page': 2}).json()
-    assert resp['count'] is None
-    assert resp['next'] is None
-    page_two = resp['results']
-    assert len(page_two) == 5
-
-    # Full page
-    resp = api_client.get(endpoint, {'order': 'id', 'page_size': 100}).json()
-    assert resp['count'] == 10
-    assert resp['next'] is None
-    full_page = resp['results']
-    assert len(full_page) == 10
-
-    # Assert full list is ordered the same as both paginated lists
-    assert full_page == page_one + page_two
-
-
-@pytest.mark.django_db()
-def test_version_pagination(api_client, dandiset, published_version_factory):
-    endpoint = f'/api/dandisets/{dandiset.identifier}/versions/'
-
-    for _ in range(10):
-        published_version_factory(dandiset=dandiset)
-
-    resp = api_client.get(endpoint, {'order': 'created', 'page_size': 5}).json()
-
-    assert resp['count'] == 10
-    page_one = resp['results']
-    assert len(page_one) == 5
-
-    resp = api_client.get(endpoint, {'order': 'created', 'page_size': 5, 'page': 2}).json()
-    assert resp['count'] is None
-    assert resp['next'] is None
-    page_two = resp['results']
-    assert len(page_two) == 5
-
-    resp = api_client.get(endpoint, {'order': 'created', 'page_size': 100}).json()
-    assert resp['count'] == 10
-    assert resp['next'] is None
-    full_page = resp['results']
-    assert len(full_page) == 10
-
-    assert full_page == page_one + page_two
-
-
-@pytest.mark.django_db()
 def test_asset_pagination(api_client, version, asset_factory):
     endpoint = f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/assets/'
 
@@ -91,31 +32,4 @@ def test_asset_pagination(api_client, version, asset_factory):
     assert len(full_page) == 10
 
     # Assert full list is ordered the same as both paginated lists
-    assert full_page == page_one + page_two
-
-
-@pytest.mark.django_db()
-def test_zarr_pagination(api_client, zarr_archive_factory):
-    endpoint = '/api/zarr/'
-
-    for _ in range(10):
-        zarr_archive_factory()
-
-    resp = api_client.get(endpoint, {'page_size': 5}).json()
-    assert resp['count'] == 10
-    page_one = resp['results']
-    assert len(page_one) == 5
-
-    resp = api_client.get(endpoint, {'page_size': 5, 'page': 2}).json()
-    assert resp['count'] is None
-    assert resp['next'] is None
-    page_two = resp['results']
-    assert len(page_two) == 5
-
-    resp = api_client.get(endpoint, {'page_size': 100}).json()
-    assert resp['count'] == 10
-    assert resp['next'] is None
-    full_page = resp['results']
-    assert len(full_page) == 10
-
     assert full_page == page_one + page_two

--- a/dandiapi/api/views/pagination.py
+++ b/dandiapi/api/views/pagination.py
@@ -1,12 +1,3 @@
-"""
-Implement an optimized pagination scheme.
-
-This module provides a custom pagination implementation, as the existing `PageNumberPagination`
-class returns a `count` field for every page returned. This can be very inefficient on large tables,
-and in reality, the count is only necessary on the first page of results. This module implements
-such a pagination scheme, only returning 'count' on the first page of results.
-"""
-
 from __future__ import annotations
 
 from collections import OrderedDict
@@ -15,6 +6,24 @@ from django.core.paginator import Page, Paginator
 from django.utils.functional import cached_property
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
+
+
+class DandiPagination(PageNumberPagination):
+    page_size = 100
+    max_page_size = 1000
+    page_size_query_param = 'page_size'
+
+    @cached_property
+    def page_size_query_description(self):
+        return f'{super().page_size_query_description[:-1]} (maximum {self.max_page_size}).'
+
+
+"""
+The below code provides a custom pagination implementation, as the existing `PageNumberPagination`
+class returns a `count` field for every page returned. This can be very inefficient on large tables,
+and in reality, the count is only necessary on the first page of results. This module implements
+such a pagination scheme, only returning 'count' on the first page of results.
+"""
 
 
 class LazyPage(Page):
@@ -96,7 +105,3 @@ class LazyPagination(PageNumberPagination):
         )
 
         return Response(page_dict)
-
-
-# Alias
-DandiPagination = LazyPagination


### PR DESCRIPTION
Fixes #1917

#1911 greedily implemented the custom pagination class (not including `count` in every page of the paginated response) for every listing endpoint. In reality, the main target of that PR was the asset list endpoint. Since there are various places in the web client that assume the removed `count` field is present, this PR reverts the functionality for all list endpoints except for the asset list endpoint.