### PR TITLE
Convert remaining Vue components to `<script setup>` syntax

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -34,6 +34,10 @@ export default [
       ],
       'vue/multi-word-component-names': 'off',
       "@typescript-eslint/no-explicit-any": 'off',
+      "vue/component-api-style": ["error",
+        // Only allow `script-setup` for Vue components
+        ["script-setup"]
+      ],
     }
   }
 ]

--- a/web/src/components/DLP/AccessInformationTab.vue
+++ b/web/src/components/DLP/AccessInformationTab.vue
@@ -4,26 +4,15 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  name: 'AccessInformationTab',
-  components: {
+<script setup lang="ts">
+defineProps({
+  schema: {
+    type: Object,
+    required: true,
   },
-  props: {
-    schema: {
-      type: Object,
-      required: true,
-    },
-    meta: {
-      type: Object,
-      required: true,
-    },
-  },
-  setup() {
-    return {
-    };
+  meta: {
+    type: Object,
+    required: true,
   },
 });
 </script>

--- a/web/src/components/DLP/AssetSummaryTab.vue
+++ b/web/src/components/DLP/AssetSummaryTab.vue
@@ -4,26 +4,15 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  name: 'AssetSummaryTab',
-  components: {
+<script setup lang="ts">
+defineProps({
+  schema: {
+    type: Object,
+    required: true,
   },
-  props: {
-    schema: {
-      type: Object,
-      required: true,
-    },
-    meta: {
-      type: Object,
-      required: true,
-    },
-  },
-  setup() {
-    return {
-    };
+  meta: {
+    type: Object,
+    required: true,
   },
 });
 </script>

--- a/web/src/components/DLP/ContributorsTab.vue
+++ b/web/src/components/DLP/ContributorsTab.vue
@@ -4,26 +4,15 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  name: 'ContributorsTab',
-  components: {
+<script setup lang="ts">
+defineProps({
+  schema: {
+    type: Object,
+    required: true,
   },
-  props: {
-    schema: {
-      type: Object,
-      required: true,
-    },
-    meta: {
-      type: Object,
-      required: true,
-    },
-  },
-  setup() {
-    return {
-    };
+  meta: {
+    type: Object,
+    required: true,
   },
 });
 </script>

--- a/web/src/components/DLP/MetadataCard.vue
+++ b/web/src/components/DLP/MetadataCard.vue
@@ -69,49 +69,44 @@
   </v-card>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import type { PropType } from 'vue';
-import { computed, defineComponent } from 'vue';
+import { computed } from 'vue';
 import { useDisplay, useTheme } from 'vuetify';
 
 // The maximum amount of columns to show on a metadata card,
 // regardless of how many entries there are.
 const MAX_COLUMNS = 4;
 
-export default defineComponent({
-  name: 'MetadataCard',
-  props: {
-    backgroundColor: {
-      type: String,
-      default: 'white',
-    },
-    items: {
-      type: Array as PropType<any[]>,
-      required: true,
-    },
-    name: {
-      type: String,
-      required: true,
-    },
-    icon: {
-      type: String,
-      required: true,
-    },
+
+const props = defineProps({
+  backgroundColor: {
+    type: String,
+    default: 'white',
   },
-  setup(props) {
-    const theme = useTheme();
-    const display = useDisplay();
-
-    const borderLeftColor = computed(() => theme.current.value.colors.primary);
-
-    // Try to estimate the ideal number of columns to break the items into.
-    // When viewing on a smaller screen, force the number of columns to 1.
-    const columnCount = computed(
-      () => (display.mdAndDown.value
-        ? 1 : Math.min(Math.ceil(props.items.length / 2), MAX_COLUMNS)),
-    );
-
-    return { borderLeftColor, columnCount };
+  items: {
+    type: Array as PropType<any[]>,
+    required: true,
+  },
+  name: {
+    type: String,
+    required: true,
+  },
+  icon: {
+    type: String,
+    required: true,
   },
 });
+
+const theme = useTheme();
+const display = useDisplay();
+
+const borderLeftColor = computed(() => theme.current.value.colors.primary);
+
+// Try to estimate the ideal number of columns to break the items into.
+// When viewing on a smaller screen, force the number of columns to 1.
+const columnCount = computed(
+  () => (display.mdAndDown.value
+    ? 1 : Math.min(Math.ceil(props.items.length / 2), MAX_COLUMNS)),
+);
 </script>

--- a/web/src/components/DLP/RelatedResourcesTab.vue
+++ b/web/src/components/DLP/RelatedResourcesTab.vue
@@ -4,26 +4,15 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  name: 'RelatedResourcesTab',
-  components: {
+<script setup lang="ts">
+defineProps({
+  schema: {
+    type: Object,
+    required: true,
   },
-  props: {
-    schema: {
-      type: Object,
-      required: true,
-    },
-    meta: {
-      type: Object,
-      required: true,
-    },
-  },
-  setup() {
-    return {
-    };
+  meta: {
+    type: Object,
+    required: true,
   },
 });
 </script>

--- a/web/src/components/DLP/SubjectMatterTab.vue
+++ b/web/src/components/DLP/SubjectMatterTab.vue
@@ -4,26 +4,15 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  name: 'SubjectMatterTab',
-  components: {
+<script setup lang="ts">
+defineProps({
+  schema: {
+    type: Object,
+    required: true,
   },
-  props: {
-    schema: {
-      type: Object,
-      required: true,
-    },
-    meta: {
-      type: Object,
-      required: true,
-    },
-  },
-  setup() {
-    return {
-    };
+  meta: {
+    type: Object,
+    required: true,
   },
 });
 </script>

--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -99,7 +99,6 @@
 
 <script setup lang="ts">
 import CookieBanner from './CookieBanner.vue';
-import { cookiesEnabled } from '@/rest';
 
 const version = import.meta.env.VITE_APP_VERSION;
 const githubLink = import.meta.env.VITE_APP_GIT_REVISION ? `https://github.com/dandi/dandi-archive/commit/${import.meta.env.VITE_APP_GIT_REVISION}` : 'https://github.com/dandi/dandi-archive';

--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -97,28 +97,12 @@
   </v-footer>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-
+<script setup lang="ts">
 import CookieBanner from './CookieBanner.vue';
 import { cookiesEnabled } from '@/rest';
 
 const version = import.meta.env.VITE_APP_VERSION;
 const githubLink = import.meta.env.VITE_APP_GIT_REVISION ? `https://github.com/dandi/dandi-archive/commit/${import.meta.env.VITE_APP_GIT_REVISION}` : 'https://github.com/dandi/dandi-archive';
-
-export default defineComponent({
-  name: 'DandiFooter',
-  components: {
-    CookieBanner,
-  },
-  setup() {
-    return {
-      version,
-      githubLink,
-      cookiesEnabled,
-    };
-  },
-});
 </script>
 
 <style scoped>

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -80,7 +80,6 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import moment from 'moment';
 import { filesize } from 'filesize';
@@ -98,10 +97,6 @@ defineProps({
 
 const route = useRoute();
 
-const origin = computed(() => {
-  const { name, params, query } = route;
-  return { name, params, query };
-});
 // current position in search result set = items on prev pages + position on current page
 function getPos(index: number) {
   return (Number(route.query.page || 1) - 1) * DANDISETS_PER_PAGE + (index + 1);

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -78,9 +78,9 @@
   </v-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import type { PropType } from 'vue';
-import { defineComponent, computed } from 'vue';
+import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import moment from 'moment';
 import { filesize } from 'filesize';
@@ -89,41 +89,26 @@ import StarButton from '@/components/StarButton.vue';
 import type { Version } from '@/types';
 import { DANDISETS_PER_PAGE } from '@/utils/constants';
 
-export default defineComponent({
-  name: 'DandisetList',
-  components: {
-    StarButton,
-  },
-  props: {
-    dandisets: {
-      type: Array as PropType<Version[]>,
-      required: true,
-    },
-  },
-  setup() {
-    const route = useRoute();
-
-    const origin = computed(() => {
-      const { name, params, query } = route;
-      return { name, params, query };
-    });
-    // current position in search result set = items on prev pages + position on current page
-    function getPos(index: number) {
-      return (Number(route.query.page || 1) - 1) * DANDISETS_PER_PAGE + (index + 1);
-    }
-    function formatDate(date: string) {
-      return moment(date).format('LL');
-    }
-
-    return {
-      origin,
-      formatDate,
-      getPos,
-      // Returned imports
-      filesize,
-    };
+defineProps({
+  dandisets: {
+    type: Array as PropType<Version[]>,
+    required: true,
   },
 });
+
+const route = useRoute();
+
+const origin = computed(() => {
+  const { name, params, query } = route;
+  return { name, params, query };
+});
+// current position in search result set = items on prev pages + position on current page
+function getPos(index: number) {
+  return (Number(route.query.page || 1) - 1) * DANDISETS_PER_PAGE + (index + 1);
+}
+function formatDate(date: string) {
+  return moment(date).format('LL');
+}
 </script>
 
 <style scoped>

--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -22,59 +22,49 @@
   </v-form>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref } from 'vue';
+<script setup lang="ts">
+import { ref } from 'vue';
 import type { RouteLocationRaw } from 'vue-router';
 import { useRoute } from 'vue-router';
 import router from '@/router';
 
-export default defineComponent({
-  name: 'DandisetSearchField',
-  props: {
-    dense: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-  },
-  setup() {
-    const route = useRoute();
-    const currentSearch = ref(route.query.search || '');
-
-    function updateSearch(search: string) {
-      currentSearch.value = search;
-    }
-
-    function performSearch(evt: Event) {
-      evt.preventDefault(); // prevent form submission from refreshing page
-
-      if (currentSearch.value === route.query.search) {
-        // nothing has changed, do nothing
-        return;
-      }
-      if (route.name !== 'searchDandisets') {
-        router.push({
-          name: 'searchDandisets',
-          query: {
-            search: currentSearch.value,
-          },
-        });
-      } else {
-        router.replace({
-          ...route,
-          query: {
-            ...route.query,
-            search: currentSearch.value,
-          },
-        } as RouteLocationRaw);
-      }
-    }
-
-    return {
-      currentSearch,
-      updateSearch,
-      performSearch,
-    };
+defineProps({
+  dense: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
 });
+
+const route = useRoute();
+const currentSearch = ref(route.query.search || '');
+
+function updateSearch(search: string) {
+  currentSearch.value = search;
+}
+
+function performSearch(evt: Event) {
+  evt.preventDefault(); // prevent form submission from refreshing page
+
+  if (currentSearch.value === route.query.search) {
+    // nothing has changed, do nothing
+    return;
+  }
+  if (route.name !== 'searchDandisets') {
+    router.push({
+      name: 'searchDandisets',
+      query: {
+        search: currentSearch.value,
+      },
+    });
+  } else {
+    router.replace({
+      ...route,
+      query: {
+        ...route.query,
+        search: currentSearch.value,
+      },
+    } as RouteLocationRaw);
+  }
+}
 </script>

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-page-title="pageTitle">
     <v-toolbar
       color="grey-darken-2"
       class="px-4"

--- a/web/src/views/DandisetLandingView/DandisetSidebar.vue
+++ b/web/src/views/DandisetLandingView/DandisetSidebar.vue
@@ -16,10 +16,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import {
-  defineComponent, computed,
-} from 'vue';
+<script setup lang="ts">
+import { computed } from 'vue';
 
 import { useDandisetStore } from '@/stores/dandiset';
 import type { Version } from '@/types';
@@ -29,35 +27,19 @@ import DandisetOwners from './DandisetOwners.vue';
 import DandisetPublish from './DandisetPublish.vue';
 import DandisetUnembargo from './DandisetUnembargo.vue';
 
-export default defineComponent({
-  name: 'DandisetSidebar',
-  components: {
-    DandisetActions,
-    DandisetOwners,
-    DandisetPublish,
-    DandisetUnembargo,
+defineProps({
+  userCanModifyDandiset: {
+    type: Boolean,
+    required: true,
   },
-  props: {
-    userCanModifyDandiset: {
-      type: Boolean,
-      required: true,
-    },
-  },
-  setup() {
-    const store = useDandisetStore();
+})
 
-    const currentDandiset = computed(() => store.dandiset);
-    const currentVersion = computed(() => store.version);
+const store = useDandisetStore();
 
-    const otherVersions = computed(() => store.versions?.filter(
-      (version: Version) => version.version !== currentVersion.value,
-    ));
+const currentDandiset = computed(() => store.dandiset);
+const currentVersion = computed(() => store.version);
 
-    return {
-      currentDandiset,
-      currentVersion,
-      otherVersions,
-    };
-  },
-});
+const otherVersions = computed(() => store.versions?.filter(
+  (version: Version) => version.version !== currentVersion.value,
+));
 </script>

--- a/web/src/views/DandisetLandingView/DandisetSidebar.vue
+++ b/web/src/views/DandisetLandingView/DandisetSidebar.vue
@@ -20,7 +20,6 @@
 import { computed } from 'vue';
 
 import { useDandisetStore } from '@/stores/dandiset';
-import type { Version } from '@/types';
 
 import DandisetActions from './DandisetActions.vue';
 import DandisetOwners from './DandisetOwners.vue';
@@ -37,9 +36,4 @@ defineProps({
 const store = useDandisetStore();
 
 const currentDandiset = computed(() => store.dandiset);
-const currentVersion = computed(() => store.version);
-
-const otherVersions = computed(() => store.versions?.filter(
-  (version: Version) => version.version !== currentVersion.value,
-));
 </script>


### PR DESCRIPTION
All of our Vue components have been converted to TS/Composition API, but not all of them use `script setup`. 
This PR updates all those outstanding components, and also cleans up some unused variables that got detected by the better static analysis tooling that comes along with using `script setup`.