### PR TITLE
Display validation errors on DLP for embargoed dandisets

### DIFF
--- a/web/src/components/DLP/OverviewTab.vue
+++ b/web/src/components/DLP/OverviewTab.vue
@@ -171,8 +171,8 @@
             <div
               v-else-if="!assetSummary || !Object.keys(assetSummary).length"
               class="font-italic font-weight-bold"
+              v-text="`This Dandiset does not contain any valid assets.${currentDandiset?.asset_validation_errors.length ? ' Please check the asset validation errors on the right panel.' : ''}`"
             >
-              This Dandiset does not contain any valid assets.
             </div>
             <div
               v-for="([type, items], i) in Object.entries(assetSummary)"

--- a/web/src/components/DLP/OverviewTab.vue
+++ b/web/src/components/DLP/OverviewTab.vue
@@ -172,7 +172,7 @@
               v-else-if="!assetSummary || !Object.keys(assetSummary).length"
               class="font-italic font-weight-bold"
             >
-              This Dandiset does not contain any assets.
+              This Dandiset does not contain any valid assets.
             </div>
             <div
               v-for="([type, items], i) in Object.entries(assetSummary)"

--- a/web/src/views/DandisetLandingView/DandisetUnembargo.vue
+++ b/web/src/views/DandisetLandingView/DandisetUnembargo.vue
@@ -146,6 +146,9 @@
         <span>This dandiset is being unembargoed, please wait.</span>
       </v-tooltip>
     </v-row>
+
+    <DandisetValidationErrors :dandiset="currentDandiset" :isOwner="true" />
+
     <v-row>
       <v-subheader class="mb-2 black--text text-h5">
         This Version
@@ -176,6 +179,7 @@ import moment from 'moment';
 import { dandiRest } from '@/rest';
 import { useDandisetStore } from '@/stores/dandiset';
 import type { IncompleteUpload } from '@/types';
+import DandisetValidationErrors from './DandisetValidationErrors.vue';
 import filesize from 'filesize';
 
 function formatDate(date: string, format: string = 'll'): string {

--- a/web/src/views/DandisetLandingView/DandisetValidationErrors.vue
+++ b/web/src/views/DandisetLandingView/DandisetValidationErrors.vue
@@ -1,0 +1,152 @@
+<template>
+  <v-container>
+    <v-row
+      v-if="dandiset.status === 'Pending'"
+      class="my-2 px-1"
+      no-gutters
+    >
+      <v-menu
+        :nudge-width="200"
+      >
+        <template #activator="{ on: menu, attrs }">
+          <v-tooltip bottom>
+            <template #activator="{ on: tooltip }">
+              <v-card
+                class="amber lighten-5 no-text-transform"
+                outlined
+                v-bind="attrs"
+                v-on="{ ...tooltip, ...menu }"
+              >
+                <v-row class="align-center px-4">
+                  <v-col
+                    cols="1"
+                    class="justify-center py-0"
+                  >
+                    <v-icon
+                      color="warning"
+                      class="mr-1"
+                    >
+                      mdi-playlist-remove
+                    </v-icon>
+                  </v-col>
+                  <v-spacer />
+                  <v-col cols="9">
+                    <div class="text-caption">
+                      Validation of the dandiset is pending.
+                    </div>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </template>
+            <span>Reload the page to see if validation is over.</span>
+          </v-tooltip>
+        </template>
+      </v-menu>
+    </v-row>
+
+    <!-- Dialog where version and asset errors are shown -->
+    <v-dialog v-model="errorDialogOpen">
+      <ValidationErrorDialog
+        :selected-tab="selectedTab"
+        :asset-validation-errors="dandiset.asset_validation_errors"
+        :version-validation-errors="dandiset.version_validation_errors"
+        :owner="isOwner"
+        @openMeditor="openMeditor"
+      />
+    </v-dialog>
+
+    <!-- Version Validation Errors Button -->
+    <v-card
+      v-if="dandiset.version_validation_errors.length"
+      class="my-2 px-1 amber lighten-5 no-text-transform"
+      outlined
+      @click="openErrorDialog('metadata')"
+    >
+      <v-row class="align-center px-4">
+        <v-col
+          cols="1"
+          class="justify-center py-0"
+        >
+          <v-icon
+            color="warning"
+            class="mr-1"
+          >
+            mdi-playlist-remove
+          </v-icon>
+        </v-col>
+        <v-spacer />
+        <v-col cols="9">
+          <div class="text-caption">
+            This Dandiset has {{ dandiset.version_validation_errors.length }}
+            metadata validation error(s).
+          </div>
+        </v-col>
+      </v-row>
+    </v-card>
+
+    <!-- Asset Validation Errors Button -->
+    <v-card
+      v-if="numAssetValidationErrors"
+      class="my-2 px-1 amber lighten-5 no-text-transform"
+      outlined
+      @click="openErrorDialog('assets')"
+    >
+      <v-row class="align-center px-4">
+        <v-col
+          cols="1"
+          class="justify-center py-0"
+        >
+          <v-icon
+            color="warning"
+            class="mr-1"
+          >
+            mdi-database-remove
+          </v-icon>
+        </v-col>
+        <v-spacer />
+        <v-col cols="9">
+          <div class="text-caption">
+            This Dandiset has {{ numAssetValidationErrors }}
+            asset validation error(s).
+          </div>
+        </v-col>
+      </v-row>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, defineProps, ref} from 'vue';
+import type { PropType } from 'vue';
+
+import ValidationErrorDialog from '@/components/DLP/ValidationErrorDialog.vue';
+import { open as meditorOpen } from '@/components/Meditor/state';
+import type { Version } from '@/types';
+
+const props = defineProps({
+  dandiset: {
+    type: Object as PropType<Version>,
+      required: true,
+  },
+  isOwner: {
+    type: Boolean as PropType<boolean>,
+    required: true,
+  },
+});
+
+const numAssetValidationErrors = computed(() => props.dandiset.asset_validation_errors.length);
+
+// Error dialog
+const errorDialogOpen = ref(false);
+type ErrorCategory = 'metadata' | 'assets';
+const selectedTab = ref<ErrorCategory>('metadata');
+function openErrorDialog(tab: ErrorCategory) {
+  errorDialogOpen.value = true;
+  selectedTab.value = tab;
+}
+
+function openMeditor() {
+  errorDialogOpen.value = false;
+  meditorOpen.value = true;
+}
+</script>


### PR DESCRIPTION
Fixes #2089.

We currently don't display validation errors on the DLP for embargoed dandisets. This seems to be an oversight due to much of the UI being duplicated between the `DandisetPublish` and `DandisetUnembargo` components. I've taken an initial stab at refactoring some of the duplicate templates into a reusable component in this PR, but we could probably clean it up a bit more. 

The text displayed when the Assets Summary is missing (`This Dandiset does not contain any assets.`) is also slightly misleading. A dandiset that contains _only invalid assets_ will also not have an Assets Summary; I've updated that text to reflect that.