### PR TITLE
Add search query parameter to dandiset list endpoint serializer

### DIFF
--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -223,6 +223,10 @@ class DandisetQueryParameterSerializer(serializers.Serializer):
         help_text='Whether to filter the result to only dandisets'
         ' that have been starred by the current user.',
     )
+    search = serializers.CharField(
+        required=False,
+        help_text='Search terms to filter the results.',
+    )
 
 
 class DandisetSearchQueryParameterSerializer(DandisetQueryParameterSerializer):


### PR DESCRIPTION
Despite the fact that the `/dandisets` endpoint accepts a query parameter `search` that is used to filter by the search terms, the parameter is not listed in the input serializer, and thus does not show up in the Swagger docs.

I built and tested this locally and it seems to work as expected.

Fixed #2214.