### PR TITLE
ENH: run pytest  against dandi-cli with -v to see which tests ran

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run dandi-api tests in dandi-cli
         run: |
-          python -m pytest --dandi-api \
+          python -m pytest --dandi-api -v \
             "$pythonLocation/lib/python${{ matrix.python }}/site-packages/dandi"
         env:
           DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"


### PR DESCRIPTION
and which FAILed or PASSed.  Just now realized that we do not run in verbose mode so cannot `grep` for specific test in the logs collected by tinuous for the past 