### PR TITLE
Set default values for optional DandiError fields

### DIFF
--- a/dandiapi/api/services/exceptions.py
+++ b/dandiapi/api/services/exceptions.py
@@ -4,8 +4,8 @@ from rest_framework import status
 
 
 class DandiError(Exception):
-    message: str | None
-    http_status_code: int | None
+    message: str | None = None
+    http_status_code: int | None = None
 
     def __init__(
         self, message: str | None = None, http_status_code: int | None = None, *args: object


### PR DESCRIPTION
Currently, if no values are provided for these fields when subclassed, an exception is raised here, due to the values not being set at all:

https://github.com/dandi/dandi-archive/blob/830f034fcb6d7f912b4d7f0d11d366143c9e3219/dandiapi/api/services/exceptions.py#L13

Since these field are optional (union-ed with `None`), this PR simply sets those values to `None` as a default.