### PR TITLE
Lock dandisets during un-embargo

### DIFF
--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -194,14 +194,14 @@ def build_dandisets_to_unembargo_message(dandisets: Iterable[Dandiset]):
     ]
     render_context = {**BASE_RENDER_CONTEXT, 'dandisets': dandiset_context}
     return build_message(
-        subject='DANDI: New Dandisets to un-embargo',
+        subject='DANDI: New Dandisets to unembargo',
         message=render_to_string('api/mail/dandisets_to_unembargo.txt', render_context),
         to=[settings.DANDI_DEV_EMAIL],
     )
 
 
 def send_dandisets_to_unembargo_message(dandisets: Iterable[Dandiset]):
-    logger.info('Sending dandisets to un-embargo message to devs at %s', settings.DANDI_DEV_EMAIL)
+    logger.info('Sending dandisets to unembargo message to devs at %s', settings.DANDI_DEV_EMAIL)
     messages = [build_dandisets_to_unembargo_message(dandisets)]
     with mail.get_connection() as connection:
         connection.send_messages(messages)
@@ -219,7 +219,7 @@ def build_dandiset_unembargoed_message(dandiset: Dandiset):
     }
     html_message = render_to_string('api/mail/dandiset_unembargoed.html', render_context)
     return build_message(
-        subject='Your Dandiset has been un-embargoed!',
+        subject='Your Dandiset has been unembargoed!',
         message=strip_tags(html_message),
         html_message=html_message,
         to=[owner.email for owner in dandiset.owners],
@@ -227,9 +227,7 @@ def build_dandiset_unembargoed_message(dandiset: Dandiset):
 
 
 def send_dandiset_unembargoed_message(dandiset: Dandiset):
-    logger.info(
-        'Sending dandisets un-embargoed message to dandiset %s owners.', dandiset.identifier
-    )
+    logger.info('Sending dandisets unembargoed message to dandiset %s owners.', dandiset.identifier)
     messages = [build_dandiset_unembargoed_message(dandiset)]
     with mail.get_connection() as connection:
         connection.send_messages(messages)

--- a/dandiapi/api/migrations/0008_migrate_embargoed_data.py
+++ b/dandiapi/api/migrations/0008_migrate_embargoed_data.py
@@ -21,7 +21,7 @@ def migrate_embargoed_asset_blobs(apps, _):
         #       as the above case, but between an embargoed and open dandiset, instead of two
         #       embargoed dandisets.
         #
-        # In case #3, the asset will effectively be un-embargoed.
+        # In case #3, the asset will effectively be unembargoed.
         existing_blob = AssetBlob.objects.filter(
             etag=embargoed_blob.etag, size=embargoed_blob.size
         ).first()

--- a/dandiapi/api/services/asset/__init__.py
+++ b/dandiapi/api/services/asset/__init__.py
@@ -136,7 +136,7 @@ def add_asset_to_version(
         raise ZarrArchiveBelongsToDifferentDandisetError
 
     # Creating an asset in an OPEN dandiset that points to an embargoed blob results in that
-    # blob being un-embargoed
+    # blob being unembargoed
     unembargo_asset_blob = (
         asset_blob is not None
         and asset_blob.embargoed
@@ -159,7 +159,7 @@ def add_asset_to_version(
         version.save()
 
     # Perform this after the above transaction has finished, to ensure we only operate on
-    # un-embargoed asset blobs
+    # unembargoed asset blobs
     if asset_blob and unembargo_asset_blob:
         remove_asset_blob_embargoed_tag_task.delay(blob_id=asset_blob.blob_id)
 

--- a/dandiapi/api/services/dandiset/__init__.py
+++ b/dandiapi/api/services/dandiset/__init__.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from dandiapi.api.models.dandiset import Dandiset
 from dandiapi.api.models.version import Version
 from dandiapi.api.services.dandiset.exceptions import DandisetAlreadyExistsError
-from dandiapi.api.services.embargo.exceptions import DandisetUnEmbargoInProgressError
+from dandiapi.api.services.embargo.exceptions import DandisetUnembargoInProgressError
 from dandiapi.api.services.exceptions import AdminOnlyOperationError, NotAllowedError
 from dandiapi.api.services.version.metadata import _normalize_version_metadata
 
@@ -57,7 +57,7 @@ def delete_dandiset(*, user, dandiset: Dandiset) -> None:
     if dandiset.versions.filter(status=Version.Status.PUBLISHING).exists():
         raise NotAllowedError('Cannot delete dandisets that are currently being published.')
     if dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
-        raise DandisetUnEmbargoInProgressError
+        raise DandisetUnembargoInProgressError
 
     # Delete all versions first, so that AssetPath deletion is cascaded
     # through versions, rather than through zarrs directly

--- a/dandiapi/api/services/dandiset/__init__.py
+++ b/dandiapi/api/services/dandiset/__init__.py
@@ -4,10 +4,8 @@ from django.db import transaction
 
 from dandiapi.api.models.dandiset import Dandiset
 from dandiapi.api.models.version import Version
-from dandiapi.api.services.dandiset.exceptions import (
-    DandisetAlreadyExistsError,
-    DandisetUnEmbargoInProgressError,
-)
+from dandiapi.api.services.dandiset.exceptions import DandisetAlreadyExistsError
+from dandiapi.api.services.embargo.exceptions import DandisetUnEmbargoInProgressError
 from dandiapi.api.services.exceptions import AdminOnlyOperationError, NotAllowedError
 from dandiapi.api.services.version.metadata import _normalize_version_metadata
 

--- a/dandiapi/api/services/dandiset/__init__.py
+++ b/dandiapi/api/services/dandiset/__init__.py
@@ -4,7 +4,10 @@ from django.db import transaction
 
 from dandiapi.api.models.dandiset import Dandiset
 from dandiapi.api.models.version import Version
-from dandiapi.api.services.dandiset.exceptions import DandisetAlreadyExistsError
+from dandiapi.api.services.dandiset.exceptions import (
+    DandisetAlreadyExistsError,
+    DandisetUnEmbargoInProgressError,
+)
 from dandiapi.api.services.exceptions import AdminOnlyOperationError, NotAllowedError
 from dandiapi.api.services.version.metadata import _normalize_version_metadata
 
@@ -55,6 +58,8 @@ def delete_dandiset(*, user, dandiset: Dandiset) -> None:
         raise NotAllowedError('Cannot delete dandisets with published versions.')
     if dandiset.versions.filter(status=Version.Status.PUBLISHING).exists():
         raise NotAllowedError('Cannot delete dandisets that are currently being published.')
+    if dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
+        raise DandisetUnEmbargoInProgressError
 
     # Delete all versions first, so that AssetPath deletion is cascaded
     # through versions, rather than through zarrs directly

--- a/dandiapi/api/services/dandiset/exceptions.py
+++ b/dandiapi/api/services/dandiset/exceptions.py
@@ -7,15 +7,3 @@ from dandiapi.api.services.exceptions import DandiError
 
 class DandisetAlreadyExistsError(DandiError):
     http_status_code = status.HTTP_400_BAD_REQUEST
-
-
-class UnauthorizedEmbargoAccessError(DandiError):
-    http_status_code = status.HTTP_401_UNAUTHORIZED
-    message = (
-        'Authentication credentials must be provided when attempting to access embargoed dandisets'
-    )
-
-
-class DandisetUnEmbargoInProgressError(DandiError):
-    http_status_code = status.HTTP_400_BAD_REQUEST
-    message = 'Dandiset modification not allowed during un-embargo'

--- a/dandiapi/api/services/dandiset/exceptions.py
+++ b/dandiapi/api/services/dandiset/exceptions.py
@@ -14,3 +14,8 @@ class UnauthorizedEmbargoAccessError(DandiError):
     message = (
         'Authentication credentials must be provided when attempting to access embargoed dandisets'
     )
+
+
+class DandisetUnEmbargoInProgressError(DandiError):
+    http_status_code = status.HTTP_400_BAD_REQUEST
+    message = 'Dandiset modification not allowed during un-embargo'

--- a/dandiapi/api/services/embargo/__init__.py
+++ b/dandiapi/api/services/embargo/__init__.py
@@ -12,7 +12,11 @@ from dandiapi.api.models import Asset, AssetBlob, Dandiset, Version
 from dandiapi.api.services.asset.exceptions import DandisetOwnerRequiredError
 from dandiapi.api.storage import get_boto_client
 
-from .exceptions import AssetBlobEmbargoedError, DandisetNotEmbargoedError
+from .exceptions import (
+    AssetBlobEmbargoedError,
+    DandisetActiveUploadsError,
+    DandisetNotEmbargoedError,
+)
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -74,6 +78,9 @@ def unembargo_dandiset(*, user: User, dandiset: Dandiset):
 
     if not user.has_perm('owner', dandiset):
         raise DandisetOwnerRequiredError
+
+    if dandiset.uploads.count():
+        raise DandisetActiveUploadsError
 
     # A scheduled task will pick up any new dandisets with this status and email the admins to
     # initiate the un-embargo process

--- a/dandiapi/api/services/embargo/__init__.py
+++ b/dandiapi/api/services/embargo/__init__.py
@@ -83,7 +83,7 @@ def unembargo_dandiset(*, user: User, dandiset: Dandiset):
         raise DandisetActiveUploadsError
 
     # A scheduled task will pick up any new dandisets with this status and email the admins to
-    # initiate the un-embargo process
+    # initiate the unembargo process
     dandiset.embargo_status = Dandiset.EmbargoStatus.UNEMBARGOING
     dandiset.save()
 

--- a/dandiapi/api/services/embargo/exceptions.py
+++ b/dandiapi/api/services/embargo/exceptions.py
@@ -17,12 +17,12 @@ class DandisetNotEmbargoedError(DandiError):
 
 class DandisetActiveUploadsError(DandiError):
     http_status_code = status.HTTP_400_BAD_REQUEST
-    message = 'Dandiset un-embargo not allowed with active uploads'
+    message = 'Dandiset unembargo not allowed with active uploads'
 
 
-class DandisetUnEmbargoInProgressError(DandiError):
+class DandisetUnembargoInProgressError(DandiError):
     http_status_code = status.HTTP_400_BAD_REQUEST
-    message = 'Dandiset modification not allowed during un-embargo'
+    message = 'Dandiset modification not allowed during unembargo'
 
 
 class UnauthorizedEmbargoAccessError(DandiError):

--- a/dandiapi/api/services/embargo/exceptions.py
+++ b/dandiapi/api/services/embargo/exceptions.py
@@ -18,3 +18,15 @@ class DandisetNotEmbargoedError(DandiError):
 class DandisetActiveUploadsError(DandiError):
     http_status_code = status.HTTP_400_BAD_REQUEST
     message = 'Dandiset un-embargo not allowed with active uploads'
+
+
+class DandisetUnEmbargoInProgressError(DandiError):
+    http_status_code = status.HTTP_400_BAD_REQUEST
+    message = 'Dandiset modification not allowed during un-embargo'
+
+
+class UnauthorizedEmbargoAccessError(DandiError):
+    http_status_code = status.HTTP_401_UNAUTHORIZED
+    message = (
+        'Authentication credentials must be provided when attempting to access embargoed dandisets'
+    )

--- a/dandiapi/api/services/embargo/exceptions.py
+++ b/dandiapi/api/services/embargo/exceptions.py
@@ -13,3 +13,8 @@ class AssetBlobEmbargoedError(DandiError):
 class DandisetNotEmbargoedError(DandiError):
     http_status_code = status.HTTP_400_BAD_REQUEST
     message = 'Dandiset not embargoed'
+
+
+class DandisetActiveUploadsError(DandiError):
+    http_status_code = status.HTTP_400_BAD_REQUEST
+    message = 'Dandiset un-embargo not allowed with active uploads'

--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -48,11 +48,12 @@ def _lock_dandiset_for_publishing(*, user: User, dandiset: Dandiset) -> None:
 
     This function MUST be called before _publish_dandiset is called.
     """
-    if (
-        not user.has_perm('owner', dandiset)
-        or dandiset.embargo_status != Dandiset.EmbargoStatus.OPEN
-    ):
+    if not user.has_perm('owner', dandiset):
         raise NotAllowedError
+
+    if dandiset.embargo_status != Dandiset.EmbargoStatus.OPEN:
+        raise NotAllowedError('Operation only allowed on OPEN dandisets', 400)
+
     if dandiset.zarr_archives.exists() or dandiset.embargoed_zarr_archives.exists():
         raise NotAllowedError('Cannot publish dandisets which contain zarrs', 400)
 

--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -42,7 +42,7 @@ def publish_asset(*, asset: Asset) -> None:
         locked_asset.save()
 
 
-def _lock_dandiset_for_publishing(*, user: User, dandiset: Dandiset) -> None:
+def _lock_dandiset_for_publishing(*, user: User, dandiset: Dandiset) -> None:  # noqa: C901
     """
     Prepare a dandiset to be published by locking it and setting its status to PUBLISHING.
 

--- a/dandiapi/api/tasks/scheduled.py
+++ b/dandiapi/api/tasks/scheduled.py
@@ -114,7 +114,7 @@ def send_pending_users_email() -> None:
 
 @shared_task(soft_time_limit=20)
 def send_dandisets_to_unembargo_email() -> None:
-    """Send an email to admins listing dandisets that have requested un-embargo."""
+    """Send an email to admins listing dandisets that have requested unembargo."""
     dandisets = Dandiset.objects.filter(embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING)
     if dandisets.exists():
         send_dandisets_to_unembargo_message(dandisets)
@@ -148,7 +148,7 @@ def register_scheduled_tasks(sender: Celery, **kwargs):
     # Send daily email to admins containing a list of users awaiting approval
     sender.add_periodic_task(crontab(hour=0, minute=0), send_pending_users_email.s())
 
-    # Send daily email to admins containing a list of dandisets to un-embargo
+    # Send daily email to admins containing a list of dandisets to unembargo
     sender.add_periodic_task(crontab(hour=0, minute=0), send_dandisets_to_unembargo_email.s())
 
     # Refresh the materialized view used by asset search every 10 mins.

--- a/dandiapi/api/templates/api/mail/dandiset_unembargoed.html
+++ b/dandiapi/api/templates/api/mail/dandiset_unembargoed.html
@@ -1,4 +1,4 @@
-Dandiset <a href="{{ dandiset.ui_link }}"> {{ dandiset.identifier }} </a> has been un-embargoed, and is now open for
+Dandiset <a href="{{ dandiset.ui_link }}"> {{ dandiset.identifier }} </a> has been unembargoed, and is now open for
 public access.
 <br><br>
 <em>You are receiving this email because you are an owner of this dandiset.</em>

--- a/dandiapi/api/templates/api/mail/dandisets_to_unembargo.txt
+++ b/dandiapi/api/templates/api/mail/dandisets_to_unembargo.txt
@@ -1,5 +1,5 @@
 {% autoescape off %}
-The following new dandisets are awaiting un-embargo:
+The following new dandisets are awaiting unembargo:
 
 {% for ds in dandisets %}
 Dandiset ID: {{ ds.identifier }}

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -670,7 +670,7 @@ def test_asset_create_embargoed_asset_blob_open_dandiset(
     api_client, user, draft_version, embargoed_asset_blob, mocker
 ):
     # Ensure that creating an asset in an open dandiset that points to an embargoed asset blob
-    # results in that asset blob being un-embargoed
+    # results in that asset blob being unembargoed
     assert draft_version.dandiset.embargo_status == Dandiset.EmbargoStatus.OPEN
     assert embargoed_asset_blob.embargoed
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -751,7 +751,7 @@ def test_dandiset_rest_delete(api_client, draft_version_factory, user):
     assert response.status_code == 204
     assert not Dandiset.objects.all()
 
-    # Ensure that currently un-embargoing dandisets can't be deleted
+    # Ensure that currently unembargoing dandisets can't be deleted
     draft_version = draft_version_factory(
         dandiset__embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING
     )
@@ -891,7 +891,7 @@ def test_dandiset_rest_change_owners_unembargoing(
     user_factory,
     social_account_factory,
 ):
-    """Test that un-embargoing a dandiset prevents user modification."""
+    """Test that unembargoing a dandiset prevents user modification."""
     draft_version = draft_version_factory(
         dandiset__embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING
     )

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -734,21 +734,31 @@ def test_dandiset_rest_create_with_invalid_identifier(api_client, admin_user):
     assert response.data == f'Invalid Identifier {identifier}'
 
 
-@pytest.mark.parametrize(
-    ('embargo_status'),
-    [choice[0] for choice in Dandiset.EmbargoStatus.choices],
-    ids=[choice[1] for choice in Dandiset.EmbargoStatus.choices],
-)
 @pytest.mark.django_db()
-def test_dandiset_rest_delete(api_client, draft_version_factory, user, embargo_status):
-    draft_version = draft_version_factory(dandiset__embargo_status=embargo_status)
+def test_dandiset_rest_delete(api_client, draft_version_factory, user):
     api_client.force_authenticate(user=user)
-    assign_perm('owner', user, draft_version.dandiset)
 
+    # Ensure that open or embargoed dandisets can be deleted
+    draft_version = draft_version_factory(dandiset__embargo_status=Dandiset.EmbargoStatus.OPEN)
+    assign_perm('owner', user, draft_version.dandiset)
     response = api_client.delete(f'/api/dandisets/{draft_version.dandiset.identifier}/')
     assert response.status_code == 204
-
     assert not Dandiset.objects.all()
+
+    draft_version = draft_version_factory(dandiset__embargo_status=Dandiset.EmbargoStatus.EMBARGOED)
+    assign_perm('owner', user, draft_version.dandiset)
+    response = api_client.delete(f'/api/dandisets/{draft_version.dandiset.identifier}/')
+    assert response.status_code == 204
+    assert not Dandiset.objects.all()
+
+    # Ensure that currently un-embargoing dandisets can't be deleted
+    draft_version = draft_version_factory(
+        dandiset__embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING
+    )
+    assign_perm('owner', user, draft_version.dandiset)
+    response = api_client.delete(f'/api/dandisets/{draft_version.dandiset.identifier}/')
+    assert response.status_code == 400
+    assert Dandiset.objects.count() == 1
 
 
 @pytest.mark.django_db()
@@ -831,14 +841,20 @@ def test_dandiset_rest_get_owners_no_social_account(api_client, dandiset, user):
     assert resp.data == [{'username': user.username, 'name': f'{user.first_name} {user.last_name}'}]
 
 
+@pytest.mark.parametrize(
+    'embargo_status',
+    [Dandiset.EmbargoStatus.OPEN, Dandiset.EmbargoStatus.EMBARGOED],
+)
 @pytest.mark.django_db()
 def test_dandiset_rest_change_owner(
     api_client,
-    draft_version,
+    draft_version_factory,
     user_factory,
     social_account_factory,
     mailoutbox,
+    embargo_status,
 ):
+    draft_version = draft_version_factory(dandiset__embargo_status=embargo_status)
     dandiset = draft_version.dandiset
     user1 = user_factory()
     user2 = user_factory()
@@ -866,6 +882,37 @@ def test_dandiset_rest_change_owner(
     assert mailoutbox[0].to == [user1.email]
     assert mailoutbox[1].subject == f'Added to Dandiset "{dandiset.draft_version.name}"'
     assert mailoutbox[1].to == [user2.email]
+
+
+@pytest.mark.django_db()
+def test_dandiset_rest_change_owners_unembargoing(
+    api_client,
+    draft_version_factory,
+    user_factory,
+    social_account_factory,
+):
+    """Test that un-embargoing a dandiset prevents user modification."""
+    draft_version = draft_version_factory(
+        dandiset__embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING
+    )
+    dandiset = draft_version.dandiset
+    user1 = user_factory()
+    user2 = user_factory()
+    social_account1 = social_account_factory(user=user1)
+    social_account2 = social_account_factory(user=user2)
+    assign_perm('owner', user1, dandiset)
+    api_client.force_authenticate(user=user1)
+
+    resp = api_client.put(
+        f'/api/dandisets/{dandiset.identifier}/users/',
+        [
+            {'username': social_account1.extra_data['login']},
+            {'username': social_account2.extra_data['login']},
+        ],
+        format='json',
+    )
+
+    assert resp.status_code == 400
 
 
 @pytest.mark.django_db()

--- a/dandiapi/api/tests/test_unembargo.py
+++ b/dandiapi/api/tests/test_unembargo.py
@@ -39,3 +39,18 @@ def test_unembargo_dandiset_sends_emails(
     assert 'un-embargo' in mailoutbox[0].subject
     assert dandiset.identifier in mailoutbox[0].message().get_payload()
     assert user.username in mailoutbox[0].message().get_payload()
+
+
+@pytest.mark.django_db()
+def test_unembargo_dandiset_lingering_uploads(
+    api_client, user, dandiset_factory, draft_version_factory, upload_factory
+):
+    dandiset = dandiset_factory(embargo_status=Dandiset.EmbargoStatus.EMBARGOED)
+    draft_version_factory(dandiset=dandiset)
+    upload_factory(dandiset=dandiset)
+
+    assign_perm('owner', user, dandiset)
+    api_client.force_authenticate(user=user)
+
+    resp = api_client.post(f'/api/dandisets/{dandiset.identifier}/unembargo/')
+    assert resp.status_code == 400

--- a/dandiapi/api/tests/test_unembargo.py
+++ b/dandiapi/api/tests/test_unembargo.py
@@ -36,7 +36,7 @@ def test_unembargo_dandiset_sends_emails(
     send_dandisets_to_unembargo_email()
 
     assert mailoutbox
-    assert 'un-embargo' in mailoutbox[0].subject
+    assert 'unembargo' in mailoutbox[0].subject
     assert dandiset.identifier in mailoutbox[0].message().get_payload()
     assert user.username in mailoutbox[0].message().get_payload()
 

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -110,6 +110,25 @@ def test_upload_initialize(api_client, user, dandiset_factory, embargoed):
 
 
 @pytest.mark.django_db()
+def test_upload_initialize_unembargoing(api_client, user, dandiset_factory):
+    dandiset = dandiset_factory(embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING)
+    api_client.force_authenticate(user=user)
+    assign_perm('owner', user, dandiset)
+
+    content_size = 123
+    resp = api_client.post(
+        '/api/uploads/initialize/',
+        {
+            'contentSize': content_size,
+            'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
+            'dandiset': dandiset.identifier,
+        },
+        format='json',
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db()
 def test_upload_initialize_existing_asset_blob(api_client, user, dandiset, asset_blob):
     api_client.force_authenticate(user=user)
     assign_perm('owner', user, dandiset)

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -602,6 +602,32 @@ def test_version_rest_update(api_client, user, draft_version):
 
 
 @pytest.mark.django_db()
+def test_version_rest_update_unembargoing(api_client, user, draft_version_factory):
+    draft_version = draft_version_factory(
+        dandiset__embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING
+    )
+    assign_perm('owner', user, draft_version.dandiset)
+    api_client.force_authenticate(user=user)
+
+    new_name = 'A unique and special name!'
+    new_metadata = {
+        '@context': (
+            'https://raw.githubusercontent.com/dandi/schema/master/releases/'
+            f'{settings.DANDI_SCHEMA_VERSION}/context.json'
+        ),
+        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'num': 123,
+    }
+
+    resp = api_client.put(
+        f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
+        {'metadata': new_metadata, 'name': new_name},
+        format='json',
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db()
 def test_version_rest_update_published_version(api_client, user, published_version):
     assign_perm('owner', user, published_version.dandiset)
     api_client.force_authenticate(user=user)

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -9,6 +9,7 @@ from dandiapi.api.services.asset import (
     remove_asset_from_version,
 )
 from dandiapi.api.services.asset.exceptions import DraftDandisetNotModifiableError
+from dandiapi.api.services.dandiset.exceptions import DandisetUnEmbargoInProgressError
 from dandiapi.zarr.models import ZarrArchive
 
 try:
@@ -318,10 +319,13 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
     )
     def create(self, request, versions__dandiset__pk, versions__version):
         version: Version = get_object_or_404(
-            Version,
+            Version.objects.select_related('dandiset'),
             dandiset=versions__dandiset__pk,
             version=versions__version,
         )
+
+        if version.dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
+            raise DandisetUnEmbargoInProgressError
 
         serializer = AssetRequestSerializer(data=self.request.data)
         serializer.is_valid(raise_exception=True)
@@ -351,12 +355,14 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
     def update(self, request, versions__dandiset__pk, versions__version, **kwargs):
         """Update the metadata of an asset."""
         version: Version = get_object_or_404(
-            Version,
+            Version.objects.select_related('dandiset'),
             dandiset__pk=versions__dandiset__pk,
             version=versions__version,
         )
         if version.version != 'draft':
             raise DraftDandisetNotModifiableError
+        if version.dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
+            raise DandisetUnEmbargoInProgressError
 
         serializer = AssetRequestSerializer(data=self.request.data)
         serializer.is_valid(raise_exception=True)
@@ -389,10 +395,12 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
     )
     def destroy(self, request, versions__dandiset__pk, versions__version, **kwargs):
         version = get_object_or_404(
-            Version,
+            Version.objects.select_related('dandiset'),
             dandiset__pk=versions__dandiset__pk,
             version=versions__version,
         )
+        if version.dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
+            raise DandisetUnEmbargoInProgressError
 
         # Lock asset for delete
         with transaction.atomic():

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -9,7 +9,7 @@ from dandiapi.api.services.asset import (
     remove_asset_from_version,
 )
 from dandiapi.api.services.asset.exceptions import DraftDandisetNotModifiableError
-from dandiapi.api.services.embargo.exceptions import DandisetUnEmbargoInProgressError
+from dandiapi.api.services.embargo.exceptions import DandisetUnembargoInProgressError
 from dandiapi.zarr.models import ZarrArchive
 
 try:
@@ -325,7 +325,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         )
 
         if version.dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
-            raise DandisetUnEmbargoInProgressError
+            raise DandisetUnembargoInProgressError
 
         serializer = AssetRequestSerializer(data=self.request.data)
         serializer.is_valid(raise_exception=True)
@@ -362,7 +362,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         if version.version != 'draft':
             raise DraftDandisetNotModifiableError
         if version.dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
-            raise DandisetUnEmbargoInProgressError
+            raise DandisetUnembargoInProgressError
 
         serializer = AssetRequestSerializer(data=self.request.data)
         serializer.is_valid(raise_exception=True)
@@ -400,7 +400,7 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
             version=versions__version,
         )
         if version.dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
-            raise DandisetUnEmbargoInProgressError
+            raise DandisetUnembargoInProgressError
 
         # Lock asset for delete
         with transaction.atomic():

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -9,7 +9,7 @@ from dandiapi.api.services.asset import (
     remove_asset_from_version,
 )
 from dandiapi.api.services.asset.exceptions import DraftDandisetNotModifiableError
-from dandiapi.api.services.dandiset.exceptions import DandisetUnEmbargoInProgressError
+from dandiapi.api.services.embargo.exceptions import DandisetUnEmbargoInProgressError
 from dandiapi.zarr.models import ZarrArchive
 
 try:

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -25,7 +25,10 @@ from dandiapi.api.asset_paths import get_root_paths_many
 from dandiapi.api.mail import send_ownership_change_emails
 from dandiapi.api.models import Dandiset, Version
 from dandiapi.api.services.dandiset import create_dandiset, delete_dandiset
-from dandiapi.api.services.dandiset.exceptions import UnauthorizedEmbargoAccessError
+from dandiapi.api.services.dandiset.exceptions import (
+    DandisetUnEmbargoInProgressError,
+    UnauthorizedEmbargoAccessError,
+)
 from dandiapi.api.services.embargo import unembargo_dandiset
 from dandiapi.api.views.common import DANDISET_PK_PARAM
 from dandiapi.api.views.pagination import DandiPagination
@@ -374,6 +377,9 @@ class DandisetViewSet(ReadOnlyModelViewSet):
     def users(self, request, dandiset__pk):
         dandiset: Dandiset = self.get_object()
         if request.method == 'PUT':
+            if dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
+                raise DandisetUnEmbargoInProgressError
+
             # Verify that the user is currently an owner
             response = get_40x_or_None(request, ['owner'], dandiset, return_403=True)
             if response:

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -374,7 +374,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
     )
     # TODO: move these into a viewset
     @action(methods=['GET', 'PUT'], detail=True)
-    def users(self, request, dandiset__pk):
+    def users(self, request, dandiset__pk):  # noqa: C901
         dandiset: Dandiset = self.get_object()
         if request.method == 'PUT':
             if dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -27,7 +27,7 @@ from dandiapi.api.models import Dandiset, Version
 from dandiapi.api.services.dandiset import create_dandiset, delete_dandiset
 from dandiapi.api.services.embargo import unembargo_dandiset
 from dandiapi.api.services.embargo.exceptions import (
-    DandisetUnEmbargoInProgressError,
+    DandisetUnembargoInProgressError,
     UnauthorizedEmbargoAccessError,
 )
 from dandiapi.api.views.common import DANDISET_PK_PARAM
@@ -378,7 +378,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         dandiset: Dandiset = self.get_object()
         if request.method == 'PUT':
             if dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
-                raise DandisetUnEmbargoInProgressError
+                raise DandisetUnembargoInProgressError
 
             # Verify that the user is currently an owner
             response = get_40x_or_None(request, ['owner'], dandiset, return_403=True)

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -25,11 +25,11 @@ from dandiapi.api.asset_paths import get_root_paths_many
 from dandiapi.api.mail import send_ownership_change_emails
 from dandiapi.api.models import Dandiset, Version
 from dandiapi.api.services.dandiset import create_dandiset, delete_dandiset
-from dandiapi.api.services.dandiset.exceptions import (
+from dandiapi.api.services.embargo import unembargo_dandiset
+from dandiapi.api.services.embargo.exceptions import (
     DandisetUnEmbargoInProgressError,
     UnauthorizedEmbargoAccessError,
 )
-from dandiapi.api.services.embargo import unembargo_dandiset
 from dandiapi.api.views.common import DANDISET_PK_PARAM
 from dandiapi.api.views.pagination import DandiPagination
 from dandiapi.api.views.serializers import (

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -17,7 +17,7 @@ from s3_file_field._multipart import TransferredPart, TransferredParts
 
 from dandiapi.api.models import AssetBlob, Dandiset, Upload
 from dandiapi.api.permissions import IsApproved
-from dandiapi.api.services.dandiset.exceptions import DandisetUnEmbargoInProgressError
+from dandiapi.api.services.embargo.exceptions import DandisetUnEmbargoInProgressError
 from dandiapi.api.tasks import calculate_sha256
 from dandiapi.api.views.serializers import AssetBlobSerializer
 

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -17,6 +17,7 @@ from s3_file_field._multipart import TransferredPart, TransferredParts
 
 from dandiapi.api.models import AssetBlob, Dandiset, Upload
 from dandiapi.api.permissions import IsApproved
+from dandiapi.api.services.dandiset.exceptions import DandisetUnEmbargoInProgressError
 from dandiapi.api.tasks import calculate_sha256
 from dandiapi.api.views.serializers import AssetBlobSerializer
 
@@ -134,6 +135,10 @@ def upload_initialize_view(request: Request) -> HttpResponseBase:
     response = get_40x_or_None(request, ['owner'], dandiset, return_403=True)
     if response:
         return response
+
+    # Ensure dandiset not in the process of un-embargo
+    if dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
+        raise DandisetUnEmbargoInProgressError
 
     logging.info(
         'Starting upload initialization of size %s, ETag %s to dandiset %s',

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -17,7 +17,7 @@ from s3_file_field._multipart import TransferredPart, TransferredParts
 
 from dandiapi.api.models import AssetBlob, Dandiset, Upload
 from dandiapi.api.permissions import IsApproved
-from dandiapi.api.services.embargo.exceptions import DandisetUnEmbargoInProgressError
+from dandiapi.api.services.embargo.exceptions import DandisetUnembargoInProgressError
 from dandiapi.api.tasks import calculate_sha256
 from dandiapi.api.views.serializers import AssetBlobSerializer
 
@@ -136,9 +136,9 @@ def upload_initialize_view(request: Request) -> HttpResponseBase:
     if response:
         return response
 
-    # Ensure dandiset not in the process of un-embargo
+    # Ensure dandiset not in the process of unembargo
     if dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
-        raise DandisetUnEmbargoInProgressError
+        raise DandisetUnembargoInProgressError
 
     logging.info(
         'Starting upload initialization of size %s, ETag %s to dandiset %s',

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -14,7 +14,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSetMixin
 
 from dandiapi.api.models import Dandiset, Version
-from dandiapi.api.services.embargo.exceptions import DandisetUnEmbargoInProgressError
+from dandiapi.api.services.embargo.exceptions import DandisetUnembargoInProgressError
 from dandiapi.api.services.publish import publish_dandiset
 from dandiapi.api.tasks import delete_doi_task
 from dandiapi.api.views.common import DANDISET_PK_PARAM, VERSION_PARAM
@@ -96,7 +96,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
                 status=status.HTTP_405_METHOD_NOT_ALLOWED,
             )
         if version.dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
-            raise DandisetUnEmbargoInProgressError
+            raise DandisetUnembargoInProgressError
 
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -14,7 +14,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSetMixin
 
 from dandiapi.api.models import Dandiset, Version
-from dandiapi.api.services.dandiset.exceptions import DandisetUnEmbargoInProgressError
+from dandiapi.api.services.embargo.exceptions import DandisetUnEmbargoInProgressError
 from dandiapi.api.services.publish import publish_dandiset
 from dandiapi.api.tasks import delete_doi_task
 from dandiapi.api.views.common import DANDISET_PK_PARAM, VERSION_PARAM

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -14,6 +14,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSetMixin
 
 from dandiapi.api.models import Dandiset, Version
+from dandiapi.api.services.dandiset.exceptions import DandisetUnEmbargoInProgressError
 from dandiapi.api.services.publish import publish_dandiset
 from dandiapi.api.tasks import delete_doi_task
 from dandiapi.api.views.common import DANDISET_PK_PARAM, VERSION_PARAM
@@ -94,6 +95,8 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
                 'Only draft versions can be modified.',
                 status=status.HTTP_405_METHOD_NOT_ALLOWED,
             )
+        if version.dandiset.embargo_status == Dandiset.EmbargoStatus.UNEMBARGOING:
+            raise DandisetUnEmbargoInProgressError
 
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/doc/design/embargo-redesign.md
+++ b/doc/design/embargo-redesign.md
@@ -71,9 +71,9 @@ sequenceDiagram
     end
 ```
 
-## Change to Un-Embargo Procedure
+## Change to Unembargo Procedure
 
-Once the time comes to *********un-embargo********* those files, all that is required is to remove the `embargoed` tag from all of the objects. This can be achieved by an [S3 Batch Operations Job](https://docs.aws.amazon.com/AmazonS3/latest/userguide/batch-ops-create-job.html), in which the list of files is specified (all files belonging to the dandiset), and the desired action is specified (delete/replace tags).
+Once the time comes to *********unembargo********* those files, all that is required is to remove the `embargoed` tag from all of the objects. This can be achieved by an [S3 Batch Operations Job](https://docs.aws.amazon.com/AmazonS3/latest/userguide/batch-ops-create-job.html), in which the list of files is specified (all files belonging to the dandiset), and the desired action is specified (delete/replace tags).
 
 The benefit of this approach is that once the files are uploaded, no further movement is required to change the embargo state, eliminating the storage, egress, and time costs associated with unembargoing from a second bucket. Using S3 Batch Operations to perform the untagging also means we can rely on AWS’s own error reporting mechanisms, while retrying any failed operations requires only minimal engineering effort within the Archive codebase.
 
@@ -85,7 +85,7 @@ The benefit of this approach is that once the files are uploaded, no further mov
 4. If there are no failures, the Job ID is set to null in the DB model, and the embargo status, metadata, etc. is updated to reflect that the dandiset is now `OPEN`.
 5. Otherwise, an exception is raised and attended to by the developers.
 
-A diagram of the un-embargo procedure (pertaining to just the objects) is shown below
+A diagram of the unembargo procedure (pertaining to just the objects) is shown below
 
 ```mermaid
 sequenceDiagram
@@ -95,8 +95,8 @@ sequenceDiagram
     participant Worker
     participant S3
 
-    Client ->> Server: Un-embargo dandiset
-    Server ->> Worker: Dispatch un-embargo task
+    Client ->> Server: Unembargo dandiset
+    Server ->> Worker: Dispatch unembargo task
     Worker ->> S3: List of all dandiset objects are aggregated into a manifest
     Worker ->> S3: S3 Batch Operation job created
     S3 ->> Worker: Job ID is returned

--- a/web/src/views/DandisetLandingView/DandisetUnembargo.vue
+++ b/web/src/views/DandisetLandingView/DandisetUnembargo.vue
@@ -17,11 +17,11 @@
         <v-divider class="my-3" />
         <v-card-text>
           <span>
-            This action will un-embargo this dandiset. Note that this is a
+            This action will unembargo this dandiset. Note that this is a
             <span class="font-weight-bold">
               permanent
             </span>
-            action and cannot be undone. Once a dandiset has been un-embargoed,
+            action and cannot be undone. Once a dandiset has been unembargoed,
             it cannot be re-embargoed.
             <br><br>
             Note: this may take several days to complete.


### PR DESCRIPTION
This change will help prevent race conditions that could arise if modifications are allowed while un-embargo is ongoing.