### PR TITLE
Include support for neuroglancer url for umembargoed zarr and nifti

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -230,7 +230,8 @@
                       <v-list-item
                         v-for="el in item.services"
                         :key="el.name"
-                        :href="el.url"
+                        @click="el.isPublicNeuroglancer ? redirectNeuroglancerUrl(item) : null"
+                        :href="!el.isPublicNeuroglancer ? el.url : null"
                         target="_blank"
                         rel="noreferrer"
                       >
@@ -330,7 +331,6 @@ const EXTERNAL_SERVICES = [
     maxsize: 1e9,
     endpoint: 'http://nwbexplorer.opensourcebrain.org/nwbfile=$asset_url$',
   },
-
   {
     name: 'VTK/ITK Viewer',
     regex: /\.ome\.zarr$/,
@@ -351,19 +351,23 @@ const EXTERNAL_SERVICES = [
     maxsize: Infinity,
     endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
   },
-
   {
     name: 'Neurosift',
     regex: /\.nwb\.lindi\.(json|tar)$/,
     maxsize: Infinity,
     endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&st=lindi&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
   },
-
   {
     name: 'Neurosift',
     regex: /\.avi$/,
     maxsize: Infinity,
     endpoint: 'https://neurosift.app?p=/avi&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
+  },
+  {
+    name: 'Neuroglancer',
+    regex: /\.nii(\.gz)?$|\.zarr$/,
+    maxsize: Infinity,
+    endpoint: '', // defaults to redirectNeuroglancerUrl logic
   }
 ];
 type Service = typeof EXTERNAL_SERVICES[0];
@@ -441,7 +445,7 @@ function getExternalServices(path: AssetPath, info: {dandisetId: string, dandise
   // used, but we're forced to supply the internal DANDI URL for embargoed
   // dandisets (since the ready-made S3 URL will prevent access in that case).
   const assetUrl = embargoed.value ? assetDandiUrl : assetS3Url;
-
+  
   return EXTERNAL_SERVICES
     .filter((service) => servicePredicate(service, path))
     .map((service) => ({
@@ -453,6 +457,7 @@ function getExternalServices(path: AssetPath, info: {dandisetId: string, dandise
         assetDandiUrl,
         assetS3Url,
       }),
+      isPublicNeuroglancer: service.name === 'Neuroglancer' && !embargoed.value,
     }));
 }
 
@@ -555,6 +560,30 @@ async function deleteAsset() {
   // Recompute the items to display in the browser.
   getItems();
   itemToDelete.value = null;
+}
+
+function redirectNeuroglancerUrl(item: any) {
+    const assetS3Url = trimEnd((item.asset as AssetFile).url, '/');
+    const baseUrl = `https://neuroglancer-demo.appspot.com/#!`;  // Public neuroglancer instance
+    const jsonObject = {
+        layers: [
+            {
+                type: "new",
+                source: assetS3Url.includes("zarr") ? `zarr://${assetS3Url}` : `nifti://${assetS3Url}`,
+                tab: "source",
+                name: item.asset.asset_id
+            }
+        ],
+        selectedLayer: {
+            visible: true,
+            layer: item.asset.asset_id
+        },
+        layout: "4panel"
+    };
+
+    const jsonStr = JSON.stringify(jsonObject);
+    const encodedJson = encodeURIComponent(jsonStr);
+    window.open(`${baseUrl}${encodedJson}`);
 }
 
 // Update URL if location changes


### PR DESCRIPTION
As per @satra's suggestion for consolidation of LINC --> DANDI, here is some consolidation of providing a Neuroglancer `EXTERNAL_SERVICE` link for public assets at this time.

Cc @kabilar 

@yarikoptic @satra @waxlamp -- if you are curious, here is some documentation for how on the LINC side we went about rendering private assets (e.g. in DANDI case, embargoed essentially): https://github.com/lincbrain/linc-archive/blob/0b1fe19cfdb7075b1c5a5d5a47fec702db948fd7/doc/design/linc_permissions.md#cloudfront-distribution-with-origin-access-identity-control-for-relevant-s3-buckets

I'm hesitant to fully deploy the LINC CloudFront strategy to DANDI until further conversations happen with the Neuroglancer folks. The key blocker here with the LINC neuroglancer<>CloudFront strategy is that it requires 1. another fork of `neuroglancer` to maintain, and 2. will probably break once data is sourced from MIT infra -- thus conversations probably need to be had with core neuroglancer regarding injection of creds outside of just Google Cloud Platform

Happy to expound further here need be -- thanks all