### PR TITLE
Add Neurosift service for AVI files

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -357,6 +357,13 @@ const EXTERNAL_SERVICES = [
     regex: /\.nwb.lindi.json$/,
     maxsize: Infinity,
     endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&st=lindi&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
+  },
+
+  {
+    name: 'Neurosift',
+    regex: /\.avi$/,
+    maxsize: Infinity,
+    endpoint: 'https://neurosift.app?p=/avi&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
   }
 ];
 type Service = typeof EXTERNAL_SERVICES[0];


### PR DESCRIPTION
This is a small change to add an "Open With -> Neurosift" entry for .avi files.

DANDI supports uploading of .avi files, but currently there is no way to preview/stream those files in the browser (browsers do not support AVI).

Neurosift now provides a workaround by using Dendro to precompute .mp4 files associated with portions of the .avi files.

For example:

https://dandiarchive.org/dandiset/001084/draft/files?location=sub-DL18%2Fsub-DL18_ses-211110_image%2Bophys&page=1

With this PR you would be able to "Open With" Neurosift and be directed to

https://neurosift.app/?p=/avi&url=https://api.dandiarchive.org/api/assets/3d760886-c1ac-467d-bd87-3dfd71a5cb65/download/&dandisetId=001084&dandisetVersion=draft

At that link, you should be able to view the first X minutes of that video because the Dendro job had already been submitted and completed. For other AVI files, the .mp4 file might not be prepared, and the Dendro job would need to be submitted. Dendro is still at an early stage and we are working on documenting how to obtain a Dendro API key, etc, to be able to submit those jobs. But it would be a great to establish this connection between the archive and Neurosift even during the development phase.

tag: @bendichter @yarikoptic 

