### PR TITLE
admin view: Also show (list) zarr for Assets view

### DIFF
--- a/dandiapi/api/admin.py
+++ b/dandiapi/api/admin.py
@@ -216,6 +216,7 @@ class AssetAdmin(admin.ModelAdmin):
         'asset_id',
         'path',
         'blob',
+        'zarr',
         'status',
         'size',
         'modified',


### PR DESCRIPTION
ATM shows only blobs, so to get to zarr requires 2 clicks. As long as we have zarr as valuable as blob, we better list both.

Having said that, I do not feel strongly about it yet, so feel free to quickly close if you feel we better keep it just to blobs for now.