### PR TITLE
Explicitly install Python in CD workflows

### DIFF
--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -37,6 +37,11 @@ jobs:
           fetch-depth: 0 # fetch history for all branches and tags
           ref: release
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install Heroku CLI
         run: curl https://cli-assets.heroku.com/install.sh | sh
 

--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           fetch-depth: 0 # fetch history for all branches and tags
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install Heroku CLI
         run: curl https://cli-assets.heroku.com/install.sh | sh
 


### PR DESCRIPTION
This is currently resulting in deploy failures to staging, and will also impact production the next time a deploy happens there. https://github.com/dandi/dandi-archive/actions/runs/11349812410

GitHub Actions' switch to Ubuntu 24.04 breaks the deploy workflows. We currently use `pip` to install the `build` package prior to packaging the `dandiapi` sdist. But, we do not explicitly install the Python runtime before doing this. It looks `pip` was available on the default Ubuntu 22.04 runners, but not 24.04, so this was basically working by accident before.

