### PR TITLE
Fix reactivity bug in meditor

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <Meditor v-if="currentDandiset" />
+    <Meditor v-if="currentDandiset" :key="`${currentDandiset.dandiset.identifier}/${currentDandiset.version}`" />
     <v-toolbar class="grey darken-2 white--text">
       <DandisetSearchField />
       <v-pagination


### PR DESCRIPTION
Fixes #2081

This PR adds a `key` to the `Meditor` component consisting of the currently selected dandiset identifier and version. This will result in the meditor re-rendering when the user selects a new version, fixing the issue in #2081.

I initially attempted to fix this by making the `editorInterface` variable properly reactive (https://github.com/dandi/dandi-archive/commit/62f2bb2ce2bb01858331a050197bd4486fd76f7b), but that ended up breaking a bunch of other things in the meditor. Eventually after fixing a long trail of new bugs, I ran into this issue again https://github.com/dandi/dandi-archive/blob/master/web/src/components/Meditor/state.ts#L4-L7 and got stuck.

I think this code could use a refactor to be less brittle and fix whatever bizarre reactivity bug is going on with the `editorInterface` state, but this simple solution will fix the critical bug for the time being.