### PR TITLE
Include robots.txt in UI and API for handling of web crawlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,5 +125,5 @@ dmypy.json
 
 # Editor settings
 .vscode
-
+.idea/
 .DS_Store

--- a/dandiapi/api/views/__init__.py
+++ b/dandiapi/api/views/__init__.py
@@ -5,6 +5,7 @@ from .auth import auth_token_view, authorize_view, user_questionnaire_form_view
 from .dandiset import DandisetViewSet
 from .dashboard import DashboardView, mailchimp_csv_view, user_approval_view
 from .info import info_view
+from .robots import robots_txt_view
 from .root import root_content_view
 from .stats import stats_view
 from .upload import (
@@ -36,4 +37,5 @@ __all__ = [
     'stats_view',
     'info_view',
     'root_content_view',
+    'robots_txt_view'
 ]

--- a/dandiapi/api/views/robots.py
+++ b/dandiapi/api/views/robots.py
@@ -1,0 +1,10 @@
+from django.views.decorators.cache import cache_page
+from django.http import HttpResponse
+
+@cache_page(60 * 60 * 24)  # 24 hour cache
+def robots_txt_view(request):
+    content = """
+    User-agent: *
+    Disallow: /
+    """
+    return HttpResponse(content, content_type="text/plain")

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -19,6 +19,7 @@ from dandiapi.api.views import (
     blob_read_view,
     info_view,
     mailchimp_csv_view,
+    robots_txt_view,
     root_content_view,
     stats_view,
     upload_complete_view,
@@ -80,8 +81,10 @@ class DandisetIDConverter:
 register_converter(DandisetIDConverter, 'dandiset_id')
 urlpatterns = [
     path('', root_content_view),
+    path("robots.txt", robots_txt_view),
     path('api/', include(router.urls)),
     path('api/auth/token/', auth_token_view, name='auth-token'),
+    path('api/stats/', stats_view),
     path('api/stats/', stats_view),
     path('api/info/', info_view),
     path('api/blobs/digest/', blob_read_view, name='blob-read'),

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
@yarikoptic -- per https://dandiarchive.slack.com/archives/GMRLT5RQ8/p1732553458007359 -- includes `robots.txt` in both UI and backend, per @jwodder suggestion

Cc @jjnesbitt @mvandenburgh 