### PR TITLE
Draft: Reference count from cached object_list for lazy paginator

### DIFF
--- a/admin_dev_startup.sh
+++ b/admin_dev_startup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script can be used to launch the front-end and back-end applications locally.
+# Happy developing!
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <image_name> <your.email@email.com>"
+  exit 1
+fi
+
+image_name=$1
+email=$2
+
+cd web/
+
+# Build Docker image (include the path to the Dockerfile's context)
+docker build -t $image_name -f Dockerfile.dev .
+
+# Run the Docker container for frontend in background
+docker run -d -v "$(pwd):/usr/src/app" -v /usr/src/app/node_modules -p 8085:8085 -e CHOKIDAR_USEPOLLING=true $image_name
+
+cd ..
+
+# Run Docker Compose commands for backend
+docker compose run --rm django ./manage.py migrate
+docker compose run --rm django ./manage.py createcachetable
+docker compose run --rm django ./manage.py createsuperuser
+docker compose run --rm django ./manage.py create_dev_dandiset --owner $email
+
+# Bring backend application to life!
+docker compose up

--- a/dandiapi/api/management/commands/create_dev_dandiset.py
+++ b/dandiapi/api/management/commands/create_dev_dandiset.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import hashlib
 
 from uuid import uuid4
 
@@ -17,39 +18,48 @@ from dandiapi.api.tasks import calculate_sha256
 @click.command()
 @click.option('--name', default='Development Dandiset')
 @click.option('--owner', 'email', required=True, help='The email address of the owner')
-def create_dev_dandiset(*, name: str, email: str):
+@click.option('--first_name', default='Randi The Admin')
+@click.option('--last_name', default='Dandi')
+def create_dev_dandiset(name: str, email: str, first_name: str, last_name: str):
     owner = User.objects.get(email=email)
+    owner.first_name = first_name
+    owner.last_name = last_name
+    owner.save()
 
     version_metadata = {
         'description': 'An informative description',
         'license': ['spdx:CC0-1.0'],
     }
-    _, draft_version = create_dandiset(
-        user=owner, embargo=False, version_name=name, version_metadata=version_metadata
-    )
+    for i in range(1, 21):
+        name = f"version_{i}"
+        _, draft_version = create_dandiset(user=owner, embargo=False, version_name=name,
+                                        version_metadata=version_metadata)
 
-    uploaded_file = SimpleUploadedFile(name='foo/bar.txt', content=b'A' * 20)
-    etag = '76d36e98f312e98ff908c8c82c8dd623-0'
-    try:
-        asset_blob = AssetBlob.objects.get(etag=etag)
-    except AssetBlob.DoesNotExist:
-        asset_blob = AssetBlob(
-            blob_id=uuid4(),
-            blob=uploaded_file,
-            etag=etag,
-            size=20,
+        file_size = 20
+        file_content = b'A' * file_size
+        uploaded_file = SimpleUploadedFile(name='foo/bar.txt', content=file_content)
+        etag = '76d36e98f312e98ff908c8c82c8dd623-0'
+
+        try:
+            asset_blob = AssetBlob.objects.get(etag=etag)
+        except AssetBlob.DoesNotExist:
+            # Since the SimpleUploadedFile is non-zarr asset, validation fails
+            # without a sha2_256 initially provided.
+            sha256_hash = hashlib.sha256(file_content).hexdigest()
+            asset_blob = AssetBlob(
+                blob_id=uuid4(), blob=uploaded_file, etag=etag, size=file_size, sha256=sha256_hash
+            )
+            asset_blob.save()
+        asset_metadata = {
+            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'encodingFormat': 'text/plain',
+            'schemaKey': 'Asset',
+            'path': 'foo/bar.txt',
+        }
+        asset = add_asset_to_version(
+            user=owner, version=draft_version, asset_blob=asset_blob, metadata=asset_metadata
         )
-        asset_blob.save()
-    asset_metadata = {
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
-        'encodingFormat': 'text/plain',
-        'schemaKey': 'Asset',
-        'path': 'foo/bar.txt',
-    }
-    asset = add_asset_to_version(
-        user=owner, version=draft_version, asset_blob=asset_blob, metadata=asset_metadata
-    )
 
-    calculate_sha256(blob_id=asset_blob.blob_id)
-    validate_asset_metadata(asset=asset)
-    validate_version_metadata(version=draft_version)
+        calculate_sha256(blob_id=asset_blob.blob_id)
+        validate_asset_metadata(asset=asset)
+        validate_version_metadata(version=draft_version)


### PR DESCRIPTION
Follow-up from https://github.com/dandi/dandi-archive/pull/1911

Unfortunately, returning `count` as `null` violates the requirement for `v-paginator` to operate as intended -- rather than extending logic in the UI, this PR references `cached_property` of `self.object_list` as a method of retrieving an accurate count.