### PR TITLE
Add a CI job that runs linting and formatting against latest ruff

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: [lint, type, test, check-migrations]
+        tox-env: [lint, type, test, check-migrations, ruff-latest]
     services:
       postgres:
         image: postgres:latest
@@ -48,6 +48,7 @@ jobs:
           pip install --upgrade pip
           pip install tox
       - name: Run tests
+        continue-on-error: ${{ matrix.tox-env == 'ruff-latest' }}
         run: |
           tox -e ${{ matrix.tox-env }}
         env:

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,16 @@ commands =
     ruff check --fix-only
     ruff format
 
+[testenv:ruff-latest]
+package = skip
+ignore_errors = True
+deps =
+    ruff
+commands =
+    ruff -V
+    ruff check
+    ruff format --check
+
 [testenv:type]
 deps =
     mypy


### PR DESCRIPTION
This is an experimental idea based off of the work in #2053, which pins Ruff to a specific minor version so that dev and CI don't go out of sync. The idea is to give CI the ability to run against _latest_ Ruff and let the failure of that run indicate new rules, etc., that we may want to adopt by fixing those errors and re-pinning the version used in the "real" runs.