### PR TITLE
Display message in GUI when accessing embargoed dandiset

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -241,6 +241,21 @@ def test_dandiset_rest_retrieve(api_client, dandiset):
     }
 
 
+@pytest.mark.django_db
+def test_dandiset_rest_retrieve_embargoed(api_client, dandiset_factory, user):
+    dandiset: Dandiset = dandiset_factory(embargo_status=Dandiset.EmbargoStatus.EMBARGOED)
+    resp = api_client.get(f'/api/dandisets/{dandiset.identifier}/')
+    assert resp.status_code == 401
+
+    api_client.force_authenticate(user=user)
+    resp = api_client.get(f'/api/dandisets/{dandiset.identifier}/')
+    assert resp.status_code == 403
+
+    dandiset.set_owners([user])
+    resp = api_client.get(f'/api/dandisets/{dandiset.identifier}/')
+    assert resp.status_code == 200
+
+
 @pytest.mark.parametrize(
     ('embargo_status'),
     [choice[0] for choice in Dandiset.EmbargoStatus.choices],


### PR DESCRIPTION
Fixes #1350

The following is now displayed when an embargoed dandiset that the current user is not an owner on is accessed.

![image](https://github.com/user-attachments/assets/f18d05a1-d28d-4816-a2ef-f73fb9209739)
