### PR TITLE
Set assets to pending during unembargo

### DIFF
--- a/dandiapi/api/services/embargo/__init__.py
+++ b/dandiapi/api/services/embargo/__init__.py
@@ -7,6 +7,7 @@ from django.db import transaction
 
 from dandiapi.api.mail import send_dandiset_unembargoed_message
 from dandiapi.api.models import AssetBlob, Dandiset, Version
+from dandiapi.api.models.asset import Asset
 from dandiapi.api.services import audit
 from dandiapi.api.services.asset.exceptions import DandisetOwnerRequiredError
 from dandiapi.api.services.embargo.utils import _delete_object_tags, remove_dandiset_embargo_tags
@@ -47,6 +48,8 @@ def unembargo_dandiset(ds: Dandiset, user: User):
     logger.info('Removing tags...')
     remove_dandiset_embargo_tags(ds)
 
+    # Set all assets to pending
+    updated_assets = Asset.objects.filter(versions__dandiset=ds).update(status=Asset.Status.PENDING)
     # Update embargoed flag on asset blobs and zarrs
     updated_blobs = AssetBlob.objects.filter(embargoed=True, assets__versions__dandiset=ds).update(
         embargoed=False
@@ -54,6 +57,7 @@ def unembargo_dandiset(ds: Dandiset, user: User):
     updated_zarrs = ZarrArchive.objects.filter(
         embargoed=True, assets__versions__dandiset=ds
     ).update(embargoed=False)
+    logger.info('Set %s assets to PENDING', updated_assets)
     logger.info('Updated %s asset blobs', updated_blobs)
     logger.info('Updated %s zarrs', updated_zarrs)
 


### PR DESCRIPTION
This addresses the effects of #2116. Currently, without this change, every asset of a previously unembargoed dandiset can be left with the validation error `An embargo end date is required for NIH awards to be in compliance with NIH resource sharing policy.`. Now, when a dandiset is unembargoed, all assets will be set to `PENDING` status, so that their metadata can be re-validated.