### PR TITLE
Restrict updates to metadata `access` field

### DIFF
--- a/dandiapi/api/models/dandiset.py
+++ b/dandiapi/api/models/dandiset.py
@@ -59,6 +59,10 @@ class Dandiset(TimeStampedModel):
         return f'{self.id:06}' if self.id is not None else ''
 
     @property
+    def embargoed(self) -> bool:
+        return self.embargo_status == self.EmbargoStatus.EMBARGOED
+
+    @property
     def most_recent_published_version(self):
         return self.versions.exclude(version='draft').order_by('modified').last()
 

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -166,7 +166,19 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
             'publishedBy',
             'manifestLocation',
         ]
-        return {key: metadata[key] for key in metadata if key not in computed_fields}
+        stripped = {key: metadata[key] for key in metadata if key not in computed_fields}
+
+        # Strip the status and schemaKey fields, as modifying them is not supported
+        if (
+            'access' in stripped
+            and isinstance(stripped['access'], list)
+            and len(stripped['access'])
+            and isinstance(stripped['access'][0], dict)
+        ):
+            stripped['access'][0].pop('schemaKey', None)
+            stripped['access'][0].pop('status', None)
+
+        return stripped
 
     def _populate_access_metadata(self):
         default_access = [{}]

--- a/dandiapi/api/services/embargo/__init__.py
+++ b/dandiapi/api/services/embargo/__init__.py
@@ -48,12 +48,6 @@ def _unembargo_dandiset(dandiset: Dandiset):
     embargoed_assets: QuerySet[Asset] = draft_version.assets.filter(blob__embargoed=True)
     AssetBlob.objects.filter(assets__in=embargoed_assets).update(embargoed=False)
 
-    # Update draft version metadata
-    draft_version.metadata['access'] = [
-        {'schemaKey': 'AccessRequirements', 'status': 'dandi:OpenAccess'}
-    ]
-    draft_version.save()
-
     # Set access on dandiset
     dandiset.embargo_status = Dandiset.EmbargoStatus.OPEN
     dandiset.save()

--- a/dandiapi/api/services/version/metadata.py
+++ b/dandiapi/api/services/version/metadata.py
@@ -32,13 +32,6 @@ def _normalize_version_metadata(
                 'includeInCitation': True,
             },
         ],
-        # TODO: move this into dandischema
-        'access': [
-            {
-                'schemaKey': 'AccessRequirements',
-                'status': 'dandi:EmbargoedAccess' if embargo else 'dandi:OpenAccess',
-            }
-        ],
         **version_metadata,
     }
     # Run the version_metadata through the pydantic model to automatically include any boilerplate

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -5,6 +5,7 @@ import hashlib
 
 from allauth.socialaccount.models import SocialAccount
 from dandischema.digests.dandietag import DandiETag
+from dandischema.models import AccessType
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import files as django_files
@@ -95,6 +96,14 @@ class BaseVersionFactory(factory.django.DjangoModelFactory):
             'schemaVersion': settings.DANDI_SCHEMA_VERSION,
             'schemaKey': 'Dandiset',
             'description': faker.Faker().sentence(),
+            'access': [
+                {
+                    'schemaKey': 'AccessRequirements',
+                    'status': AccessType.EmbargoedAccess.value
+                    if self.dandiset.embargoed
+                    else AccessType.OpenAccess.value,
+                }
+            ],
             'contributor': [
                 {
                     'name': f'{faker.Faker().last_name()}, {faker.Faker().first_name()}',


### PR DESCRIPTION
Closes #1787
Closes #1831

It seems both these issues were due to us not prohibiting the `access` field from being updated. A user should never update the `access` field (as it is derived from the embargo status of the dandiset), nor is there a natural way for that to happen using the meditor. However, it was not actually disallowed in anyway, so the following situations were possible:

1. After the dandiset is embargoed, if the meditor uses old metadata in some way, it can overwrite this field with the old embargoed access field. All without the user being aware, since that field isn't available in the meditor
2. If someone were to simply use the API outside of the meditor, they could set that field to whatever they want, intentional or not.

~This PR updates that field to treat it as `computed` and thus not able to be changed from a simple metadata update.~ (See below)
