### PR TITLE
Fix dandiset ordering icons, default to descending

### DIFF
--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -51,11 +51,11 @@
         >
           {{ option.name }}
           <v-icon right>
-            <template v-if="sortDir === 1 || sortOption !== i">
-              mdi-sort-ascending
+            <template v-if="sortDir === -1 || sortOption !== i">
+              mdi-sort-variant
             </template>
             <template v-else>
-              mdi-sort-descending
+              mdi-sort-reverse-variant
             </template>
           </v-icon>
         </v-chip>
@@ -204,7 +204,7 @@ export default defineComponent({
         sortDir.value *= -1;
       } else {
         sortOption.value = index;
-        sortDir.value = 1;
+        sortDir.value = -1;
       }
 
       page.value = 1;


### PR DESCRIPTION
The existing icons for sorting on any dandiset list page is backwards of what you'd expect (arrow pointing up is actually "descending"). This PR fixes that.