### PR TITLE
Allow robots on web frontend, besides /dandiset/

### DIFF
--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /
+Disallow: /dandiset/


### PR DESCRIPTION
I left api still with full Disallow, as it was the original concern here in #1272. It was unclear though on how it got to API -- via web UI or just somehow traversing api interfaces?

Original intent here -- is to make google "see" our website. 
- Hopefully closes #2199