### PR TITLE
Check if dandiset contains zarr assets using asset list endpoint

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -431,6 +431,11 @@ class NestedAssetViewSet(NestedViewSetMixin, AssetViewSet, ReadOnlyModelViewSet)
         # Apply filtering from included filter class first
         asset_queryset = self.filter_queryset(version.assets.all())
 
+        # Filter query to only zarr assets, if requested
+        zarr_only = serializer.validated_data['zarr']
+        if zarr_only:
+            asset_queryset = asset_queryset.filter(zarr__isnull=False)
+
         # Must do glob pattern matching before pagination
         glob_pattern: str | None = serializer.validated_data.get('glob')
         if glob_pattern is not None:

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -373,6 +373,7 @@ class AssetDetailSerializer(AssetSerializer):
 class AssetListSerializer(serializers.Serializer):
     glob = serializers.CharField(required=False)
     metadata = serializers.BooleanField(required=False, default=False)
+    zarr = serializers.BooleanField(required=False, default=False)
 
 
 class AssetPathsQueryParameterSerializer(serializers.Serializer):

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -313,7 +313,7 @@ watchEffect(async () => {
       { params: { zarr: true, page_size: 1 } },
     );
 
-    containsZarr.value = res.count > 0;
+    containsZarr.value = res !== null && res.count > 0;
   }
 });
 

--- a/web/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/web/src/views/DandisetLandingView/DandisetPublish.vue
@@ -305,11 +305,15 @@ const alreadyBeingPublishedError = ref(false);
 const containsZarr = ref(false);
 watchEffect(async () => {
   if (currentDandiset.value) {
-    const zarr = await dandiRest.zarr({
-      dandiset: currentDandiset.value.dandiset.identifier,
-    });
+    const { identifier } = currentDandiset.value.dandiset;
+    const { version } = currentDandiset.value;
+    const res = await dandiRest.assets(
+      identifier,
+      version,
+      { params: { zarr: true, page_size: 1 } },
+    );
 
-    containsZarr.value = zarr.count > 0;
+    containsZarr.value = res.count > 0;
   }
 });
 


### PR DESCRIPTION
Closes #2149

This PR adds a simple `zarr` boolean query param to the `/assets` endpoint, and updates the client to use that endpoint when checking for zarrs in a dandiset (to prevent publishing of zarrs).