### PR TITLE
Add Netlify link to footer

### DIFF
--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -51,6 +51,14 @@
             mdi-open-in-new
           </v-icon>
           <br>
+          - <a
+            target="_blank"
+            rel="noopener"
+            href="https://netlify.com"
+          >This site is powered by Netlify</a>
+          <v-icon x-small>
+            mdi-open-in-new
+          </v-icon>
         </v-col>
         <v-col>
           Support:<br>
@@ -77,7 +85,7 @@
           >Issues</a>
           <v-icon x-small>
             mdi-open-in-new
-          </v-icon>
+          </v-icon>        
         </v-col>
       </v-row>
     </v-container>

--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -85,7 +85,7 @@
           >Issues</a>
           <v-icon x-small>
             mdi-open-in-new
-          </v-icon>        
+          </v-icon>
         </v-col>
       </v-row>
     </v-container>


### PR DESCRIPTION
For context, please see https://github.com/dandi/dandi-archive/pull/2130#issue-2771594956.

I will be applying for the [Netlify sponsored open-source plan](https://www.netlify.com/legal/open-source-policy/) for LINC and DANDI. They require a link to netlify.com on the project homepage and a code of conduct, which I have included in this pull request.