### PR TITLE
Boost us back to 2025 in the footer after having it lost during merge conflict resolving

### DIFF
--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -15,12 +15,12 @@
       </cookie-law>
       <v-row>
         <v-col offset="2">
-          &copy; 2019 - 2024 The DANDI Team<br>
+          &copy; 2019 - 2025 The DANDI Team<br>
           <a
             target="_blank"
             rel="noopener"
             href="https://docs.dandiarchive.org/about/terms/"
-          >Terms</a> 
+          >Terms</a>
           <v-icon x-small>
             mdi-open-in-new
           </v-icon> / <a


### PR DESCRIPTION
I felt odd when saw 2024 back online, while seeing #2144 merged and released.  It also took a bit to track it down since apparently `git log -p` does not show merges, and here I believe it happened in #2135 while resolving conflict merges in 700abad2c5f3ae28cb32ce8bc1099a3501347c5d .

See

    git diff 700abad2c5f3ae28cb32ce8bc1099a3501347c5d^2..700abad2c5f3ae28cb32ce8bc1099a3501347c5d -- web/src/components/DandiFooter.vue

To at least partially assist and annotate merges which were problematic and how, I have in my `~/.gitconfig`

```
[merge]
    summary = true
    log = true
```

and then when I do merge locally I get commented out section listing conflicted files, which I uncomment and add description on why conflict and how was handled. See e.g. https://github.com/dandi/dandi-cli/commit/19488660676cd9585feb9442918a0a2802b51f6d .  Might be worth adopting IMHO.

Also this commit/PR includes auto-removal of useless trailing spaces done by pre-commit to that file

    [INFO] This may take a few minutes...
    trim trailing whitespace.................................................Failed
    - hook id: trailing-whitespace
    - exit code: 1
    - files were modified by this hook

    Fixing web/src/components/DandiFooter.vue

@kabilar do you have pre-commit enabled for your local clone?