### PR TITLE
Adjust Neurosift external URLs for v2 of Neurosift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.4.19
+
+#### 🐛 Bug Fix
+
+- Adjust neurosift external urls for dandisets and nwb files
+
+#### Authors: 1
+
+- Jeremy Magland ([@magland](https://github.com/magland))
+
 # v0.4.18 (Fri Feb 07 2025)
 
 #### 🐛 Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,3 @@
-# v0.4.19
-
-#### 🐛 Bug Fix
-
-- Adjust neurosift external urls for dandisets and nwb files
-
-#### Authors: 1
-
-- Jeremy Magland ([@magland](https://github.com/magland))
-
 # v0.4.18 (Fri Feb 07 2025)
 
 #### 🐛 Bug Fix

--- a/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
+++ b/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
@@ -84,7 +84,7 @@ const neurosiftURL = computed(() => {
   const dandisetVersion = metadata.version;
   const stagingParam = metadata.url!.startsWith('https://gui-staging.dandiarchive.org/') ? '&staging=1' : '';
 
-  return `https://neurosift.app/dandiset?dandisetId=${dandisetId}&dandisetVersion=${dandisetVersion}${stagingParam}`;
+  return `https://neurosift.app/dandiset/${dandisetId}?dandisetVersion=${dandisetVersion}${stagingParam}`;
 });
 
 </script>

--- a/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
+++ b/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
@@ -84,7 +84,7 @@ const neurosiftURL = computed(() => {
   const dandisetVersion = metadata.version;
   const stagingParam = metadata.url!.startsWith('https://gui-staging.dandiarchive.org/') ? '&staging=1' : '';
 
-  return `https://neurosift.app/?p=/dandiset&dandisetId=${dandisetId}&dandisetVersion=${dandisetVersion}${stagingParam}`;
+  return `https://neurosift.app/dandiset?dandisetId=${dandisetId}&dandisetVersion=${dandisetVersion}${stagingParam}`;
 });
 
 </script>

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -349,21 +349,21 @@ const EXTERNAL_SERVICES = [
     name: 'Neurosift',
     regex: /\.nwb$/,
     maxsize: Infinity,
-    endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
+    endpoint: 'https://neurosift.app/nwb?url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
   },
 
   {
     name: 'Neurosift',
     regex: /\.nwb\.lindi\.(json|tar)$/,
     maxsize: Infinity,
-    endpoint: 'https://neurosift.app?p=/nwb&url=$asset_dandi_url$&st=lindi&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
+    endpoint: 'https://neurosift.app/nwb?url=$asset_dandi_url$&st=lindi&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
   },
 
   {
     name: 'Neurosift',
     regex: /\.avi$/,
     maxsize: Infinity,
-    endpoint: 'https://neurosift.app?p=/avi&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
+    endpoint: 'https://v1.neurosift.app?p=/avi&url=$asset_dandi_url$&dandisetId=$dandiset_id$&dandisetVersion=$dandiset_version$', // eslint-disable-line max-len
   }
 ];
 type Service = typeof EXTERNAL_SERVICES[0];


### PR DESCRIPTION
Neurosift has been updated to v2, and with this update, the URL specification has changed slightly. The old URLs still work, but they redirect to the new ones. It would be best to have DANDI use the new URL scheme for the external links.

For example, for a dandiset:

old:
https://neurosift.app/?p=/dandiset&dandisetId=001335&dandisetVersion=draft

new:
https://neurosift.app/dandiset/001335?dandisetVersion=draft

And for an NWB file:

old:
https://neurosift.app/?p=/nwb&url=https://api.dandiarchive.org/api/assets/7d5046f1-12b5-4b88-9ccf-9e738f265652/download/&dandisetId=000409&dandisetVersion=draft

new:
https://neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/7d5046f1-12b5-4b88-9ccf-9e738f265652/download/&dandisetId=000409&dandisetVersion=draft

For an AVI file, this is not (yet) supported in v2, so we should direct this to v1 explicitly like this:

old:
https://neurosift.app?p=/avi...

new
https://v1.neurosift/avi?...

(I don't have an example for that one at my fingertips)