### PR TITLE
Rename `The DANDI Team` to `DANDI` in footer

### DIFF
--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -15,7 +15,7 @@
       </cookie-law>
       <v-row>
         <v-col offset="2">
-          &copy; 2019 - 2024 The DANDI Team<br>
+          &copy; 2019 - 2024 DANDI<br>
           version
           <a
             class="version-link"


### PR DESCRIPTION
If I understand correctly, `The DANDI Team`, `DANDI`, and `DANDI Archive` are synonyms in this context so I suggest this minor change to simplify the text.