### PR TITLE
Capitalize `Archive` when it follows `DANDI`

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -142,14 +142,14 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
         url = f'https://doi.org/{metadata["doi"]}' if 'doi' in metadata else metadata['url']
         version = metadata['version']
         # If we can't find any contributors, use this citation format
-        citation = f'{name} ({year}). (Version {version}) [Data set]. DANDI archive. {url}'
+        citation = f'{name} ({year}). (Version {version}) [Data set]. DANDI Archive. {url}'
         if 'contributor' in metadata and isinstance(metadata['contributor'], list):
             cl = '; '.join(
                 [val['name'] for val in metadata['contributor'] if val.get('includeInCitation')]
             )
             if cl:
                 citation = (
-                    f'{cl} ({year}) {name} (Version {version}) [Data set]. DANDI archive. {url}'
+                    f'{cl} ({year}) {name} (Version {version}) [Data set]. DANDI Archive. {url}'
                 )
         return citation
 

--- a/dandiapi/api/templates/api/mail/registered_message.txt
+++ b/dandiapi/api/templates/api/mail/registered_message.txt
@@ -4,7 +4,7 @@ Dear {{ greeting_name }},
 Welcome to DANDI.
 
 
-Thank you for registering on the DANDI archive. Your account is now pending approval by
+Thank you for registering on the DANDI Archive. Your account is now pending approval by
 a DANDI admin. Once approved, you will be able to create Dandisets and upload data right
 away. You will also be able to use the Jupyterhub (https://hub.dandiarchive.org) for
 computing on dandisets in the cloud.

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -388,7 +388,7 @@ def test_dandiset_rest_create(api_client, user):
         'dateCreated': UTC_ISO_TIMESTAMP_RE,
         'citation': (
             f'{user.last_name}, {user.first_name} ({year}) {name} '
-            f'(Version draft) [Data set]. DANDI archive. {url}'
+            f'(Version draft) [Data set]. DANDI Archive. {url}'
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
@@ -482,7 +482,7 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
         'dateCreated': UTC_ISO_TIMESTAMP_RE,
         'citation': (
             f'{admin_user.last_name}, {admin_user.first_name} ({year}) {name} '
-            f'(Version draft) [Data set]. DANDI archive. {url}'
+            f'(Version draft) [Data set]. DANDI Archive. {url}'
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
@@ -589,7 +589,7 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
         'url': url,
         'dateCreated': UTC_ISO_TIMESTAMP_RE,
         'citation': (
-            f'Jane Doe ({year}) {name} ' f'(Version draft) [Data set]. DANDI archive. {url}'
+            f'Jane Doe ({year}) {name} ' f'(Version draft) [Data set]. DANDI Archive. {url}'
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
@@ -681,7 +681,7 @@ def test_dandiset_rest_create_embargoed(api_client, user):
         'dateCreated': UTC_ISO_TIMESTAMP_RE,
         'citation': (
             f'{user.last_name}, {user.first_name} ({year}) {name} '
-            f'(Version draft) [Data set]. DANDI archive. {url}'
+            f'(Version draft) [Data set]. DANDI Archive. {url}'
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -153,7 +153,7 @@ def test_version_metadata_citation_draft(draft_version):
     )
     assert (
         draft_version.metadata['citation']
-        == f'{name} ({year}). (Version {draft_version.version}) [Data set]. DANDI archive. {url}'
+        == f'{name} ({year}). (Version {draft_version.version}) [Data set]. DANDI Archive. {url}'
     )
 
 
@@ -164,7 +164,7 @@ def test_version_metadata_citation_published(published_version):
     url = f'https://doi.org/{published_version.doi}'
     assert published_version.metadata['citation'] == (
         f'{name} ({year}). (Version {published_version.version}) [Data set]. '
-        f'DANDI archive. {url}'
+        f'DANDI Archive. {url}'
     )
 
 
@@ -176,7 +176,7 @@ def test_version_metadata_citation_no_contributors(version):
     name = version.metadata['name'].rstrip('.')
     year = datetime.datetime.now(datetime.UTC).year
     assert version.metadata['citation'].startswith(
-        f'{name} ({year}). (Version {version.version}) [Data set]. DANDI archive. '
+        f'{name} ({year}). (Version {version.version}) [Data set]. DANDI Archive. '
     )
 
 
@@ -191,7 +191,7 @@ def test_version_metadata_citation_contributor_not_in_citation(version):
     name = version.metadata['name'].rstrip('.')
     year = datetime.datetime.now(datetime.UTC).year
     assert version.metadata['citation'].startswith(
-        f'{name} ({year}). (Version {version.version}) [Data set]. DANDI archive. '
+        f'{name} ({year}). (Version {version.version}) [Data set]. DANDI Archive. '
     )
 
 
@@ -203,7 +203,7 @@ def test_version_metadata_citation_contributor(version):
     name = version.metadata['name'].rstrip('.')
     year = datetime.datetime.now(datetime.UTC).year
     assert version.metadata['citation'].startswith(
-        f'Doe, Jane ({year}) {name} (Version {version.version}) [Data set]. DANDI archive. '
+        f'Doe, Jane ({year}) {name} (Version {version.version}) [Data set]. DANDI Archive. '
     )
 
 
@@ -219,7 +219,7 @@ def test_version_metadata_citation_multiple_contributors(version):
     year = datetime.datetime.now(datetime.UTC).year
     assert version.metadata['citation'].startswith(
         f'John Doe; Jane Doe ({year}) {name} (Version {version.version}) [Data set]. '
-        f'DANDI archive. '
+        f'DANDI Archive. '
     )
 
 
@@ -564,7 +564,7 @@ def test_version_rest_update(api_client, user, draft_version):
         'repository': settings.DANDI_WEB_APP_URL,
         'dateCreated': UTC_ISO_TIMESTAMP_RE,
         'access': [{'schemaKey': 'AccessRequirements', 'status': AccessType.OpenAccess.value}],
-        'citation': f'{new_name} ({year}). (Version draft) [Data set]. DANDI archive. {url}',
+        'citation': f'{new_name} ({year}). (Version draft) [Data set]. DANDI Archive. {url}',
         'assetsSummary': {
             'numberOfBytes': 0,
             'numberOfFiles': 0,

--- a/doc/design/new-user-questionnaire.md
+++ b/doc/design/new-user-questionnaire.md
@@ -36,7 +36,7 @@ them full capabilities of any other normal user (creating/editing dandisets, etc
 
 ### Proposed user signup flow
 1) The user navigates to https://gui.dandiarchive.org and clicks the "LOG IN WITH GITHUB" button.
-2) The user is redirected to GitHub, enters their credentials, and clicks "Sign in". This action creates a new DANDI archive account for the user with the `status` field set to `INCOMPLETE`.
+2) The user is redirected to GitHub, enters their credentials, and clicks "Sign in". This action creates a new DANDI Archive account for the user with the `status` field set to `INCOMPLETE`.
 3) The user is redirected to the SSR rendered questionnaire form and they fill it out and submit it. This populates the `questionnaire_form` field in the DB and sets the `status` field to `PENDING`.
 4) An email is sent to the user confirming their registration and telling them when they can expect approval.
 5) The user is redirected to the DANDI Archive homepage. A banner will be displayed underneath the navbar telling the user that their account is pending approval.

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -31,7 +31,7 @@
                 </template>
                 <span>
                   Embargoed Dandisets are hidden from public access until a specific time period has
-                  elapsed. Uploading data to the DANDI archive under embargo requires a relevant
+                  elapsed. Uploading data to the DANDI Archive under embargo requires a relevant
                   NIH award number, and the data will be automatically published when the embargo
                   period expires.
                 </span>


### PR DESCRIPTION
The changes in this pull request are based on the [style guidelines](https://github.com/dandi/handbook?tab=readme-ov-file#dandi-style-guidelines).

cc @yarikoptic 