### PR TITLE
Bump dandischema to 0.10.2 (schema version 0.6.8)

### DIFF
--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -108,6 +108,7 @@ class BaseVersionFactory(factory.django.DjangoModelFactory):
                 {
                     'name': f'{faker.Faker().last_name()}, {faker.Faker().first_name()}',
                     'roleName': ['dcite:ContactPerson'],
+                    'email': faker.Faker().email(),
                     'schemaKey': 'Person',
                 }
             ],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'celery',
         # Pin dandischema to exact version to make explicit which schema version is being used
-        'dandischema==0.10.1',  # schema version 0.6.7
+        'dandischema==0.10.2',  # schema version 0.6.8
         'django~=4.1.0',
         'django-admin-display',
         # Require 0.58.0 as it is the first version to support postgres' native

--- a/web/src/components/Meditor/types.ts
+++ b/web/src/components/Meditor/types.ts
@@ -65,7 +65,7 @@ export const isJSONSchema = (schema: JSONSchemaUnionType): schema is JSONSchema7
 
 export const isBasicSchema = (schema: JSONSchemaUnionType): schema is BasicSchema => (
   isJSONSchema(schema)
-  && (isBasicType(schema.type) || schema.type === undefined)
+  && (isBasicType(schema.type))
 );
 
 export const isObjectSchema = (schema: JSONSchemaUnionType): schema is ObjectSchema => (


### PR DESCRIPTION
Depends on #1977
Fixes #1975

With this schema version upgrade, the meditor was failing to show certain fields. The reason for the breaking logic was due to a change in #1823 ([dd2c7b32](https://github.com/dandi/dandi-archive/commit/dd2c7b32ddea5984ee2b876f6b8aba8e6ce2e010)). The underlying reason for this logic was fixed with the new version of the schema (`0.6.8`), and so that code was no longer necessary.