### PR TITLE
Suppress lint error (SIM103)

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -218,7 +218,7 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
         if self.path != path:
             return True
 
-        if self.metadata != metadata:
+        if self.metadata != metadata:  # noqa: SIM103
             return True
 
         return False


### PR DESCRIPTION
This linting rule goes against the intention of the function it's raised in, and enforcing it would make further modification of that function more difficult.