### PR TITLE
Apply new `ruff` rules

### DIFF
--- a/dandiapi/analytics/tests/test_download_counts.py
+++ b/dandiapi/analytics/tests/test_download_counts.py
@@ -8,12 +8,12 @@ from dandiapi.analytics.tasks import collect_s3_log_records_task, process_s3_log
 from dandiapi.api.storage import create_s3_storage, get_boto_client
 
 
-@pytest.fixture()
+@pytest.fixture
 def s3_log_bucket():
     return create_s3_storage(settings.DANDI_DANDISETS_LOG_BUCKET_NAME).bucket_name
 
 
-@pytest.fixture()
+@pytest.fixture
 def s3_log_file(s3_log_bucket, asset_blob):
     s3 = get_boto_client()
 
@@ -44,7 +44,7 @@ def s3_log_file(s3_log_bucket, asset_blob):
     s3.delete_object(Bucket=s3_log_bucket, Key=log_file_name)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_processing_s3_log_files(s3_log_file, asset_blob):
     collect_s3_log_records_task()
     asset_blob.refresh_from_db()
@@ -53,7 +53,7 @@ def test_processing_s3_log_files(s3_log_file, asset_blob):
     assert asset_blob.download_count == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_processing_s3_log_files_idempotent(s3_log_file, asset_blob):
     # this tests that the outer task which collects the log files to process is
     # idempotent, in other words, it uses StartAfter correctly.
@@ -66,7 +66,7 @@ def test_processing_s3_log_files_idempotent(s3_log_file, asset_blob):
     assert asset_blob.download_count == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_processing_s3_log_file_task_idempotent(s3_log_file, asset_blob):
     # this tests that the inner task which processes a single log file is
     # idempotent, utilizing the unique constraint on ProcessedS3Log correctly.

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -26,7 +26,7 @@ from .fuzzy import HTTP_URL_RE, TIMESTAMP_RE, URN_RE, UTC_ISO_TIMESTAMP_RE, UUID
 # Model tests
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_no_blob_zarr(draft_asset_factory):
     asset = draft_asset_factory()
 
@@ -38,7 +38,7 @@ def test_asset_no_blob_zarr(draft_asset_factory):
     assert 'blob-xor-zarr' in str(excinfo.value)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_blob_and_zarr(draft_asset, zarr_archive):
     # An integrity error is thrown by the constraint that both blob and zarr cannot both be defined
     draft_asset.zarr = zarr_archive
@@ -48,7 +48,7 @@ def test_asset_blob_and_zarr(draft_asset, zarr_archive):
     assert 'blob-xor-zarr' in str(excinfo.value)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_path(api_client, draft_version_factory, asset_factory):
     # Initialize version and contained assets
     version: Version = draft_version_factory()
@@ -69,7 +69,7 @@ def test_asset_rest_path(api_client, draft_version_factory, asset_factory):
     assert val['aggregate_files'] == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_path_not_found(api_client, draft_version_factory, asset_factory):
     # Initialize version and contained assets
     version: Version = draft_version_factory()
