### PR TITLE
Remove TODO for locking zarr finalizing

### DIFF
--- a/dandiapi/zarr/views/__init__.py
+++ b/dandiapi/zarr/views/__init__.py
@@ -180,7 +180,6 @@ class ZarrViewSet(ReadOnlyModelViewSet):
     @action(methods=['POST'], url_path='finalize', detail=True)
     def finalize(self, request, zarr_id):
         """Finalize a zarr archive."""
-        # TODO: Remove locking?
         queryset = self.get_queryset().select_for_update(of=['self'])
         with transaction.atomic():
             zarr_archive: ZarrArchive = get_object_or_404(queryset, zarr_id=zarr_id)


### PR DESCRIPTION
This needs to lock, otherwise an ingestion could trigger in between fetching the zarr object and changing it to UPLOADED.