### PR TITLE
add external neurosift service for .nwb.lindi.tar

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -361,6 +361,13 @@ const EXTERNAL_SERVICES = [
 
   {
     name: 'Neurosift',
+    regex: /\.nwb.lindi.tar$/,
+    maxsize: Infinity,
+    endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&st=lindi&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
+  },
+
+  {
+    name: 'Neurosift',
     regex: /\.avi$/,
     maxsize: Infinity,
     endpoint: 'https://neurosift.app?p=/avi&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -354,14 +354,7 @@ const EXTERNAL_SERVICES = [
 
   {
     name: 'Neurosift',
-    regex: /\.nwb.lindi.json$/,
-    maxsize: Infinity,
-    endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&st=lindi&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
-  },
-
-  {
-    name: 'Neurosift',
-    regex: /\.nwb.lindi.tar$/,
+    regex: /\.nwb\.lindi\.(json|tar)$/,
     maxsize: Infinity,
     endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&st=lindi&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
   },


### PR DESCRIPTION
This small update enables external Neurosift links for assets with the .nwb.lindi.tar file extension. Support for the .nwb.lindi.json extension was previously added in #1922.

**Background**

For more information on the purpose of lindi, and why both .lindi.json and .lindi.tar extensions are necessary, please refer to the [Lindi repository](https://github.com/neurodataWithoutBorders/lindi).

**Next Steps**

Currently, I plan to upload lindi files only to the staging site, as Lindi is not yet officially supported. Over the coming weeks, I will be working on making a case for future DANDI support, and look forward to discussion on the topic. I know there are issues about avoiding broken references.

In the meantime, having this menu option functional would be highly beneficial to me. Specifically, I will be presenting at a workshop next Thursday, and it would be convenient to have this feature available by then, although I could make do without it.