### PR TITLE
Re-validate version metadata during unembargo

### DIFF
--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -172,7 +172,7 @@ def validate_version_metadata(*, version: Version) -> None:
         # If the version has since been modified, return early
         if current_version.status != Version.Status.PENDING:
             logger.info(
-                'Skipping validation for version %s due to concurrent modification', version_id
+                'Skipping validation for version with a status of %s', current_version.status
             )
             return
 


### PR DESCRIPTION
This addresses what I believe to be the cause of https://github.com/dandi/helpdesk/issues/158. Previously, when a dandiset was unembargo, we re-populated the version metadata but never validated it. This is in contrast to the normal flow of updating a version, which sets its status to `PENDING` and is eventually validated.

Now, this is performed inline as a part of unembargo.

@danlamanna Curious about your thoughts on my changes and additional test for `validate_version_metadata`. Previously, we assumed that versions with a status besides `PENDING` were passed into the function correctly, and were concurrently modified, changing the status. However, the function could easily be called mistakenly with a different version status, and so I think the log message should be updated to reflect that.