### PR TITLE
DLP: Have "Cite as" only for OPEN (non embargoed) dandisets

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetActions.vue
+++ b/web/src/views/DandisetLandingView/DandisetActions.vue
@@ -38,6 +38,7 @@
         </DownloadDialog>
       </v-row>
       <v-row
+        v-if="currentDandiset.dandiset.embargo_status === 'OPEN'"
         no-gutters
       >
         <CiteAsDialog>


### PR DESCRIPTION
Closes #2094

A trivial PR. Seems to work locally I see

![image](https://github.com/user-attachments/assets/5f0243bc-3685-4d4c-b5d9-2c4857e98d01)

and then for OPEN

![image](https://github.com/user-attachments/assets/af4e975a-8f5a-4125-9465-8abbea55c0ac)

NB error is there even on master, I didn't dig in.