### PR TITLE
Enable User search by GitHub username

### DIFF
--- a/dandiapi/api/admin.py
+++ b/dandiapi/api/admin.py
@@ -47,7 +47,7 @@ class SocialAccountInline(TabularInline):
 class UserAdmin(BaseUserAdmin):
     list_select_related = ['metadata']
     list_display = ['email', 'first_name', 'last_name', 'github_username', 'status', 'date_joined']
-    search_fields = ['email', 'first_name', 'last_name']
+    search_fields = ['email', 'first_name', 'last_name', 'socialaccount__extra_data__login']
     inlines = (
         UserMetadataInline,
         SocialAccountInline,


### PR DESCRIPTION
This adds the `github_username` field to the list of searchable fields in the `User` admin console.