### PR TITLE
Pin ruff version to avoid spurious test failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     codespell~=2.0
     ruff~=0.6.2
 commands =
+    ruff -V
     ruff check
     ruff format --check
     codespell .
@@ -23,6 +24,7 @@ package = skip
 deps =
     ruff~=0.6.2
 commands =
+    ruff -V
     ruff check --fix-only
     ruff format
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ package = skip
 ignore_errors = True
 deps =
     codespell~=2.0
-    ruff
+    ruff~=0.6.2
 commands =
     ruff check
     ruff format --check
@@ -21,7 +21,7 @@ commands =
 [testenv:format]
 package = skip
 deps =
-    ruff
+    ruff~=0.6.2
 commands =
     ruff check --fix-only
     ruff format

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     codespell~=2.0
     ruff~=0.6.2
 commands =
-    ruff -V
+    ruff --version
     ruff check
     ruff format --check
     codespell .
@@ -24,7 +24,7 @@ package = skip
 deps =
     ruff~=0.6.2
 commands =
-    ruff -V
+    ruff --version
     ruff check --fix-only
     ruff format
 


### PR DESCRIPTION
Since ruff is fast moving and freely publishes [new versions with breaking changes](https://docs.astral.sh/ruff/versioning/), it behooves us to pin a ruff version so that local dev and CI don't go out of sync with each other, complicating the review process for PRs.

This PR pins ruff to the 0.6.x minor series and adds a version report to each test (to make version numbers easier to determine in the future).

(See commit messages for details.)