### PR TITLE
Add incomplete upload dialog to DLP when unembargo is blocked

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -1149,8 +1149,9 @@ def test_dandiset_rest_list_active_uploads(
     response = authenticated_api_client.get(f'/api/dandisets/{ds.identifier}/uploads/')
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 1
-    assert data[0]['upload_id'] == upload.upload_id
+    assert data['count'] == 1
+    assert len(data['results']) == 1
+    assert data['results'][0]['upload_id'] == upload.upload_id
 
 
 @pytest.mark.django_db
@@ -1187,10 +1188,14 @@ def test_dandiset_rest_clear_active_uploads(
     assign_perm('owner', user, ds)
     upload_factory(dandiset=ds)
 
-    assert len(authenticated_api_client.get(f'/api/dandisets/{ds.identifier}/uploads/').json()) == 1
+    response = authenticated_api_client.get(f'/api/dandisets/{ds.identifier}/uploads/').json()
+    assert response['count'] == 1
+    assert len(response['results']) == 1
 
     response = authenticated_api_client.delete(f'/api/dandisets/{ds.identifier}/uploads/')
     assert response.status_code == 204
 
     assert ds.uploads.count() == 0
-    assert len(authenticated_api_client.get(f'/api/dandisets/{ds.identifier}/uploads/').json()) == 0
+    response = authenticated_api_client.get(f'/api/dandisets/{ds.identifier}/uploads/').json()
+    assert response['count'] == 0
+    assert len(response['results']) == 0

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import typing
 from typing import TYPE_CHECKING
 
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
 from django.db import transaction
-from django.db.models import Count, Max, OuterRef, Subquery, Sum
+from django.db.models import Count, Max, OuterRef, QuerySet, Subquery, Sum
 from django.db.models.functions import Coalesce
 from django.db.models.query_utils import Q
 from django.http import Http404
@@ -41,6 +42,7 @@ from dandiapi.api.views.serializers import (
     DandisetQueryParameterSerializer,
     DandisetSearchQueryParameterSerializer,
     DandisetSearchResultListSerializer,
+    DandisetUploadSerializer,
     UserSerializer,
     VersionMetadataSerializer,
 )
@@ -48,6 +50,8 @@ from dandiapi.search.models import AssetSearch
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
+
+    from dandiapi.api.models.upload import Upload
 
 
 class DandisetFilterBackend(filters.OrderingFilter):
@@ -155,6 +159,16 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                 queryset = queryset.filter(embargo_status='OPEN')
         return queryset
 
+    def require_owner_perm(self, dandiset: Dandiset):
+        # Raise 401 if unauthenticated
+        if not self.request.user.is_authenticated:
+            raise NotAuthenticated
+
+        # Raise 403 if unauthorized
+        self.request.user = typing.cast(User, self.request.user)
+        if not self.request.user.has_perm('owner', dandiset):
+            raise PermissionDenied
+
     def get_object(self):
         # Alternative to path converters, which DRF doesn't support
         # https://docs.djangoproject.com/en/3.0/topics/http/urls/#registering-custom-path-converters
@@ -168,12 +182,8 @@ class DandisetViewSet(ReadOnlyModelViewSet):
 
         dandiset = super().get_object()
         if dandiset.embargo_status != Dandiset.EmbargoStatus.OPEN:
-            if not self.request.user.is_authenticated:
-                # Clients must be authenticated to access it
-                raise NotAuthenticated
-            if not self.request.user.has_perm('owner', dandiset):
-                # The user does not have ownership permission
-                raise PermissionDenied
+            self.require_owner_perm(dandiset)
+
         return dandiset
 
     @staticmethod
@@ -453,3 +463,33 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                 )
 
         return Response(owners, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(
+        methods=['GET'],
+        manual_parameters=[DANDISET_PK_PARAM],
+        request_body=no_body,
+        operation_summary='List active/incomplete uploads in this dandiset.',
+    )
+    @action(methods=['GET'], detail=True)
+    def uploads(self, request, dandiset__pk):
+        dandiset: Dandiset = self.get_object()
+
+        # Special case where a "safe" method is access restricted, due to the nature of uploads
+        self.require_owner_perm(dandiset)
+
+        uploads: QuerySet[Upload] = dandiset.uploads.all()
+        serializer = DandisetUploadSerializer(instance=uploads, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(
+        manual_parameters=[DANDISET_PK_PARAM],
+        request_body=no_body,
+        operation_summary='Delete all active/incomplete uploads in this dandiset.',
+    )
+    @uploads.mapping.delete
+    def clear_uploads(self, request, dandiset__pk):
+        dandiset: Dandiset = self.get_object()
+        self.require_owner_perm(dandiset)
+
+        dandiset.uploads.all().delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -8,7 +8,7 @@ from django.db.models.query_utils import Q
 from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 
-from dandiapi.api.models import Asset, AssetBlob, AssetPath, Dandiset, Version
+from dandiapi.api.models import Asset, AssetBlob, AssetPath, Dandiset, Upload, Version
 from dandiapi.search.models import AssetSearch
 
 if TYPE_CHECKING:
@@ -297,6 +297,17 @@ class VersionDetailSerializer(VersionSerializer):
 
     def get_contact_person(self, obj):
         return extract_contact_person(obj)
+
+
+class DandisetUploadSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Upload
+        exclude = [
+            'dandiset',
+            'embargoed',
+            'id',
+            'multipart_upload_id',
+        ]
 
 
 class AssetBlobSerializer(serializers.ModelSerializer):

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -373,6 +373,11 @@ class AssetPathsQueryParameterSerializer(serializers.Serializer):
     path_prefix = serializers.CharField(default='')
 
 
+class PaginationQuerySerializer(serializers.Serializer):
+    page = serializers.IntegerField(default=1)
+    page_size = serializers.IntegerField(default=100)
+
+
 class AssetFileSerializer(AssetSerializer):
     class Meta(AssetSerializer.Meta):
         fields = ['asset_id', 'url']

--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -12,6 +12,7 @@ import type {
   AssetPath,
   Zarr,
   DandisetSearchResult,
+  IncompleteUpload,
 } from '@/types';
 import type {
   Dandiset as DandisetMetadata,
@@ -105,6 +106,13 @@ const dandiRest = {
       }
       throw e;
     }
+  },
+  async uploads(identifier: string): Promise<IncompleteUpload[]> {
+    const res = await client.get(`dandisets/${identifier}/uploads/`);
+    return res.data;
+  },
+  async clearUploads(identifier: string) {
+    await client.delete(`dandisets/${identifier}/uploads/`);
   },
   async assets(
     identifier: string,

--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -108,8 +108,22 @@ const dandiRest = {
     }
   },
   async uploads(identifier: string): Promise<IncompleteUpload[]> {
-    const res = await client.get(`dandisets/${identifier}/uploads/`);
-    return res.data;
+    const uploads = []
+    let page = 1;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const res = await client.get(`dandisets/${identifier}/uploads/`, {params: { page }});
+
+      uploads.push(...res.data.results);
+      if (res.data.next === null) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return uploads;
   },
   async clearUploads(identifier: string) {
     await client.delete(`dandisets/${identifier}/uploads/`);

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -102,3 +102,11 @@ export interface AssetPath {
   aggregate_size: number;
   asset: AssetFile | null;
 }
+
+export interface IncompleteUpload {
+  created: string;
+  blob: string;
+  upload_id: string;
+  etag: string;
+  size: number;
+}


### PR DESCRIPTION
Recently we've had several instances of a dandiset unembargo being blocked by incomplete/active uploads. Most of the time, these uploads are junk and the owners simply wish to clear them, which requires admin intervention. This PR adds the API and Vue client support for users to list and delete these lingering uploads themselves.


Here is a video of the new UI.

https://github.com/user-attachments/assets/6033cd6b-9b10-4c8d-96e1-f85ea3df2598

