### PR TITLE
Fix display of embargoed dandiset error page in GUI

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -193,20 +193,11 @@ watch(() => props.identifier, async () => {
   }
 
   // Set default values
-  embargoedOrUnauthenticated.value = false;
   loading.value = true;
 
-  // Catch error to check if response is 401, for embargoed dandisets
-  try {
-    await store.initializeDandisets({ identifier, version });
-
-  } catch (e) {
-    if (axios.isAxiosError(e) && (e.response?.status === 401 || e.response?.status === 403)) {
-      embargoedOrUnauthenticated.value = true
-    } else {
-      throw e
-    }
-  }
+  // Check if response is 401 or 403, for embargoed dandisets
+  await store.initializeDandisets({ identifier, version });
+  embargoedOrUnauthenticated.value = store.meta.dandisetExistsAndEmbargoed;
 
   loading.value = false;
 }, { immediate: true });


### PR DESCRIPTION
Fixes #1350
Follow on to #2060

It turns out the change I made to display "access denied" to embargoed dandisets didn't properly handle all cases of that access. This led to the display of "Dandiset does not exist" on dandisets that did exist, but were embargoed.