### PR TITLE
Remove quotes on DANDI_ADMIN_EMAIL env var

### DIFF
--- a/dev/.env.docker-compose
+++ b/dev/.env.docker-compose
@@ -12,6 +12,6 @@ DJANGO_DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME=dandiapi-embargo-dandisets-logs
 DJANGO_DANDI_WEB_APP_URL=http://localhost:8085
 DJANGO_DANDI_API_URL=http://localhost:8000
 DJANGO_DANDI_JUPYTERHUB_URL=https://hub.dandiarchive.org/
-DJANGO_DANDI_ADMIN_EMAIL="admin@test.mail"
+DJANGO_DANDI_ADMIN_EMAIL=admin@test.mail
 DJANGO_DANDI_DEV_EMAIL=test@example.com
 DANDI_ALLOW_LOCALHOST_URLS=1

--- a/dev/.env.docker-compose-native
+++ b/dev/.env.docker-compose-native
@@ -12,6 +12,6 @@ DJANGO_DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME=dandiapi-embargo-dandisets-logs
 DJANGO_DANDI_WEB_APP_URL=http://localhost:8085
 DJANGO_DANDI_API_URL=http://localhost:8000
 DJANGO_DANDI_JUPYTERHUB_URL=https://hub.dandiarchive.org/
-DJANGO_DANDI_ADMIN_EMAIL="admin@test.mail"
+DJANGO_DANDI_ADMIN_EMAIL=admin@test.mail
 DJANGO_DANDI_DEV_EMAIL=test@example.com
 DANDI_ALLOW_LOCALHOST_URLS=1


### PR DESCRIPTION
Following from #2205, it seems the values supplied in the dev `.env` files contain quotes around them, which could cause errors when running the app locally, depending on the local environment. This is the only place this quoting occurs, which is why CI doesn't catch it.