### PR TITLE
../assets/{asset_id}/ PUT: clarify that new asset is created

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -354,15 +354,16 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         request_body=AssetRequestSerializer,
         responses={200: AssetDetailSerializer},
         manual_parameters=[VERSIONS_DANDISET_PK_PARAM, VERSIONS_VERSION_PARAM],
-        operation_summary='Update the metadata of an asset.',
+        operation_summary='Create an asset with updated metadata.',
         operation_description='User must be an owner of the associated dandiset.\
-                               Only draft versions can be modified.',
+                               Only draft versions can be modified.\
+                               Old asset is returned if no updates to metadata are made.',
     )
     @method_decorator(
         permission_required_or_403('owner', (Dandiset, 'pk', 'versions__dandiset__pk'))
     )
     def update(self, request, versions__dandiset__pk, versions__version, **kwargs):
-        """Update the metadata of an asset."""
+        """Create an asset with updated metadata."""
         version: Version = get_object_or_404(
             Version.objects.select_related('dandiset'),
             dandiset__pk=versions__dandiset__pk,


### PR DESCRIPTION
"Update" (or "change", both words are used, see blow) IMHO implies in-place operations which is not the case here: if metadata is different, we get a new asset returned, hence there is really no "update" to an existing asset, but rather CoW style of operation on an asset upon change. 

To be frank: there is a notion of "update" as the new created asset is assigned to the same dandiset, hence it is replacing previous asset present in the dandiset. But as we are talking about a new asset object with new asset id, I think it is important to get the only visible API documentation "straight".

- [ ] Decide on either RF `(update|change)_asset` into e.g. `create_updated_asset` (since not always creates one). ATM we have 

```shell
❯ git grep '\(change\|update\)_asset\>' -- dandiapi | grep -v test_
dandiapi/api/migrations/0010_auditrecord.py:                            ('update_asset', 'update_asset'),
dandiapi/api/models/audit.py:    'update_asset',
dandiapi/api/services/asset/__init__.py:def change_asset(  # noqa: PLR0913
dandiapi/api/services/asset/__init__.py:        audit.update_asset(dandiset=version.dandiset, user=user, asset=new_asset)
dandiapi/api/services/audit/__init__.py:def update_asset(*, dandiset: Dandiset, user: User, asset: Asset) -> AuditRecord:
dandiapi/api/services/audit/__init__.py:        dandiset=dandiset, user=user, record_type='update_asset', details=details
dandiapi/api/views/asset.py:    change_asset,
dandiapi/api/views/asset.py:            asset, _ = change_asset(
```

WDYT @waxlamp @jjnesbitt ?