@@ -89,7 +89,7 @@ def test_asset_rest_path_not_found(api_client, draft_version_factory, asset_fact
     assert resp.json() == {'detail': 'Specified path not found.'}
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_s3_url(asset_blob):
     signed_url = asset_blob.blob.url
     s3_url = asset_blob.s3_url
@@ -97,7 +97,7 @@ def test_asset_s3_url(asset_blob):
     assert signed_url.split('?')[0] == s3_url
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_publish_asset(draft_asset: Asset):
     draft_asset_id = draft_asset.asset_id
     draft_blob = draft_asset.blob
@@ -139,7 +139,7 @@ def test_publish_asset(draft_asset: Asset):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_total_size(
     draft_version_factory, asset_factory, asset_blob_factory, zarr_archive_factory
 ):
@@ -176,7 +176,7 @@ def test_asset_total_size(
     # supported, ATM they are not and tested by test_zarr_rest_create_embargoed_dandiset
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_full_metadata(draft_asset_factory):
     raw_metadata = {
         'foo': 'bar',
@@ -202,7 +202,7 @@ def test_asset_full_metadata(draft_asset_factory):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_full_metadata_zarr(draft_asset_factory, zarr_archive):
     raw_metadata = {
         'foo': 'bar',
@@ -233,7 +233,7 @@ def test_asset_full_metadata_zarr(draft_asset_factory, zarr_archive):
 # API Tests
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_list(api_client, version, asset, asset_factory):
     version.assets.add(asset)
 
@@ -260,7 +260,7 @@ def test_asset_rest_list(api_client, version, asset, asset_factory):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_list_include_metadata(api_client, version, asset, asset_factory):
     version.assets.add(asset)
 
@@ -301,7 +301,7 @@ def test_asset_rest_list_include_metadata(api_client, version, asset, asset_fact
         'no-match',
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_list_path_filter(api_client, version, asset_factory, path, result_indices):
     assets = [
         asset_factory(path='foo.txt'),
@@ -348,7 +348,7 @@ def test_asset_rest_list_path_filter(api_client, version, asset_factory, path, r
     ],
     ids=['created', '-created', 'modified', '-modified', 'path', '-path'],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_list_ordering(api_client, version, asset_factory, order_param, ordering):
     # Create asset B first so that the path ordering is different from the created ordering.
     b = asset_factory(path='b')
@@ -369,7 +369,7 @@ def test_asset_rest_list_ordering(api_client, version, asset_factory, order_para
     assert result_paths == ordering
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_ordering(api_client, version, asset_factory):
     # The default collation will ignore special characters, including slashes, on the first pass. If
     # there are ties, it uses these characters to break ties. This means that in the below example,
@@ -388,7 +388,7 @@ def test_asset_path_ordering(api_client, version, asset_factory):
     assert asset_listing[1].pk == b.pk
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_retrieve(api_client, version, asset, asset_factory):
     version.assets.add(asset)
 
@@ -404,7 +404,7 @@ def test_asset_rest_retrieve(api_client, version, asset, asset_factory):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_retrieve_no_sha256(api_client, version, asset):
     version.assets.add(asset)
     # Remove the sha256 from the factory asset
@@ -420,7 +420,7 @@ def test_asset_rest_retrieve_no_sha256(api_client, version, asset):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_retrieve_embargoed_admin(
     api_client,
     draft_version_factory,
@@ -450,7 +450,7 @@ def test_asset_rest_retrieve_embargoed_admin(
     assert r.status_code == 200
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_download_embargoed_admin(
     api_client,
     draft_version_factory,
@@ -480,7 +480,7 @@ def test_asset_rest_download_embargoed_admin(
     assert r.status_code == 302
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_info(api_client, version, asset):
     version.assets.add(asset)
 
@@ -499,7 +499,7 @@ def test_asset_rest_info(api_client, version, asset):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ('status', 'validation_error'),
     [
@@ -525,7 +525,7 @@ def test_asset_rest_validation(api_client, version, asset, status, validation_er
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create(api_client, user, draft_version, asset_blob):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -597,7 +597,7 @@ def test_asset_create(api_client, user, draft_version, asset_blob):
         ('foo/.bar', 200),
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_path_validation(
     api_client, user, draft_version, asset_blob, path, expected_status_code
 ):
@@ -620,7 +620,7 @@ def test_asset_create_path_validation(
     assert resp.status_code == expected_status_code, resp.data
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_conflicting_path(api_client, user, draft_version, asset_blob):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -661,7 +661,7 @@ def test_asset_create_conflicting_path(api_client, user, draft_version, asset_bl
         )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_embargo(
     api_client, user, draft_version_factory, dandiset_factory, embargoed_asset_blob
 ):
@@ -696,7 +696,7 @@ def test_asset_create_embargo(
     assert draft_version.status == Version.Status.PENDING
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_unembargo_in_progress(
     api_client, user, draft_version_factory, dandiset_factory, embargoed_asset_blob
 ):
@@ -768,7 +768,7 @@ def test_asset_create_embargoed_asset_blob_open_dandiset(
     assert draft_version.status == Version.Status.PENDING
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_zarr(api_client, user, draft_version, zarr_archive):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -865,7 +865,7 @@ def test_asset_create_zarr_validated(
     assert asset2.status == Asset.Status.VALID
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_zarr_wrong_dandiset(
     api_client, user, draft_version, zarr_archive_factory, dandiset_factory
 ):
@@ -894,7 +894,7 @@ def test_asset_create_zarr_wrong_dandiset(
     assert resp.json() == 'The zarr archive belongs to a different dandiset'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_no_blob_or_zarr(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -918,7 +918,7 @@ def test_asset_create_no_blob_or_zarr(api_client, user, draft_version):
     assert resp.json() == {'blob_id': ['Exactly one of blob_id or zarr_id must be specified.']}
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_blob_and_zarr(api_client, user, draft_version, asset_blob, zarr_archive):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -942,7 +942,7 @@ def test_asset_create_blob_and_zarr(api_client, user, draft_version, asset_blob,
     assert resp.json() == {'blob_id': ['Exactly one of blob_id or zarr_id must be specified.']}
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_no_valid_blob(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -960,7 +960,7 @@ def test_asset_create_no_valid_blob(api_client, user, draft_version):
     assert resp.status_code == 404
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_no_path(api_client, user, draft_version, asset_blob):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -977,7 +977,7 @@ def test_asset_create_no_path(api_client, user, draft_version, asset_blob):
     assert resp.data == {'metadata': ['No path specified in metadata.']}, resp.data
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_not_an_owner(api_client, user, version):
     api_client.force_authenticate(user=user)
 
@@ -991,7 +991,7 @@ def test_asset_create_not_an_owner(api_client, user, version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_published_version(api_client, user, published_version, asset):
     assign_perm('owner', user, published_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -1012,7 +1012,7 @@ def test_asset_create_published_version(api_client, user, published_version, ass
     assert resp.data == 'Only draft versions can be modified.'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_create_existing_path(api_client, user, draft_version, asset_blob, asset_factory):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -1038,7 +1038,7 @@ def test_asset_create_existing_path(api_client, user, draft_version, asset_blob,
     assert resp.status_code == 409
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_rename(api_client, user, draft_version, asset_blob):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -1064,7 +1064,7 @@ def test_asset_rest_rename(api_client, user, draft_version, asset_blob):
     assert resp.json()['asset_id'] != str(asset.asset_id)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_update(api_client, user, draft_version, asset, asset_blob):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -1125,7 +1125,7 @@ def test_asset_rest_update(api_client, user, draft_version, asset, asset_blob):
     assert draft_version.status == Version.Status.PENDING
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_update_embargo(api_client, user, draft_version, asset, embargoed_asset_blob):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -1181,7 +1181,7 @@ def test_asset_rest_update_embargo(api_client, user, draft_version, asset, embar
     assert draft_version.status == Version.Status.PENDING
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_update_unembargo_in_progress(
     api_client, user, draft_version_factory, asset, embargoed_asset_blob
 ):
@@ -1210,7 +1210,7 @@ def test_asset_rest_update_unembargo_in_progress(
     assert resp.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_update_zarr(
     api_client,
     user,
@@ -1279,7 +1279,7 @@ def test_asset_rest_update_zarr(
     assert draft_version.status == Version.Status.PENDING
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_update_unauthorized(api_client, draft_version, asset):
     draft_version.assets.add(asset)
     new_metadata = asset.metadata
@@ -1295,7 +1295,7 @@ def test_asset_rest_update_unauthorized(api_client, draft_version, asset):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_update_not_an_owner(api_client, user, draft_version, asset):
     api_client.force_authenticate(user=user)
     draft_version.assets.add(asset)
@@ -1313,7 +1313,7 @@ def test_asset_rest_update_not_an_owner(api_client, user, draft_version, asset):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_update_published_version(api_client, user, published_version, asset):
     assign_perm('owner', user, published_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -1331,7 +1331,7 @@ def test_asset_rest_update_published_version(api_client, user, published_version
     assert resp.data == 'Only draft versions can be modified.'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_update_to_existing(api_client, user, draft_version, asset_factory):
     old_asset = asset_factory()
     existing_asset = asset_factory()
@@ -1352,7 +1352,7 @@ def test_asset_rest_update_to_existing(api_client, user, draft_version, asset_fa
     assert resp.status_code == 409
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_delete(api_client, user, draft_version, asset):
     assign_perm('owner', user, draft_version.dandiset)
     draft_version.assets.add(asset)
@@ -1384,7 +1384,7 @@ def test_asset_rest_delete(api_client, user, draft_version, asset):
     assert draft_version.status == Version.Status.PENDING
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_delete_unembargo_in_progress(api_client, user, draft_version_factory, asset):
     draft_version = draft_version_factory(
         dandiset__embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING
@@ -1401,7 +1401,7 @@ def test_asset_rest_delete_unembargo_in_progress(api_client, user, draft_version
     assert response.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_delete_zarr(
     api_client,
     user,
@@ -1431,7 +1431,7 @@ def test_asset_rest_delete_zarr(
     assert resp.status_code == 204
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_delete_zarr_modified(
     api_client,
     user,
@@ -1490,7 +1490,7 @@ def test_asset_rest_delete_zarr_modified(
     assert resp.status_code == 204
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_delete_not_an_owner(api_client, user, version, asset):
     api_client.force_authenticate(user=user)
     version.assets.add(asset)
@@ -1504,7 +1504,7 @@ def test_asset_rest_delete_not_an_owner(api_client, user, version, asset):
     assert asset in Asset.objects.all()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_rest_delete_published_version(api_client, user, published_version, asset):
     api_client.force_authenticate(user=user)
     assign_perm('owner', user, published_version.dandiset)
@@ -1518,7 +1518,7 @@ def test_asset_rest_delete_published_version(api_client, user, published_version
     assert response.data == 'Only draft versions can be modified.'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_download(api_client, storage, version, asset):
     # Pretend like AssetBlob was defined with the given storage
     AssetBlob.blob.field.storage = storage
@@ -1544,7 +1544,7 @@ def test_asset_download(api_client, storage, version, asset):
         assert download.content == reader.read()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_download_embargo(
     authenticated_api_client,
     user,
@@ -1590,7 +1590,7 @@ def test_asset_download_embargo(
         assert download.content == reader.read()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_download_zarr(api_client, version, asset_factory, zarr_archive):
     asset = asset_factory(blob=None, zarr=zarr_archive)
     version.assets.add(asset)
@@ -1602,7 +1602,7 @@ def test_asset_download_zarr(api_client, version, asset_factory, zarr_archive):
     assert response.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_direct_download(api_client, storage, version, asset):
     # Pretend like AssetBlob was defined with the given storage
     AssetBlob.blob.field.storage = storage
@@ -1625,7 +1625,7 @@ def test_asset_direct_download(api_client, storage, version, asset):
         assert download.content == reader.read()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_direct_download_zarr(api_client, version, asset_factory, zarr_archive):
     asset = asset_factory(blob=None, zarr=zarr_archive)
     version.assets.add(asset)
@@ -1634,7 +1634,7 @@ def test_asset_direct_download_zarr(api_client, version, asset_factory, zarr_arc
     assert response.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_direct_download_head(api_client, storage, version, asset):
     # Pretend like AssetBlob was defined with the given storage
     AssetBlob.blob.field.storage = storage
@@ -1657,14 +1657,14 @@ def test_asset_direct_download_head(api_client, storage, version, asset):
         assert download.content == reader.read()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_direct_metadata(api_client, asset):
     assert (
         json.loads(api_client.get(f'/api/assets/{asset.asset_id}/').content) == asset.full_metadata
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_direct_info(api_client, asset):
     assert api_client.get(f'/api/assets/{asset.asset_id}/info/').json() == {
         'asset_id': str(asset.asset_id),
@@ -1678,7 +1678,7 @@ def test_asset_direct_info(api_client, asset):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ('glob_pattern', 'expected_paths'),
     [

--- a/dandiapi/api/tests/test_asset_paths.py
+++ b/dandiapi/api/tests/test_asset_paths.py
@@ -19,7 +19,7 @@ from dandiapi.api.services.asset.exceptions import AssetAlreadyExistsError
 from dandiapi.api.tasks import publish_dandiset_task
 
 
-@pytest.fixture()
+@pytest.fixture
 def ingested_asset(draft_version_factory, asset_factory) -> Asset:
     asset: Asset = asset_factory()
     version: Version = draft_version_factory()
@@ -43,7 +43,7 @@ def test_extract_paths(path, expected):
     assert extract_paths(path) == expected
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_add_asset(draft_version_factory, asset_factory):
     # Create asset with version
     asset: Asset = asset_factory()
@@ -84,7 +84,7 @@ def test_asset_path_add_asset(draft_version_factory, asset_factory):
         )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_add_asset_idempotent(draft_version_factory, asset_factory):
     # Create asset with version
     asset: Asset = asset_factory()
@@ -101,7 +101,7 @@ def test_asset_path_add_asset_idempotent(draft_version_factory, asset_factory):
     assert path.aggregate_size == asset.size
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_add_asset_conflicting_path(draft_version_factory, asset_factory):
     # Create asset with version
     asset1: Asset = asset_factory()
@@ -122,7 +122,7 @@ def test_asset_path_add_asset_conflicting_path(draft_version_factory, asset_fact
     assert version.asset_paths.filter(asset__isnull=False).count() == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_add_version_asset_paths(draft_version_factory, asset_factory):
     # Create asset with version
     version: Version = draft_version_factory()
@@ -156,7 +156,7 @@ def test_asset_path_add_version_asset_paths(draft_version_factory, asset_factory
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_add_version_asset_paths_idempotent(draft_version_factory, asset_factory):
     # Create asset with version
     version: Version = draft_version_factory()
@@ -178,7 +178,7 @@ def test_asset_path_add_version_asset_paths_idempotent(draft_version_factory, as
         assert path.aggregate_size == path.asset.size
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_add_asset_shared_paths(draft_version_factory, asset_factory):
     # Create asset with version
     version: Version = draft_version_factory()
@@ -197,7 +197,7 @@ def test_asset_path_add_asset_shared_paths(draft_version_factory, asset_factory)
     assert path.aggregate_files == 2
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_delete_asset(ingested_asset):
     asset = ingested_asset
     version = ingested_asset.versions.first()
@@ -210,7 +210,7 @@ def test_asset_path_delete_asset(ingested_asset):
     assert not AssetPath.objects.filter(path=asset.path, version=version).exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_delete_asset_idempotent(ingested_asset):
     asset = ingested_asset
     version = ingested_asset.versions.first()
@@ -220,7 +220,7 @@ def test_asset_path_delete_asset_idempotent(ingested_asset):
     delete_asset_paths(asset, version)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_update_asset(draft_version_factory, asset_factory):
     # Create asset with version
     version: Version = draft_version_factory()
@@ -248,7 +248,7 @@ def test_asset_path_update_asset(draft_version_factory, asset_factory):
         assert AssetPath.objects.filter(path=path, version=version).exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_delete_asset_shared_paths(
     draft_version_factory, asset_factory, asset_blob_factory
 ):
@@ -272,7 +272,7 @@ def test_asset_path_delete_asset_shared_paths(
     assert path.aggregate_files == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_search_asset_paths(draft_version_factory, asset_factory):
     version: Version = draft_version_factory()
     assets = [asset_factory(path=path) for path in ['foo/bar.txt', 'foo/baz.txt', 'bar/foo.txt']]
@@ -294,7 +294,7 @@ def test_asset_path_search_asset_paths(draft_version_factory, asset_factory):
     assert all(x.asset is not None for x in qs)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_publish_version(draft_version_factory, asset_factory, user):
     version: Version = draft_version_factory()
     asset = asset_factory(path='foo/bar.txt', status=Asset.Status.VALID)
@@ -325,7 +325,7 @@ def test_asset_path_publish_version(draft_version_factory, asset_factory, user):
         AssetPath.objects.get(path=path, version=published_version)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_get_root_paths(draft_version_factory, asset_factory):
     version = draft_version_factory()
     version.assets.add(asset_factory(path='a'))
@@ -337,7 +337,7 @@ def test_asset_path_get_root_paths(draft_version_factory, asset_factory):
     assert get_root_paths(version).count() == 4
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_path_get_root_paths_many(draft_version_factory, asset_factory):
     version = draft_version_factory()
     version.assets.add(asset_factory(path='a'))

--- a/dandiapi/api/tests/test_audit.py
+++ b/dandiapi/api/tests/test_audit.py
@@ -62,7 +62,7 @@ def create_dandiset(
     return Dandiset.objects.get(pk=dandiset_id)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_create_dandiset(api_client, user):
     """Test create_dandiset audit record."""
     # Create a Dandiset with specified name and metadata.
@@ -79,7 +79,7 @@ def test_audit_create_dandiset(api_client, user):
     assert rec.details['metadata']['name'] == name
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_change_owners(api_client, user_factory, draft_version):
     """Test the change_owners audit record."""
     # Create some users.
@@ -116,7 +116,7 @@ def test_audit_change_owners(api_client, user_factory, draft_version):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_update_metadata(api_client, draft_version, user):
     # Create a Dandiset.
     dandiset = draft_version.dandiset
@@ -145,7 +145,7 @@ def test_audit_update_metadata(api_client, draft_version, user):
     assert metadata['foo'] == 'bar'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_delete_dandiset(api_client, user, draft_version):
     # Create a Dandiset.
     dandiset = draft_version.dandiset
@@ -183,7 +183,7 @@ def test_audit_unembargo(api_client, user):
     assert rec.details == {}
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_add_asset(api_client, user, draft_version, asset_blob_factory):
     # Create a Dandiset.
     dandiset = draft_version.dandiset
@@ -211,7 +211,7 @@ def test_audit_add_asset(api_client, user, draft_version, asset_blob_factory):
     assert rec.details['asset_blob_id'] == blob.blob_id
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_update_asset(
     api_client, user, draft_version, asset_blob_factory, draft_asset_factory
 ):
@@ -245,7 +245,7 @@ def test_audit_update_asset(
     assert rec.details['asset_blob_id'] == blob.blob_id
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_remove_asset(
     api_client, user, draft_version, asset_blob_factory, draft_asset_factory
 ):
@@ -302,7 +302,7 @@ def test_audit_publish_dandiset(
     assert rec.details['version'] == dandiset.most_recent_published_version.version
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_zarr_create(api_client, user, draft_version):
     # Create a Dandiset.
     dandiset = draft_version.dandiset
@@ -328,7 +328,7 @@ def test_audit_zarr_create(api_client, user, draft_version):
     assert rec.details['zarr_id'] == zarr_id
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_upload_zarr_chunks(api_client, user, draft_version, zarr_archive_factory, storage):
     ZarrArchive.storage = storage
 
@@ -354,7 +354,7 @@ def test_audit_upload_zarr_chunks(api_client, user, draft_version, zarr_archive_
     assert rec.details['paths'] == paths
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_finalize_zarr(
     api_client, user, draft_version, zarr_archive_factory, storage, settings
 ):
@@ -395,7 +395,7 @@ def test_audit_finalize_zarr(
     assert rec.details['zarr_id'] == zarr.zarr_id
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_audit_delete_zarr_chunks(
     api_client, user, draft_version, zarr_archive_factory, storage, settings
 ):

--- a/dandiapi/api/tests/test_auth.py
+++ b/dandiapi/api/tests/test_auth.py
@@ -4,24 +4,24 @@ import pytest
 from rest_framework.authtoken.models import Token
 
 
-@pytest.fixture()
+@pytest.fixture
 def token(user) -> Token:
     return Token.objects.get(user=user)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_auth_token_retrieve(api_client, user, token):
     api_client.force_authenticate(user=user)
 
     assert api_client.get('/api/auth/token/').data == token.key
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_auth_token_retrieve_unauthorized(api_client, user, token):
     assert api_client.get('/api/auth/token/').status_code == 401
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_auth_token_refresh(api_client, user, token):
     api_client.force_authenticate(user=user)
 
@@ -32,6 +32,6 @@ def test_auth_token_refresh(api_client, user, token):
     assert new_token_key == new_token.key
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_auth_token_reset_unauthorized(api_client, user, token):
     assert api_client.post('/api/auth/token/').status_code == 401

--- a/dandiapi/api/tests/test_create_dev_dandiset.py
+++ b/dandiapi/api/tests/test_create_dev_dandiset.py
@@ -6,7 +6,7 @@ from dandiapi.api.management.commands.create_dev_dandiset import create_dev_dand
 from dandiapi.api.models import Asset, AssetBlob, Dandiset, Version
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_create_dev_dandiset(user):
     create_dev_dandiset('--name', 'My Test Dandiset', '--owner', user.email)
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -13,7 +13,7 @@ from dandiapi.api.models import Dandiset, Version
 from .fuzzy import DANDISET_ID_RE, DANDISET_SCHEMA_ID_RE, TIMESTAMP_RE, UTC_ISO_TIMESTAMP_RE
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_identifier(dandiset):
     assert int(dandiset.identifier) == dandiset.id
 
@@ -24,7 +24,7 @@ def test_dandiset_identifer_missing(dandiset_factory):
     assert dandiset.identifier == ''
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_published_count(
     dandiset_factory, draft_version_factory, published_version_factory
 ):
@@ -52,7 +52,7 @@ def test_dandiset_published_count(
         ('UNEMBARGOING', 'not-owner', False),
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_manager_visible_to(
     dandiset_factory, user_factory, embargo_status, user_status, visible
 ):
@@ -64,7 +64,7 @@ def test_dandiset_manager_visible_to(
     assert list(Dandiset.objects.visible_to(user)) == ([dandiset] if visible else [])
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_list(api_client, user, dandiset):
     # Test un-authenticated request
     assert api_client.get('/api/dandisets/', {'draft': 'true', 'empty': 'true'}).json() == {
@@ -113,7 +113,7 @@ def test_dandiset_rest_list(api_client, user, dandiset):
         'draft-false-empty-false',
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_versions(
     api_client,
     dandiset_factory,
@@ -203,7 +203,7 @@ def test_dandiset_versions(
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_list_for_user(api_client, user, dandiset_factory):
     dandiset = dandiset_factory()
     # Create an extra dandiset that should not be included in the response
@@ -228,7 +228,7 @@ def test_dandiset_rest_list_for_user(api_client, user, dandiset_factory):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_retrieve(api_client, dandiset):
     assert api_client.get(f'/api/dandisets/{dandiset.identifier}/').data == {
         'identifier': dandiset.identifier,
@@ -246,7 +246,7 @@ def test_dandiset_rest_retrieve(api_client, dandiset):
     [choice[0] for choice in Dandiset.EmbargoStatus.choices],
     ids=[choice[1] for choice in Dandiset.EmbargoStatus.choices],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_embargo_access(
     api_client, user_factory, dandiset_factory, embargo_status: str
 ):
@@ -321,7 +321,7 @@ def test_dandiset_rest_embargo_access(
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_create(api_client, user):
     user.first_name = 'John'
     user.last_name = 'Doe'
@@ -412,7 +412,7 @@ def test_dandiset_rest_create(api_client, user):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_create_with_identifier(api_client, admin_user):
     admin_user.first_name = 'John'
     admin_user.last_name = 'Doe'
@@ -505,7 +505,7 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_create_with_contributor(api_client, admin_user):
     admin_user.first_name = 'John'
     admin_user.last_name = 'Doe'
@@ -611,7 +611,7 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_create_embargoed(api_client, user):
     user.first_name = 'John'
     user.last_name = 'Doe'
@@ -702,7 +702,7 @@ def test_dandiset_rest_create_embargoed(api_client, user):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_create_with_duplicate_identifier(api_client, admin_user, dandiset):
     api_client.force_authenticate(user=admin_user)
     name = 'Test Dandiset'
@@ -718,7 +718,7 @@ def test_dandiset_rest_create_with_duplicate_identifier(api_client, admin_user, 
     assert response.data == f'Dandiset {identifier} already exists'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_create_with_invalid_identifier(api_client, admin_user):
     api_client.force_authenticate(user=admin_user)
     name = 'Test Dandiset'
@@ -734,7 +734,7 @@ def test_dandiset_rest_create_with_invalid_identifier(api_client, admin_user):
     assert response.data == f'Invalid Identifier {identifier}'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ('embargo_status', 'success'),
     [
@@ -759,7 +759,7 @@ def test_dandiset_rest_delete(api_client, draft_version_factory, user, embargo_s
         assert Dandiset.objects.count() == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_delete_with_zarrs(
     api_client,
     draft_version,
@@ -781,7 +781,7 @@ def test_dandiset_rest_delete_with_zarrs(
     assert not Dandiset.objects.all()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_delete_not_an_owner(api_client, draft_version, user):
     api_client.force_authenticate(user=user)
 
@@ -791,7 +791,7 @@ def test_dandiset_rest_delete_not_an_owner(api_client, draft_version, user):
     assert draft_version.dandiset in Dandiset.objects.all()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_delete_published(api_client, published_version, user):
     api_client.force_authenticate(user=user)
     assign_perm('owner', user, published_version.dandiset)
@@ -803,7 +803,7 @@ def test_dandiset_rest_delete_published(api_client, published_version, user):
     assert published_version.dandiset in Dandiset.objects.all()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_delete_published_admin(api_client, published_version, admin_user):
     api_client.force_authenticate(user=admin_user)
 
@@ -814,7 +814,7 @@ def test_dandiset_rest_delete_published_admin(api_client, published_version, adm
     assert published_version.dandiset in Dandiset.objects.all()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_get_owners(api_client, dandiset, social_account):
     assign_perm('owner', social_account.user, dandiset)
 
@@ -830,7 +830,7 @@ def test_dandiset_rest_get_owners(api_client, dandiset, social_account):
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_get_owners_no_social_account(api_client, dandiset, user):
     assign_perm('owner', user, dandiset)
 
@@ -850,7 +850,7 @@ def test_dandiset_rest_get_owners_no_social_account(api_client, dandiset, user):
     'embargo_status',
     [Dandiset.EmbargoStatus.OPEN, Dandiset.EmbargoStatus.EMBARGOED],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_change_owner(
     api_client,
     draft_version_factory,
@@ -890,7 +890,7 @@ def test_dandiset_rest_change_owner(
     assert mailoutbox[1].to == [user2.email]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_change_owners_unembargo_in_progress(
     api_client,
     draft_version_factory,
@@ -921,7 +921,7 @@ def test_dandiset_rest_change_owners_unembargo_in_progress(
     assert resp.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_add_owner(
     api_client,
     draft_version,
@@ -966,7 +966,7 @@ def test_dandiset_rest_add_owner(
     assert mailoutbox[0].to == [user2.email]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_remove_owner(
     api_client,
     draft_version,
@@ -1003,7 +1003,7 @@ def test_dandiset_rest_remove_owner(
     assert mailoutbox[0].to == [user2.email]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_not_an_owner(api_client, dandiset, user):
     api_client.force_authenticate(user=user)
 
@@ -1015,7 +1015,7 @@ def test_dandiset_rest_not_an_owner(api_client, dandiset, user):
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_delete_all_owners_fails(api_client, dandiset, user):
     assign_perm('owner', user, dandiset)
     api_client.force_authenticate(user=user)
@@ -1029,7 +1029,7 @@ def test_dandiset_rest_delete_all_owners_fails(api_client, dandiset, user):
     assert resp.data == ['Cannot remove all draft owners']
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_add_owner_does_not_exist(api_client, dandiset, user):
     assign_perm('owner', user, dandiset)
     api_client.force_authenticate(user=user)
@@ -1044,7 +1044,7 @@ def test_dandiset_rest_add_owner_does_not_exist(api_client, dandiset, user):
     assert resp.data == [f'User {fake_name} not found']
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_add_malformed(api_client, dandiset, user):
     assign_perm('owner', user, dandiset)
     api_client.force_authenticate(user=user)
@@ -1058,17 +1058,17 @@ def test_dandiset_rest_add_malformed(api_client, dandiset, user):
     assert resp.data == [{'username': ['This field is required.']}]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_search_no_query(api_client):
     assert api_client.get('/api/dandisets/').data['results'] == []
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_search_empty_query(api_client):
     assert api_client.get('/api/dandisets/', {'search': ''}).data['results'] == []
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_dandiset_rest_search_identifier(api_client, draft_version):
     results = api_client.get(
         '/api/dandisets/',
@@ -1083,7 +1083,7 @@ def test_dandiset_rest_search_identifier(api_client, draft_version):
     assert results[0]['draft_version']['name'] == draft_version.name
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     'contributors',
     [None, 'string', 1, [], {}],

--- a/dandiapi/api/tests/test_embargo.py
+++ b/dandiapi/api/tests/test_embargo.py
@@ -61,7 +61,7 @@ EMPTY_PAGINATION = {
         ),
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_embargo_visibility(
     api_client,
     user,
@@ -89,7 +89,7 @@ def test_embargo_visibility(
     assert response.status_code == 403
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_remove_asset_blob_embargoed_tag_fails_on_embargod(embargoed_asset_blob, asset_blob):
     with pytest.raises(AssetBlobEmbargoedError):
         remove_asset_blob_embargoed_tag(embargoed_asset_blob)

--- a/dandiapi/api/tests/test_garbage.py
+++ b/dandiapi/api/tests/test_garbage.py
@@ -9,7 +9,7 @@ from dandiapi.api.garbage import stale_assets
 from dandiapi.api.models import Asset, Version
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stale_assets(version: Version, draft_asset_factory, published_asset_factory):
     stale_date = timezone.now() - timedelta(days=8)
 

--- a/dandiapi/api/tests/test_manifests.py
+++ b/dandiapi/api/tests/test_manifests.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from django.core.files.storage import Storage
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_write_dandiset_jsonld(storage: Storage, version: Version):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls
@@ -38,7 +38,7 @@ def test_write_dandiset_jsonld(storage: Storage, version: Version):
         assert f.read() == expected
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_write_assets_jsonld(storage: Storage, version: Version, asset_factory):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls
@@ -58,7 +58,7 @@ def test_write_assets_jsonld(storage: Storage, version: Version, asset_factory):
         assert f.read() == expected
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_write_collection_jsonld(storage: Storage, version: Version, asset):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls
@@ -85,7 +85,7 @@ def test_write_collection_jsonld(storage: Storage, version: Version, asset):
         assert f.read() == expected
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_write_dandiset_yaml(storage: Storage, version: Version):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls
@@ -102,7 +102,7 @@ def test_write_dandiset_yaml(storage: Storage, version: Version):
         assert f.read() == expected
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_write_assets_yaml(storage: Storage, version: Version, asset_factory):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls
@@ -122,7 +122,7 @@ def test_write_assets_yaml(storage: Storage, version: Version, asset_factory):
         assert f.read() == expected
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_write_dandiset_yaml_already_exists(storage: Storage, version: Version):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls
@@ -142,7 +142,7 @@ def test_write_dandiset_yaml_already_exists(storage: Storage, version: Version):
         assert f.read() == expected
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_write_assets_yaml_already_exists(storage: Storage, version: Version, asset_factory):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls

--- a/dandiapi/api/tests/test_pagination.py
+++ b/dandiapi/api/tests/test_pagination.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_asset_pagination(api_client, version, asset_factory):
     endpoint = f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/assets/'
 

--- a/dandiapi/api/tests/test_permission.py
+++ b/dandiapi/api/tests/test_permission.py
@@ -67,7 +67,7 @@ from rest_framework.permissions import SAFE_METHODS
         ('post', '/api/zarr/{zarr.zarr_id}/files/', True),
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_approved_or_readonly(
     api_client,
     user,

--- a/dandiapi/api/tests/test_search.py
+++ b/dandiapi/api/tests/test_search.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from rest_framework.test import APIClient
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_search_rest(api_client: APIClient) -> None:
     resp = api_client.get('/api/dandisets/search/')
     assert resp.status_code == 200

--- a/dandiapi/api/tests/test_stats.py
+++ b/dandiapi/api/tests/test_stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stats_baseline(api_client):
     assert api_client.get('/api/stats/').data == {
         'dandiset_count': 0,
@@ -14,7 +14,7 @@ def test_stats_baseline(api_client):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stats_draft(api_client, dandiset):
     stats = api_client.get('/api/stats/').data
 
@@ -22,7 +22,7 @@ def test_stats_draft(api_client, dandiset):
     assert stats['published_dandiset_count'] == 0
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stats_published(api_client, published_version_factory):
     published_version_factory()
     stats = api_client.get('/api/stats/').data
@@ -31,7 +31,7 @@ def test_stats_published(api_client, published_version_factory):
     assert stats['published_dandiset_count'] == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stats_user(api_client, user):
     stats = api_client.get('/api/stats/').data
 
@@ -39,7 +39,7 @@ def test_stats_user(api_client, user):
     assert stats['user_count'] == 2
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stats_asset(api_client, version, asset):
     version.assets.add(asset)
     stats = api_client.get('/api/stats/').data
@@ -47,7 +47,7 @@ def test_stats_asset(api_client, version, asset):
     assert stats['size'] == asset.size
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stats_embargoed_asset(api_client, version, asset_factory, embargoed_asset_blob_factory):
     embargoed_asset = asset_factory()
     embargoed_asset.blob = embargoed_asset_blob_factory()
@@ -57,7 +57,7 @@ def test_stats_embargoed_asset(api_client, version, asset_factory, embargoed_ass
     assert stats['size'] == embargoed_asset.size
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_stats_embargoed_and_regular_blobs(
     api_client, version, asset_factory, asset_blob_factory, embargoed_asset_blob_factory
 ):

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from rest_framework.test import APIClient
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_calculate_checksum_task(storage: Storage, asset_blob_factory):
     # Pretend like AssetBlob was defined with the given storage
     AssetBlob.blob.field.storage = storage
@@ -40,7 +40,7 @@ def test_calculate_checksum_task(storage: Storage, asset_blob_factory):
     assert asset_blob.sha256 == sha256
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_calculate_checksum_task_embargo(
     storage: Storage, embargoed_asset_blob_factory, monkeypatch
 ):
@@ -60,7 +60,7 @@ def test_calculate_checksum_task_embargo(
     assert asset_blob.sha256 == sha256
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_write_manifest_files(storage: Storage, version: Version, asset_factory):
     # Pretend like AssetBlob was defined with the given storage
     # The task piggybacks off of the AssetBlob storage to write the yamls
@@ -100,7 +100,7 @@ def test_write_manifest_files(storage: Storage, version: Version, asset_factory)
     assert storage.exists(collection_jsonld_path)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_asset_metadata(draft_asset: Asset):
     tasks.validate_asset_metadata_task(draft_asset.id)
 
@@ -110,7 +110,7 @@ def test_validate_asset_metadata(draft_asset: Asset):
     assert draft_asset.validation_errors == []
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_asset_metadata_malformed_schema_version(draft_asset: Asset):
     draft_asset.metadata['schemaVersion'] = 'xxx'
     draft_asset.save()
@@ -127,7 +127,7 @@ def test_validate_asset_metadata_malformed_schema_version(draft_asset: Asset):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_asset_metadata_no_encoding_format(draft_asset: Asset):
     del draft_asset.metadata['encodingFormat']
     draft_asset.save()
@@ -142,7 +142,7 @@ def test_validate_asset_metadata_no_encoding_format(draft_asset: Asset):
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_asset_metadata_no_digest(draft_asset: Asset):
     draft_asset.blob.sha256 = None
     draft_asset.blob.save()
@@ -160,7 +160,7 @@ def test_validate_asset_metadata_no_digest(draft_asset: Asset):
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_asset_metadata_malformed_keywords(draft_asset: Asset):
     draft_asset.metadata['keywords'] = 'foo'
     draft_asset.save()
@@ -175,7 +175,7 @@ def test_validate_asset_metadata_malformed_keywords(draft_asset: Asset):
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_asset_metadata_saves_version(draft_asset: Asset, draft_version: Version):
     draft_version.assets.add(draft_asset)
 
@@ -191,7 +191,7 @@ def test_validate_asset_metadata_saves_version(draft_asset: Asset, draft_version
     assert draft_version.modified != old_datetime
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_version_metadata(draft_version: Version, asset: Asset):
     draft_version.assets.add(asset)
 
@@ -210,7 +210,7 @@ def test_validate_version_metadata(draft_version: Version, asset: Asset):
     assert draft_version.modified > old_modified
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_version_metadata_non_pending_version(draft_version: Version, asset: Asset):
     # Bypass .save to manually set an older timestamp, set status to INVALID
     old_modified = timezone.now() - datetime.timedelta(minutes=10)
@@ -230,7 +230,7 @@ def test_validate_version_metadata_non_pending_version(draft_version: Version, a
     assert draft_version.modified == old_modified
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_version_metadata_no_side_effects(draft_version: Version, asset: Asset):
     draft_version.assets.add(asset)
 
@@ -252,7 +252,7 @@ def test_validate_version_metadata_no_side_effects(draft_version: Version, asset
     assert old_data == new_data
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_version_metadata_malformed_schema_version(draft_version: Version, asset: Asset):
     draft_version.assets.add(asset)
 
@@ -270,7 +270,7 @@ def test_validate_version_metadata_malformed_schema_version(draft_version: Versi
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_version_metadata_no_description(draft_version: Version, asset: Asset):
     draft_version.assets.add(asset)
 
@@ -287,7 +287,7 @@ def test_validate_version_metadata_no_description(draft_version: Version, asset:
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_version_metadata_malformed_license(draft_version: Version, asset: Asset):
     draft_version.assets.add(asset)
 
@@ -304,7 +304,7 @@ def test_validate_version_metadata_malformed_license(draft_version: Version, ass
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_validate_version_metadata_no_assets(
     draft_version: Version,
 ):
@@ -321,7 +321,7 @@ def test_validate_version_metadata_no_assets(
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_publish_task(
     api_client: APIClient,
     user: User,

--- a/dandiapi/api/tests/test_unembargo.py
+++ b/dandiapi/api/tests/test_unembargo.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from dandiapi.api.models.asset import AssetBlob
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_remove_asset_blob_embargoed_tag_fails_on_embargod(embargoed_asset_blob, asset_blob):
     with pytest.raises(AssetBlobEmbargoedError):
         remove_asset_blob_embargoed_tag(embargoed_asset_blob)
@@ -34,7 +34,7 @@ def test_remove_asset_blob_embargoed_tag_fails_on_embargod(embargoed_asset_blob,
     remove_asset_blob_embargoed_tag(asset_blob)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_kickoff_dandiset_unembargo_dandiset_not_embargoed(
     api_client, user, dandiset_factory, draft_version_factory
 ):
@@ -47,7 +47,7 @@ def test_kickoff_dandiset_unembargo_dandiset_not_embargoed(
     assert resp.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_kickoff_dandiset_unembargo_not_owner(
     api_client, user, dandiset_factory, draft_version_factory
 ):
@@ -59,7 +59,7 @@ def test_kickoff_dandiset_unembargo_not_owner(
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_kickoff_dandiset_unembargo_active_uploads(
     api_client, user, dandiset_factory, draft_version_factory, upload_factory
 ):
@@ -97,7 +97,7 @@ def test_kickoff_dandiset_unembargo(api_client, user, draft_version_factory, mai
     assert str(patched_task.mock_calls[0]) == f'call.delay({ds.pk}, {user.id})'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_unembargo_dandiset_not_unembargoing(draft_version_factory, user, api_client):
     draft_version = draft_version_factory(dandiset__embargo_status=Dandiset.EmbargoStatus.EMBARGOED)
     ds: Dandiset = draft_version.dandiset
@@ -109,7 +109,7 @@ def test_unembargo_dandiset_not_unembargoing(draft_version_factory, user, api_cl
         unembargo_dandiset(ds, user)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_unembargo_dandiset_uploads_exist(draft_version_factory, upload_factory, user, api_client):
     draft_version = draft_version_factory(
         dandiset__embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING
@@ -124,7 +124,7 @@ def test_unembargo_dandiset_uploads_exist(draft_version_factory, upload_factory,
         unembargo_dandiset(ds, user)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_remove_dandiset_asset_blob_embargo_tags_chunks(
     draft_version_factory,
     asset_factory,
@@ -151,7 +151,7 @@ def test_remove_dandiset_asset_blob_embargo_tags_chunks(
     assert len(delete_asset_blob_tags_mock.mock_calls) == chunk_size + 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_delete_asset_blob_tags_fails(
     draft_version_factory,
     asset_factory,
@@ -172,7 +172,7 @@ def test_delete_asset_blob_tags_fails(
         _remove_dandiset_asset_blob_embargo_tags(dandiset=ds)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_unembargo_dandiset(
     draft_version_factory,
     asset_factory,
@@ -223,7 +223,7 @@ def test_unembargo_dandiset(
     assert owner_email_set == mailoutbox_to_email_set
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_unembargo_dandiset_validate_version_metadata(
     draft_version_factory, asset_factory, user, mocker
 ):
@@ -250,7 +250,7 @@ def test_unembargo_dandiset_validate_version_metadata(
     assert not draft_version.validation_errors
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_unembargo_dandiset_task_failure(draft_version_factory, mailoutbox, user, api_client):
     # Intentionally set the status to embargoed so the task will fail
     draft_version = draft_version_factory(dandiset__embargo_status=Dandiset.EmbargoStatus.EMBARGOED)

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -16,7 +16,7 @@ def mb(bytes_size: int) -> int:
     return bytes_size * 2**20
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_blob_read(api_client, asset_blob):
     assert api_client.post(
         '/api/blobs/digest/',
@@ -30,7 +30,7 @@ def test_blob_read(api_client, asset_blob):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_blob_read_sha256(api_client, asset_blob):
     assert api_client.post(
         '/api/blobs/digest/',
@@ -44,7 +44,7 @@ def test_blob_read_sha256(api_client, asset_blob):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_blob_read_bad_algorithm(api_client, asset_blob):
     resp = api_client.post(
         '/api/blobs/digest/',
@@ -55,7 +55,7 @@ def test_blob_read_bad_algorithm(api_client, asset_blob):
     assert resp.data == 'Unsupported Digest Algorithm. Supported: dandi:dandi-etag, dandi:sha2-256'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_blob_read_does_not_exist(api_client):
     resp = api_client.post(
         '/api/blobs/digest/',
@@ -65,7 +65,7 @@ def test_blob_read_does_not_exist(api_client):
     assert resp.status_code == 404
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize('embargoed', [True, False])
 def test_upload_initialize(api_client, user, dandiset_factory, embargoed):
     dandiset = dandiset_factory(
@@ -109,7 +109,7 @@ def test_upload_initialize(api_client, user, dandiset_factory, embargoed):
     assert upload.blob.name == f'test-prefix/blobs/{upload_id[:3]}/{upload_id[3:6]}/{upload_id}'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_upload_initialize_unembargo_in_progress(api_client, user, dandiset_factory):
     dandiset = dandiset_factory(embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING)
     api_client.force_authenticate(user=user)
@@ -128,7 +128,7 @@ def test_upload_initialize_unembargo_in_progress(api_client, user, dandiset_fact
     assert resp.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_upload_initialize_existing_asset_blob(api_client, user, dandiset, asset_blob):
     api_client.force_authenticate(user=user)
     assign_perm('owner', user, dandiset)
@@ -148,7 +148,7 @@ def test_upload_initialize_existing_asset_blob(api_client, user, dandiset, asset
     assert not Upload.objects.all().exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_upload_initialize_not_an_owner(api_client, user, dandiset):
     api_client.force_authenticate(user=user)
 
@@ -167,7 +167,7 @@ def test_upload_initialize_not_an_owner(api_client, user, dandiset):
     assert not Upload.objects.all().exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_upload_initialize_embargo_not_an_owner(api_client, user, dandiset_factory):
     api_client.force_authenticate(user=user)
     dandiset = dandiset_factory(embargo_status=Dandiset.EmbargoStatus.EMBARGOED)
@@ -189,7 +189,7 @@ def test_upload_initialize_embargo_not_an_owner(api_client, user, dandiset_facto
     assert not Upload.objects.all().exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_upload_initialize_embargo_existing_asset_blob(
     api_client, user, dandiset_factory, asset_blob
 ):
@@ -213,7 +213,7 @@ def test_upload_initialize_embargo_existing_asset_blob(
     assert not Upload.objects.all().exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_upload_initialize_embargo_existing_embargoed_asset_blob(
     api_client, user, dandiset_factory, embargoed_asset_blob_factory
 ):
@@ -238,7 +238,7 @@ def test_upload_initialize_embargo_existing_embargoed_asset_blob(
     assert not Upload.objects.all().exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_upload_initialize_unauthorized(api_client):
     assert (
         api_client.post(

--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -31,7 +31,7 @@ def serialize_social_account(social_account):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_registration_email_content(
     social_account: SocialAccount, mailoutbox: list[EmailMessage], api_client: APIClient
 ):
@@ -71,7 +71,7 @@ def test_user_registration_email_content(
         (UserMetadata.Status.APPROVED, 0),
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_registration_email_count(
     social_account: SocialAccount,
     mailoutbox: list[EmailMessage],
@@ -90,7 +90,7 @@ def test_user_registration_email_count(
     assert len(mailoutbox) == email_count
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_me(api_client, social_account):
     api_client.force_authenticate(user=social_account.user)
 
@@ -100,7 +100,7 @@ def test_user_me(api_client, social_account):
     ).data == serialize_social_account(social_account)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_me_admin(api_client, admin_user, social_account_factory):
     api_client.force_authenticate(user=admin_user)
     social_account = social_account_factory(user=admin_user)
@@ -112,7 +112,7 @@ def test_user_me_admin(api_client, admin_user, social_account_factory):
     ).data == serialize_social_account(social_account)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_search(api_client, social_account, social_account_factory):
     api_client.force_authenticate(user=social_account.user)
 
@@ -128,7 +128,7 @@ def test_user_search(api_client, social_account, social_account_factory):
     ).data == [serialize_social_account(social_account)]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_search_prefer_social(api_client, user_factory, social_account):
     api_client.force_authenticate(user=social_account.user)
 
@@ -149,7 +149,7 @@ def test_user_search_prefer_social(api_client, user_factory, social_account):
     ).data == [user_to_dict(user)]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_search_blank_username(api_client, user):
     api_client.force_authenticate(user=user)
 
@@ -163,7 +163,7 @@ def test_user_search_blank_username(api_client, user):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_search_no_matches(api_client, user):
     api_client.force_authenticate(user=user)
 
@@ -177,7 +177,7 @@ def test_user_search_no_matches(api_client, user):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_search_multiple_matches(api_client, user, user_factory, social_account_factory):
     api_client.force_authenticate(user=user)
 
@@ -200,7 +200,7 @@ def test_user_search_multiple_matches(api_client, user, user_factory, social_acc
     ).data == [serialize_social_account(social_account) for social_account in social_accounts[:3]]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_search_limit_enforced(api_client, user, user_factory, social_account_factory):
     api_client.force_authenticate(user=user)
 
@@ -217,7 +217,7 @@ def test_user_search_limit_enforced(api_client, user, user_factory, social_accou
     ]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_search_extra_data(api_client, user, social_account, social_account_factory):
     """Test that searched keyword isn't caught by a different field in `extra_data`."""
     api_client.force_authenticate(user=user)
@@ -279,7 +279,7 @@ def test_user_search_extra_data(api_client, user, social_account, social_account
         ),
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_user_status(
     api_client: APIClient,
     user: User,
@@ -312,7 +312,7 @@ def test_user_status(
     assert response.data == expected_search_results_value
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ('questions', 'querystring', 'expected_status_code'),
     [
@@ -334,7 +334,7 @@ def test_user_questionnaire_view(
         assertContains(resp, question['question'])
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ('email', 'expected_status'),
     [

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -27,7 +27,7 @@ from dandiapi.zarr.tasks import ingest_zarr_archive
 from .fuzzy import TIMESTAMP_RE, URN_RE, UTC_ISO_TIMESTAMP_RE, VERSION_ID_RE
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_next_published_version_nosave(dandiset):
     # Without saving, the output should be reproducible
     version_str_1 = Version.next_published_version(dandiset)
@@ -36,7 +36,7 @@ def test_version_next_published_version_nosave(dandiset):
     assert version_str_1 == VERSION_ID_RE
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_next_published_version_save(mocker, dandiset, published_version_factory):
     # Given an existing version at the current time, a different one should be allocated
     next_published_version_spy = mocker.spy(Version, 'next_published_version')
@@ -47,7 +47,7 @@ def test_version_next_published_version_save(mocker, dandiset, published_version
     assert version_1.version != version_str_2
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_next_published_version_simultaneous_save(
     dandiset_factory,
     published_version_factory,
@@ -63,7 +63,7 @@ def test_version_next_published_version_simultaneous_save(
     assert version_1.version == version_2.version
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_draft_version_metadata_computed(draft_version: Version):
     original_metadata = {'schemaVersion': settings.DANDI_SCHEMA_VERSION}
     draft_version.metadata = original_metadata
@@ -99,7 +99,7 @@ def test_draft_version_metadata_computed(draft_version: Version):
     assert draft_version.metadata == expected_metadata
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_published_version_metadata_computed(published_version: Version):
     original_metadata = {'schemaVersion': settings.DANDI_SCHEMA_VERSION}
     published_version.metadata = original_metadata
@@ -143,7 +143,7 @@ def test_published_version_metadata_computed(published_version: Version):
     assert published_version.metadata == expected_metadata
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_metadata_citation_draft(draft_version):
     name = draft_version.metadata['name'].rstrip('.')
     year = datetime.datetime.now(datetime.UTC).year
@@ -157,7 +157,7 @@ def test_version_metadata_citation_draft(draft_version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_metadata_citation_published(published_version):
     name = published_version.metadata['name'].rstrip('.')
     year = datetime.datetime.now(datetime.UTC).year
@@ -168,7 +168,7 @@ def test_version_metadata_citation_published(published_version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_metadata_citation_no_contributors(version):
     version.metadata['contributor'] = []
     version.save()
@@ -180,7 +180,7 @@ def test_version_metadata_citation_no_contributors(version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_metadata_citation_contributor_not_in_citation(version):
     version.metadata['contributor'] = [
         {'name': 'Jane Doe'},
@@ -195,7 +195,7 @@ def test_version_metadata_citation_contributor_not_in_citation(version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_metadata_citation_contributor(version):
     version.metadata['contributor'] = [{'name': 'Doe, Jane', 'includeInCitation': True}]
     version.save()
@@ -207,7 +207,7 @@ def test_version_metadata_citation_contributor(version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_metadata_citation_multiple_contributors(version):
     version.metadata['contributor'] = [
         {'name': 'John Doe', 'includeInCitation': True},
@@ -223,7 +223,7 @@ def test_version_metadata_citation_multiple_contributors(version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_metadata_context(version):
     version.metadata['schemaVersion'] = '6.6.6'
     version.save()
@@ -233,7 +233,7 @@ def test_version_metadata_context(version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_metadata_assets_summary_missing(version, asset):
     version.assets.add(asset)
 
@@ -241,7 +241,7 @@ def test_version_metadata_assets_summary_missing(version, asset):
     version.save()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_aggregate_assets_summary_valid_assets(draft_version, draft_asset_factory):
     valid_asset = draft_asset_factory(status=Asset.Status.VALID)
     invalid_asset = draft_asset_factory(status=Asset.Status.INVALID)
@@ -251,7 +251,7 @@ def test_version_aggregate_assets_summary_valid_assets(draft_version, draft_asse
     assert draft_version.metadata['assetsSummary']['numberOfFiles'] == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_valid_with_valid_asset(version, asset):
     version.assets.add(asset)
 
@@ -263,7 +263,7 @@ def test_version_valid_with_valid_asset(version, asset):
     assert version.publishable
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     'status',
     [
@@ -279,7 +279,7 @@ def test_version_invalid(version, status):
     assert not version.publishable
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     'status',
     [
@@ -300,7 +300,7 @@ def test_version_valid_with_invalid_asset(version, asset, status):
     assert not version.publishable
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_publish_version(draft_version, asset):
     # Normally the publish endpoint would inject a doi, so we must do it manually
     fake_doi = 'doi'
@@ -356,7 +356,7 @@ def test_version_publish_version(draft_version, asset):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_aggregate_assets_summary(draft_version_factory, draft_asset_factory):
     version = draft_version_factory(status=Version.Status.VALID)
     asset = draft_asset_factory(status=Asset.Status.VALID)
@@ -370,7 +370,7 @@ def test_version_aggregate_assets_summary(draft_version_factory, draft_asset_fac
     assert version.metadata['assetsSummary']['schemaKey'] == 'AssetsSummary'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_aggregate_assets_summary_metadata_modified(
     draft_version_factory, draft_asset_factory
 ):
@@ -384,7 +384,7 @@ def test_version_aggregate_assets_summary_metadata_modified(
         version_aggregate_assets_summary(version)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_size(
     version,
     asset_factory,
@@ -400,7 +400,7 @@ def test_version_size(
     assert version.size == 700
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_list(api_client, version, draft_version_factory):
     # Create an extra version so that there are multiple versions to filter down
     draft_version_factory()
@@ -430,7 +430,7 @@ def test_version_rest_list(api_client, version, draft_version_factory):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_retrieve(api_client, version, draft_version_factory):
     # Create an extra version so that there are multiple versions to filter down
     draft_version_factory()
@@ -443,7 +443,7 @@ def test_version_rest_retrieve(api_client, version, draft_version_factory):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_info(api_client, version):
     assert api_client.get(
         f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/info/'
@@ -469,7 +469,7 @@ def test_version_rest_info(api_client, version):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     'asset_status',
     [Asset.Status.PENDING, Asset.Status.VALIDATING, Asset.Status.VALID, Asset.Status.INVALID],
@@ -519,7 +519,7 @@ def test_version_rest_info_with_asset(
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_update(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -605,7 +605,7 @@ def test_version_rest_update(api_client, user, draft_version):
     assert draft_version.status == Version.Status.PENDING
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_update_unembargo_in_progress(api_client, user, draft_version_factory):
     draft_version = draft_version_factory(
         dandiset__embargo_status=Dandiset.EmbargoStatus.UNEMBARGOING
@@ -631,7 +631,7 @@ def test_version_rest_update_unembargo_in_progress(api_client, user, draft_versi
     assert resp.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_update_published_version(api_client, user, published_version):
     assign_perm('owner', user, published_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -649,7 +649,7 @@ def test_version_rest_update_published_version(api_client, user, published_versi
     assert resp.data == 'Only draft versions can be modified.'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_update_not_an_owner(api_client, user, version):
     api_client.force_authenticate(user=user)
 
@@ -678,7 +678,7 @@ def test_version_rest_update_not_an_owner(api_client, user, version):
         [{'schemaKey': 'AccessRequirements', 'status': 'foobar'}],
     ],
 )
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_update_access_values(api_client, user, draft_version, access):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -702,7 +702,7 @@ def test_version_rest_update_access_values(api_client, user, draft_version, acce
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_update_access_missing(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -728,7 +728,7 @@ def test_version_rest_update_access_missing(api_client, user, draft_version):
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_update_access_valid(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -754,7 +754,7 @@ def test_version_rest_update_access_valid(api_client, user, draft_version):
     assert access[0]['extra'] == 'field'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_publish(
     api_client: APIClient,
     user: User,
@@ -788,7 +788,7 @@ def test_version_rest_publish(
     assert draft_version.status == Version.Status.PUBLISHING
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_publish_embargo(api_client: APIClient, user: User, draft_version_factory):
     draft_version = draft_version_factory(dandiset__embargo_status=Dandiset.EmbargoStatus.EMBARGOED)
     assign_perm('owner', user, draft_version.dandiset)
@@ -801,7 +801,7 @@ def test_version_rest_publish_embargo(api_client: APIClient, user: User, draft_v
     assert resp.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_publish_unembargo_in_progress(
     api_client: APIClient, user: User, draft_version_factory
 ):
@@ -818,7 +818,7 @@ def test_version_rest_publish_unembargo_in_progress(
     assert resp.status_code == 400
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_publish_zarr(
     api_client,
     user: User,
@@ -856,7 +856,7 @@ def test_version_rest_publish_zarr(
     assert resp.json() == 'Cannot publish dandisets which contain zarrs'
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_publish_not_an_owner(api_client, user, version, asset):
     api_client.force_authenticate(user=user)
     version.assets.add(asset)
@@ -867,7 +867,7 @@ def test_version_rest_publish_not_an_owner(api_client, user, version, asset):
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_publish_not_a_draft(api_client, user, published_version, asset):
     assign_perm('owner', user, published_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -880,7 +880,7 @@ def test_version_rest_publish_not_a_draft(api_client, user, published_version, a
     assert resp.status_code == 405
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     ('status', 'expected_data', 'expected_status_code'),
     [
@@ -923,7 +923,7 @@ def test_version_rest_publish_invalid(
     assert resp.data == expected_data
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_update_no_changed_metadata(
     api_client: APIClient, admin_user, draft_version: Version
 ):
@@ -945,7 +945,7 @@ def test_version_rest_update_no_changed_metadata(
     assert draft_version.modified == old_modified_time
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_delete_published_not_admin(api_client, user, published_version):
     assign_perm('owner', user, published_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -958,7 +958,7 @@ def test_version_rest_delete_published_not_admin(api_client, user, published_ver
     assert published_version in Version.objects.all()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_delete_published_admin(api_client, admin_user, published_version):
     api_client.force_authenticate(user=admin_user)
     response = api_client.delete(
@@ -969,7 +969,7 @@ def test_version_rest_delete_published_admin(api_client, admin_user, published_v
     assert not Version.objects.all()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_delete_draft_not_admin(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
@@ -981,7 +981,7 @@ def test_version_rest_delete_draft_not_admin(api_client, user, draft_version):
     assert draft_version in Version.objects.all()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_version_rest_delete_draft_admin(api_client, admin_user, draft_version):
     api_client.force_authenticate(user=admin_user)
     response = api_client.delete(

--- a/dandiapi/conftest.py
+++ b/dandiapi/conftest.py
@@ -50,12 +50,12 @@ register(ZarrArchiveFactory)
 
 
 # Register zarr file/directory factories
-@pytest.fixture()
+@pytest.fixture
 def zarr_file_factory():
     return upload_zarr_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def user(user_factory):
     """Override the default `user` fixture to use our `UserFactory` so `UserMetadata` works."""
     return user_factory()
@@ -66,7 +66,7 @@ def asset_factory(request):
     return request.param
 
 
-@pytest.fixture()
+@pytest.fixture
 def asset(asset_factory):
     return asset_factory()
 
@@ -76,12 +76,12 @@ def version(request):
     return request.param()
 
 
-@pytest.fixture()
+@pytest.fixture
 def api_client() -> APIClient:
     return APIClient()
 
 
-@pytest.fixture()
+@pytest.fixture
 def authenticated_api_client(user) -> APIClient:
     client = APIClient()
     client.force_authenticate(user=user)
@@ -107,12 +107,12 @@ def minio_storage_factory() -> MinioStorage:
     return base_minio_storage_factory(settings.DANDI_DANDISETS_BUCKET_NAME)
 
 
-@pytest.fixture()
+@pytest.fixture
 def s3_storage() -> S3Storage:
     return s3_storage_factory()
 
 
-@pytest.fixture()
+@pytest.fixture
 def minio_storage() -> MinioStorage:
     return minio_storage_factory()
 

--- a/dandiapi/search/tests/test_permissions.py
+++ b/dandiapi/search/tests/test_permissions.py
@@ -7,7 +7,7 @@ from dandiapi.api.models.dandiset import Dandiset
 from dandiapi.search.models import AssetSearch
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_assetsearch_visible_to_permissions(draft_asset_factory, draft_version, user_factory):
     asset = draft_asset_factory()
     draft_version.dandiset.embargo_status = Dandiset.EmbargoStatus.EMBARGOED

--- a/dandiapi/search/tests/test_views.py
+++ b/dandiapi/search/tests/test_views.py
@@ -8,13 +8,13 @@ if TYPE_CHECKING:
     from rest_framework.test import APIClient
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_genotype_autocomplete_rest(api_client: APIClient) -> None:
     resp = api_client.get('/api/search/genotypes/')
     assert resp.status_code == 200
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_species_autocomplete_rest(api_client: APIClient) -> None:
     resp = api_client.get('/api/search/species/')
     assert resp.status_code == 200

--- a/dandiapi/zarr/tests/test_zarr.py
+++ b/dandiapi/zarr/tests/test_zarr.py
@@ -11,7 +11,7 @@ from dandiapi.zarr.models import ZarrArchive, ZarrArchiveStatus
 from dandiapi.zarr.tasks import ingest_zarr_archive
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_create(authenticated_api_client, user, dandiset):
     assign_perm('owner', user, dandiset)
     name = 'My Zarr File!'
@@ -39,7 +39,7 @@ def test_zarr_rest_create(authenticated_api_client, user, dandiset):
     assert zarr_archive.name == name
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_dandiset_malformed(authenticated_api_client, user, dandiset):
     assign_perm('owner', user, dandiset)
     resp = authenticated_api_client.post(
@@ -54,7 +54,7 @@ def test_zarr_rest_dandiset_malformed(authenticated_api_client, user, dandiset):
     assert resp.json() == {'dandiset': ['This value does not match the required pattern.']}
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_create_not_an_owner(authenticated_api_client, zarr_archive):
     resp = authenticated_api_client.post(
         '/api/zarr/',
@@ -67,7 +67,7 @@ def test_zarr_rest_create_not_an_owner(authenticated_api_client, zarr_archive):
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_create_duplicate(authenticated_api_client, user, zarr_archive):
     assign_perm('owner', user, zarr_archive.dandiset)
     resp = authenticated_api_client.post(
@@ -82,7 +82,7 @@ def test_zarr_rest_create_duplicate(authenticated_api_client, user, zarr_archive
     assert resp.json() == ['Zarr already exists']
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_create_embargoed_dandiset(
     authenticated_api_client,
     user,
@@ -103,7 +103,7 @@ def test_zarr_rest_create_embargoed_dandiset(
     assert resp.json() == ['Cannot add zarr to embargoed dandiset']
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_get(authenticated_api_client, storage, zarr_archive_factory, zarr_file_factory):
     # Pretend like ZarrArchive was defined with the given storage
     ZarrArchive.storage = storage
@@ -128,7 +128,7 @@ def test_zarr_rest_get(authenticated_api_client, storage, zarr_archive_factory, 
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_list_filter(authenticated_api_client, dandiset_factory, zarr_archive_factory):
     # Create dandisets and zarrs
     dandiset_a: Dandiset = dandiset_factory()
@@ -171,7 +171,7 @@ def test_zarr_rest_list_filter(authenticated_api_client, dandiset_factory, zarr_
     assert results[0]['zarr_id'] == zarr_archive_b_a.zarr_id
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_get_very_big(authenticated_api_client, zarr_archive_factory):
     ten_quadrillion = 10**16
     ten_petabytes = 10**16
@@ -193,7 +193,7 @@ def test_zarr_rest_get_very_big(authenticated_api_client, zarr_archive_factory):
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_get_empty(authenticated_api_client, zarr_archive: ZarrArchive):
     resp = authenticated_api_client.get(f'/api/zarr/{zarr_archive.zarr_id}/')
     assert resp.status_code == 200
@@ -208,7 +208,7 @@ def test_zarr_rest_get_empty(authenticated_api_client, zarr_archive: ZarrArchive
     }
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_delete_file(
     authenticated_api_client,
     user,
@@ -257,7 +257,7 @@ def test_zarr_rest_delete_file(
     assert zarr_archive.size == 0
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_delete_file_asset_metadata(
     authenticated_api_client,
     user,
@@ -299,7 +299,7 @@ def test_zarr_rest_delete_file_asset_metadata(
     assert asset.full_metadata['contentSize'] == 0
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_delete_file_not_an_owner(
     authenticated_api_client, storage, zarr_archive: ZarrArchive, zarr_file_factory
 ):
@@ -313,7 +313,7 @@ def test_zarr_rest_delete_file_not_an_owner(
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_delete_multiple_files(
     authenticated_api_client,
     user,
@@ -344,7 +344,7 @@ def test_zarr_rest_delete_multiple_files(
     assert zarr_archive.size == 0
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_delete_missing_file(
     authenticated_api_client,
     user,
@@ -382,7 +382,7 @@ def test_zarr_rest_delete_missing_file(
     assert zarr_archive.size == zarr_file.size
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_file_list(api_client, storage, zarr_archive: ZarrArchive, zarr_file_factory):
     # Pretend like ZarrArchive was defined with the given storage
     ZarrArchive.storage = storage
@@ -438,7 +438,7 @@ def test_zarr_file_list(api_client, storage, zarr_archive: ZarrArchive, zarr_fil
     )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_explore_head(api_client, storage, zarr_archive: ZarrArchive):
     # Pretend like ZarrArchive was defined with the given storage
     ZarrArchive.storage = storage

--- a/dandiapi/zarr/tests/test_zarr_upload.py
+++ b/dandiapi/zarr/tests/test_zarr_upload.py
@@ -8,7 +8,7 @@ from dandiapi.api.tests.fuzzy import HTTP_URL_RE
 from dandiapi.zarr.models import ZarrArchive, ZarrArchiveStatus
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_upload_start(
     authenticated_api_client, user, zarr_archive: ZarrArchive, storage, monkeypatch
 ):
@@ -50,7 +50,7 @@ def test_zarr_rest_upload_start(
     assert resp.json() == [HTTP_URL_RE]
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_upload_start_not_an_owner(authenticated_api_client, zarr_archive: ZarrArchive):
     resp = authenticated_api_client.post(
         f'/api/zarr/{zarr_archive.zarr_id}/files/',
@@ -60,7 +60,7 @@ def test_zarr_rest_upload_start_not_an_owner(authenticated_api_client, zarr_arch
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_finalize(
     authenticated_api_client,
     user,
@@ -87,13 +87,13 @@ def test_zarr_rest_finalize(
     assert zarr_archive.status == ZarrArchiveStatus.COMPLETE
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_finalize_not_an_owner(authenticated_api_client, zarr_archive: ZarrArchive):
     resp = authenticated_api_client.post(f'/api/zarr/{zarr_archive.zarr_id}/finalize/')
     assert resp.status_code == 403
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_zarr_rest_finalize_already_ingested(
     authenticated_api_client, user, zarr_archive: ZarrArchive
 ):


### PR DESCRIPTION
Applies new `ruff` rules to the codebase. See https://astral.sh/blog/ruff-v0.6.0 for info on all changes. It seems the only change applicable to us is the changes to `PT001` and `PT023`.

This will fix the failing CI on `master` and PRs like #2008.