### PR TITLE
Set `--max-warnings` to zero for `eslint`

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "build": "vite build",
     "preview": "vite preview --port 4173",
     "type-check": "vue-tsc --noEmit",
-    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --max-warnings=0 --ignore-path .gitignore"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.7",

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -114,7 +114,6 @@ import {
 import type { Ref } from 'vue';
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router/composables';
 import type { NavigationGuardNext, RawLocation, Route } from 'vue-router';
-import axios from 'axios';
 
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
 import Meditor from '@/components/Meditor/Meditor.vue';


### PR DESCRIPTION
Currently, linting warnings emitted by `eslint` don't cause a CI failure. This is why we see the "Unchanged files with check annotations" on new PRs like this one https://github.com/dandi/dandi-archive/pull/2062/files#annotation_29329773434

Setting `--max-warnings` to zero will make the CI fail if there are any linting warnings.