### PR TITLE
Fix a case where draft asset summaries could become stale

### DIFF
--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -171,6 +171,9 @@ def _publish_dandiset(dandiset_id: int, user_id: int) -> None:
         # Add asset paths with new version
         add_version_asset_paths(version=new_version)
 
+        # Copy the finalized assetsSummary to the draft version in case it wasn't up to date
+        # before starting the publish.
+        old_version.metadata['assetsSummary'] = new_version.metadata['assetsSummary']
         # Set the version of the draft to PUBLISHED so that it cannot be published again without
         # being modified and revalidated
         old_version.status = Version.Status.PUBLISHED

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -371,6 +371,23 @@ def test_version_aggregate_assets_summary(draft_version_factory, draft_asset_fac
 
 
 @pytest.mark.django_db
+def test_version_publish_updates_draft_version_assets_summary(
+    draft_version_factory, draft_asset_factory, user
+):
+    version = draft_version_factory(status=Version.Status.PUBLISHING)
+    asset = draft_asset_factory(status=Asset.Status.VALID)
+    version.assets.add(asset)
+
+    tasks.publish_dandiset_task(version.dandiset.id, user.id)
+
+    version.refresh_from_db()
+    draft_asset_summary = version.metadata['assetsSummary']
+    published_asset_summary = Version.objects.latest('created').metadata['assetsSummary']
+
+    assert published_asset_summary == draft_asset_summary
+
+
+@pytest.mark.django_db
 def test_version_aggregate_assets_summary_metadata_modified(
     draft_version_factory, draft_asset_factory
 ):


### PR DESCRIPTION
There's an edge case where assets can be uploaded and the dandiset can transition into publishing before an appropriate asset summary for the draft version is computed. When generating the asset summary for the published version it can be copied to the draft to ensure the draft asset summary is always eventually correct.