### PR TITLE
Add Netlify configuration for branch deploys

### DIFF
--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -23,6 +23,16 @@ VITE_APP_DOI_SERVER = "https://handle.stage.datacite.org/"
 VITE_APP_SENTRY_DSN = "https://425b9a012300493d867e97785fae7b88@o308436.ingest.sentry.io/5196549"
 VITE_APP_SENTRY_ENVIRONMENT = "staging"
 
+# Branch deploys
+[context.branch-deploy.environment]
+NODE_VERSION = "20"
+VITE_APP_OAUTH_API_ROOT = "https://api-staging.dandiarchive.org/oauth/"
+VITE_APP_OAUTH_CLIENT_ID = "Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl"
+VITE_APP_DANDI_API_ROOT = "https://api-staging.dandiarchive.org/api/"
+VITE_APP_DOI_SERVER = "https://handle.stage.datacite.org/"
+VITE_APP_SENTRY_DSN = "https://425b9a012300493d867e97785fae7b88@o308436.ingest.sentry.io/5196549"
+VITE_APP_SENTRY_ENVIRONMENT = "staging"
+
 # Production
 [context.release.environment]
 NODE_VERSION = "20"


### PR DESCRIPTION
This adds a configuration block for use with [branch deploys](https://docs.netlify.com/site-deploys/overview/#branch-deploys-versus-deploy-previews). We don't have any branch deploys set up now, but they have been useful in the past (e.g., during development of #2212).

The configuration is identical to that of deploy previews.