### PR TITLE
Add dashboard link to view to emit user list as Mailchimp-compatible CSV

### DIFF
--- a/dandiapi/api/templates/dashboard/base.html
+++ b/dandiapi/api/templates/dashboard/base.html
@@ -16,6 +16,7 @@
   <a class="dandi-navbar-link" href="{% url 'dashboard-index' %}">Dashboard Home</a>
   <a class="dandi-navbar-link" href="{% url "admin:auth_user_changelist" %}">Users</a>
   <a class="dandi-navbar-link" href="{% url 'admin:index' %}">Admin</a>
+  <a class="dandi-navbar-link" href="{% url 'mailchimp-csv' %}">Mailchimp CSV</a>
   {% if title %} &rsaquo; {{ title }}{% endif %}
 </div>
 {% endblock %}

--- a/dandiapi/api/views/__init__.py
+++ b/dandiapi/api/views/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from .asset import AssetViewSet, NestedAssetViewSet
 from .auth import auth_token_view, authorize_view, user_questionnaire_form_view
 from .dandiset import DandisetViewSet
-from .dashboard import DashboardView, user_approval_view
+from .dashboard import DashboardView, mailchimp_csv_view, user_approval_view
 from .info import info_view
 from .root import root_content_view
 from .stats import stats_view
@@ -25,6 +25,7 @@ __all__ = [
     'authorize_view',
     'auth_token_view',
     'blob_read_view',
+    'mailchimp_csv_view',
     'upload_initialize_view',
     'upload_complete_view',
     'upload_validate_view',

--- a/dandiapi/api/views/dashboard.py
+++ b/dandiapi/api/views/dashboard.py
@@ -88,7 +88,7 @@ def mailchimp_csv_view(request: HttpRequest) -> HttpResponse:
     # In production, there's a placeholder user with a blank email that we want
     # to avoid.
     users = User.objects.filter(is_active=True).exclude(email='')
-    data = users.values_list('email', 'first_name', 'last_name')
+    data = users.values_list('email', 'first_name', 'last_name').iterator()
 
     response = HttpResponse(
         content_type='text/csv',

--- a/dandiapi/api/views/dashboard.py
+++ b/dandiapi/api/views/dashboard.py
@@ -92,7 +92,7 @@ def mailchimp_csv_view(request: HttpRequest) -> StreamingHttpResponse:
     fieldnames = ['email', 'first_name', 'last_name']
     data = users.values(*fieldnames).iterator()
 
-    def streaming_output():
+    def streaming_output() -> Iterator[str]:
         """A generator that "streams" CSV rows using a pseudo-buffer."""
 
         # This class implements a filelike's write() interface to provide a way

--- a/dandiapi/api/views/dashboard.py
+++ b/dandiapi/api/views/dashboard.py
@@ -87,9 +87,10 @@ class DashboardView(DashboardMixin, TemplateView):
 
 def mailchimp_csv_view(request: HttpRequest) -> StreamingHttpResponse:
     """Generate a Mailchimp-compatible CSV file of all active users."""
-    # In production, there's a placeholder user with a blank email that we want
-    # to avoid.
-    users = User.objects.filter(metadata__status=UserMetadata.Status.APPROVED).exclude(email='')
+    # Exclude the django-guardian anonymous user account.
+    users = User.objects.filter(metadata__status=UserMetadata.Status.APPROVED).exclude(
+        username='AnonymousUser'
+    )
 
     fieldnames = ['email', 'first_name', 'last_name']
     data = users.values(*fieldnames).iterator()

--- a/dandiapi/api/views/dashboard.py
+++ b/dandiapi/api/views/dashboard.py
@@ -112,7 +112,7 @@ def mailchimp_csv_view(request: HttpRequest) -> StreamingHttpResponse:
 
     return StreamingHttpResponse(
         streaming_output(),
-        content_type='text/plain',
+        content_type='text/csv',
         headers={
             'Content-Disposition': 'attachment; filename="dandi_users_mailchimp.csv"',
         },

--- a/dandiapi/api/views/dashboard.py
+++ b/dandiapi/api/views/dashboard.py
@@ -87,7 +87,7 @@ def mailchimp_csv_view(request: HttpRequest) -> StreamingHttpResponse:
     """Generate a Mailchimp-compatible CSV file of all active users."""
     # In production, there's a placeholder user with a blank email that we want
     # to avoid.
-    users = User.objects.filter(is_active=True).exclude(email='')
+    users = User.objects.filter(metadata__status=UserMetadata.Status.APPROVED).exclude(email='')
 
     fieldnames = ['email', 'first_name', 'last_name']
     data = users.values(*fieldnames).iterator()

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -106,7 +106,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('dashboard/', DashboardView.as_view(), name='dashboard-index'),
     path('dashboard/user/<str:username>/', user_approval_view, name='user-approval'),
-    path('dashboard/mailchimp', mailchimp_csv_view, name='mailchimp-csv'),
+    path('dashboard/mailchimp/', mailchimp_csv_view, name='mailchimp-csv'),
     # this url overrides the authorize url in oauth2_provider.urls to
     # support our user signup workflow
     re_path(r'^oauth/authorize/$', authorize_view, name='authorize'),

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -18,6 +18,7 @@ from dandiapi.api.views import (
     authorize_view,
     blob_read_view,
     info_view,
+    mailchimp_csv_view,
     root_content_view,
     stats_view,
     upload_complete_view,
@@ -105,6 +106,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('dashboard/', DashboardView.as_view(), name='dashboard-index'),
     path('dashboard/user/<str:username>/', user_approval_view, name='user-approval'),
+    path('dashboard/mailchimp', mailchimp_csv_view, name='mailchimp-csv'),
     # this url overrides the authorize url in oauth2_provider.urls to
     # support our user signup workflow
     re_path(r'^oauth/authorize/$', authorize_view, name='authorize'),


### PR DESCRIPTION
This is needed to automate a somewhat tricky process when done by hand. The resulting CSV can be used to import the users to a Mailchimp account in order to keep the Mailchimp audience accurate when sending (infrequent) mass emails.