### PR TITLE
Fix Dandiset emptiness detection logic

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -99,10 +99,10 @@ def test_dandiset_rest_list(api_client, user, dandiset):
     [
         ('', ['empty', 'draft', 'published', 'erased']),
         ('?draft=false', ['published', 'erased']),
-        ('?empty=false', ['draft', 'published']),
+        ('?empty=false', ['draft', 'published', 'erased']),
         ('?draft=true&empty=true', ['empty', 'draft', 'published', 'erased']),
         ('?empty=true&draft=true', ['empty', 'draft', 'published', 'erased']),
-        ('?draft=false&empty=false', ['published']),
+        ('?draft=false&empty=false', ['published', 'erased']),
     ],
     ids=[
         'nothing',

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -144,7 +144,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                 # Only include dandisets that have assets in their most recent version.
                 most_recent_version = (
                     Version.objects.filter(dandiset=OuterRef('pk'))
-                    .order_by('created')
+                    .order_by('-created')
                     .annotate(asset_count=Count('assets'))[:1]
                 )
                 queryset = queryset.annotate(

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -148,9 +148,9 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                     .annotate(asset_count=Count('assets'))[:1]
                 )
                 queryset = queryset.annotate(
-                    draft_asset_count=Subquery(most_recent_version.values('asset_count'))
+                    asset_count=Subquery(most_recent_version.values('asset_count'))
                 )
-                queryset = queryset.filter(draft_asset_count__gt=0)
+                queryset = queryset.filter(asset_count__gt=0)
             if not show_embargoed:
                 queryset = queryset.filter(embargo_status='OPEN')
         return queryset


### PR DESCRIPTION
Determine emptiness of Dandisets based on emptiness of the newest Version contained within it. See https://github.com/dandi/dandi-archive/issues/1992#issuecomment-2307802787 and the commit message at https://github.com/dandi/dandi-archive/commit/002466ad11b4fce3ec03c111529a35944ce51677 for details.

Closes #1992.