### PR TITLE
Set version status to PENDING in ingest_zarr_archive

### DIFF
--- a/dandiapi/zarr/tests/factories.py
+++ b/dandiapi/zarr/tests/factories.py
@@ -14,6 +14,15 @@ class ZarrArchiveFactory(factory.django.DjangoModelFactory):
     name = factory.Faker('catch_phrase')
     dandiset = factory.SubFactory(DandisetFactory)
 
+    @factory.post_generation
+    def ensure_draft_version(obj: ZarrArchive, *args, **kwargs):  # type: ignore  # noqa: N805, PGH003
+        from dandiapi.api.tests.factories import DraftVersionFactory
+
+        if obj.dandiset.versions.filter(version='draft').exists():
+            return
+
+        DraftVersionFactory(dandiset=obj.dandiset)
+
 
 class EmbargoedZarrArchiveFactory(ZarrArchiveFactory):
     embargoed = True


### PR DESCRIPTION
Closes #2091

@mvandenburgh The last commit fixes some zarr tests that didn't have a draft version associated with their dandiset, due the chain of `SubFactory` definitions. I originally tried to fix this on the `DandisetFactory` class itself, so that all dandisets generated in this way would always have a draft version, but that proved troublesome. For now, I've settled for just fixing the zarr tests.