### PR TITLE
Use md5 hasher in tests to speed them up

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -169,7 +169,9 @@ class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
 
     @staticmethod
     def mutate_configuration(configuration: ComposedConfiguration):
-        # use md5 in testing for quicker user creation
+        # use md5 in testing for quicker user creation.
+        # TODO: remove this when it is implemented upstream
+        # Issue: https://github.com/kitware-resonant/django-composed-configuration/issues/211
         configuration.PASSWORD_HASHERS.insert(0, 'django.contrib.auth.hashers.MD5PasswordHasher')
 
 

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -167,6 +167,11 @@ class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
         }
     }
 
+    @staticmethod
+    def mutate_configuration(configuration: ComposedConfiguration):
+        # use md5 in testing for quicker user creation
+        configuration.PASSWORD_HASHERS.insert(0, 'django.contrib.auth.hashers.MD5PasswordHasher')
+
 
 class ProductionConfiguration(DandiMixin, ProductionBaseConfiguration):
     pass


### PR DESCRIPTION
This speeds up tests by using a simpler md5 password hasher instead of the more performance intensive bcrypt hasher.