### PR TITLE
Do login into docker hub so we could reliably build our docker image

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -19,10 +19,14 @@ jobs:
 
       - name: Build Docker image
         run: |
+          docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
           docker build \
             -t dandiarchive/dandiarchive-api \
             -f dev/django-public.Dockerfile \
             .
+        env:
+          DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Export Docker image
         run: |


### PR DESCRIPTION
Otherwise, since limiting is done per IP and we do not know where requests would be coming from to the docker hub, we could get

```
    #3 [auth] library/python:pull token for registry-1.docker.io
    #3 DONE 0.0s

    #2 [internal] load metadata for docker.io/library/python:3.11-slim
    #2 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/python/manifests/sha256:5501a4fe605abe24de87c2f3d6cf9fd760354416a0cad0296cf284fddcdca9e2: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
    ------
     > [internal] load metadata for docker.io/library/python:3.11-slim:
    ------
    django-public.Dockerfile:1
    --------------------
       1 | >>> FROM python:3.11-slim
       2 |     # Install system librarires for Python packages:
       3 |     # * psycopg2
    --------------------
    ERROR: failed to solve: python:3.11-slim: failed to resolve source metadata for docker.io/library/python:3.11-slim: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/python/manifests/sha256:5501a4fe605abe24de87c2f3d6cf9fd760354416a0cad0296cf284fddcdca9e2: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
    Error: Process completed with exit code 1.
```

For now added my "personal" read-only token.