### PR TITLE
Prevent duplicate serialization of dandiset in detail view

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -360,13 +360,6 @@ def test_dandiset_rest_create(api_client, user):
             'asset_count': 0,
             'active_uploads': 0,
             'size': 0,
-            'dandiset': {
-                'identifier': DANDISET_ID_RE,
-                'created': TIMESTAMP_RE,
-                'modified': TIMESTAMP_RE,
-                'contact_person': 'Doe, John',
-                'embargo_status': 'OPEN',
-            },
             'status': 'Pending',
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
@@ -454,13 +447,6 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
             'asset_count': 0,
             'active_uploads': 0,
             'size': 0,
-            'dandiset': {
-                'identifier': identifier,
-                'created': TIMESTAMP_RE,
-                'modified': TIMESTAMP_RE,
-                'contact_person': 'Doe, John',
-                'embargo_status': 'OPEN',
-            },
             'status': 'Pending',
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
@@ -562,13 +548,6 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
             'asset_count': 0,
             'active_uploads': 0,
             'size': 0,
-            'dandiset': {
-                'identifier': identifier,
-                'created': TIMESTAMP_RE,
-                'modified': TIMESTAMP_RE,
-                'contact_person': 'Jane Doe',
-                'embargo_status': 'OPEN',
-            },
             'status': 'Pending',
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
@@ -653,13 +632,6 @@ def test_dandiset_rest_create_embargoed(api_client, user):
             'asset_count': 0,
             'active_uploads': 0,
             'size': 0,
-            'dandiset': {
-                'identifier': DANDISET_ID_RE,
-                'created': TIMESTAMP_RE,
-                'modified': TIMESTAMP_RE,
-                'contact_person': 'Doe, John',
-                'embargo_status': 'EMBARGOED',
-            },
             'status': 'Pending',
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
@@ -1115,7 +1087,7 @@ def test_dandiset_contact_person_malformed_contributors(api_client, draft_versio
         f'/api/dandisets/{draft_version.dandiset.identifier}/',
     )
 
-    assert results.data['draft_version']['dandiset']['contact_person'] == ''
+    assert results.data['contact_person'] == ''
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -100,6 +100,12 @@ class VersionSerializer(serializers.ModelSerializer):
     dandiset = DandisetSerializer()
     # name = serializers.SlugRelatedField(read_only=True, slug_field='name')
 
+    def __init__(self, *args, child_context=False, **kwargs):
+        if child_context:
+            del self.fields['dandiset']
+
+        super().__init__(*args, **kwargs)
+
 
 class DandisetVersionSerializer(serializers.ModelSerializer):
     """The version serializer nested within the Dandiset Serializer."""
@@ -174,8 +180,8 @@ class DandisetDetailSerializer(DandisetSerializer):
     class Meta(DandisetSerializer.Meta):
         fields = [*DandisetSerializer.Meta.fields, 'most_recent_published_version', 'draft_version']
 
-    most_recent_published_version = VersionSerializer(read_only=True)
-    draft_version = VersionSerializer(read_only=True)
+    most_recent_published_version = VersionSerializer(read_only=True, child_context=True)
+    draft_version = VersionSerializer(read_only=True, child_context=True)
 
 
 class DandisetQueryParameterSerializer(serializers.Serializer):


### PR DESCRIPTION
On any endpoint that used `DandisetDetailSerializer` for its response, the dandiset information was being included twice. Once at the top level, and once nested under each nested version serializer (`draft_version` and `most_recent_published_version`).