### PR TITLE
Fix validation error when only Zarr assets are uploaded

### DIFF
--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -7,6 +7,7 @@ import dandischema.exceptions
 from dandischema.metadata import aggregate_assets_summary, validate
 from django.conf import settings
 from django.db import transaction
+from django.db.models.query_utils import Q
 from django.utils import timezone
 
 from dandiapi.api.models import Asset, Version
@@ -124,7 +125,9 @@ def validate_version_metadata(*, version: Version) -> None:
         metadata_for_validation['doi'] = '10.80507/dandi.123456/0.123456.1234'
         metadata_for_validation['assetsSummary'] = {
             'schemaKey': 'AssetsSummary',
-            'numberOfBytes': 1 if version.assets.filter(blob__size__gt=0).exists() else 0,
+            'numberOfBytes': 1
+            if version.assets.filter(Q(blob__size__gt=0) | Q(zarr__size__gt=0)).exists()
+            else 0,
             'numberOfFiles': 1 if version.assets.exists() else 0,
         }
         return metadata_for_validation


### PR DESCRIPTION
## Description of error

As documented in #1814, we receive the following validation error on the web application when uploading only Zarr asset(s) to a Dandiset (and not blobs):

```
assetsSummary: A Dandiset containing no files or zero bytes is not publishable
```

The error is raised from `dandi-schema` when a validation check occurs on the `assetSummary` field in the `dandiset.yaml`.  See the [models module](https://github.com/dandi/dandi-schema/blob/bdb7dd681435f1092814041eb01eb4fabe87bf57/dandischema/models.py#L1495-L1501):

```python
@validator("assetsSummary")
def check_filesbytes(cls, values: AssetsSummary) -> AssetsSummary:
    if values.numberOfBytes == 0 or values.numberOfFiles == 0:
        raise ValueError(
            "A Dandiset containing no files or zero bytes is not publishable"
        )
    return values
```

And it arises because in the query below only the `blob` asset is evaluated:

https://github.com/dandi/dandi-archive/blob/0a4bf7057fe176097b09c9ce9c6541dfa966fc17/dandiapi/api/services/metadata/__init__.py#L127

## Description of proposed fix

The proposed changes additionally evaluate the size of Zarr assets that are in the `COMPLETE` state to generate the `assetSummary:numberOfBytes` metadata field.

cc @kabilar

Closes #1814