### PR TITLE
Pin ubuntu-22.04 for all CI jobs

### DIFF
--- a/.github/workflows/auto-add-issues.yml
+++ b/.github/workflows/auto-add-issues.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,7 +12,7 @@ on:
     - cron: "0 0 * * *"
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   reset-release-branch:
     name: Update release branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,7 +29,7 @@ jobs:
 
   production-deploy:
     name: Deploy to Heroku
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: reset-release-branch
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Heroku
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out this repository
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
           path: dandiarchive-api.tgz
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-image
     strategy:
       fail-fast: false

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -11,7 +11,7 @@ jobs:
     defaults:
         run:
           working-directory: web
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -32,7 +32,7 @@ jobs:
         run: yarn run build
 
   test-e2e-puppeteer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
`ubuntu-latest` upgraded to 24.04 recently, causing breakages in some builds. This PR generalizes #2042 to make that change universal in all CI jobs.

The linting failure will be fixed by #2053.