### PR TITLE
Login to docker hub only if credentials were provided

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -22,7 +22,7 @@ jobs:
           if [ -n "$DOCKER_LOGIN$DOCKER_TOKEN" ]; then
               docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
           else
-              echo "Not login-in to docker since no credentials were provided, might hit limits below"
+              echo "Not logging in to docker since no credentials were provided, might hit limits below"
           fi
           docker build \
             -t dandiarchive/dandiarchive-api \

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -19,7 +19,9 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
+          [ -n "$DOCKER_LOGIN$DOCKER_TOKEN" ] \
+          && docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN" \
+          || echo "Not login-in to docker since no credentials were provided, might hit limits below"
           docker build \
             -t dandiarchive/dandiarchive-api \
             -f dev/django-public.Dockerfile \

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -19,9 +19,11 @@ jobs:
 
       - name: Build Docker image
         run: |
-          [ -n "$DOCKER_LOGIN$DOCKER_TOKEN" ] \
-          && docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN" \
-          || echo "Not login-in to docker since no credentials were provided, might hit limits below"
+          if [ -n "$DOCKER_LOGIN$DOCKER_TOKEN" ]; then
+              docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
+          else
+              echo "Not login-in to docker since no credentials were provided, might hit limits below"
+          fi
           docker build \
             -t dandiarchive/dandiarchive-api \
             -f dev/django-public.Dockerfile \


### PR DESCRIPTION
I think this could be the only solution (may be besides also adding retries in addition) to allow testing against dandi-cli to be done also in PRs from forks of the project, where there is no credentials.  We could also advise our developers to provide such (own) credentials in their forks.

FTR: login originally was added in 6b815dc6aabf33aebf846aa56b67fb952e13bc77

- I think we can state that it closes https://github.com/dandi/dandi-archive/issues/2107 . If it fails to pull from docker -- it would be a differently titled issue ;-)
- note: this PR submitted from a personal fork, so would test ability to pass for similar ones