### PR TITLE
Remove gossip and mingling from Celery workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -6,8 +6,8 @@ web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi --timeout 25
 # This is OK for now because of how lightweight all high priority tasks currently are,
 # but we may need to switch back to a dedicated worker in the future.
 # The queue `celery` is the default queue.
-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B
+worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B --without-gossip --without-mingle
 # The checksum-worker calculates blob checksums and updates zarr checksum files
-checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256,ingest_zarr_archive
+checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256,ingest_zarr_archive --without-gossip --without-mingle
 # The analytics-worker processes s3 log files serially
-analytics-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --concurrency 1 -Q s3-log-processing
+analytics-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --concurrency 1 -Q s3-log-processing --without-gossip --without-mingle


### PR DESCRIPTION
Stemming from behavior in @sandyhider 's work on EMBER Archive (a clone of DANDI Archive), their respective CloudAMQP instance quickly hits capacity

Similar behavior has been observed in LINC (Cc @kabilar )

From Sandy's correspondence with CloudAMQP support staff, a suggestion was received to disable gossip and mingling.

**Why can we not see current gossip and mingling:**

Current, our `Procfile` has --log-level at `INFO` -- gossip and mingling are only expressed at the `DEBUG` level

**Do we need mingling in DANDI Archive**

No -- `mingling` is meant to handle celery workers that have tasks defined in differing code bases. Our celery tasks are all prescribed in the same static codde

**Do we need gossip in DANDI Archive**

No -- gossip enables Celery workers to broadcast and listen to events (used for things like remote control, celery events, and dashboards like Flower).

Our Celery setup is primarily producer/consumer within a single deployment, so there’s no need for this cross-worker coordination.

This PR includes the appropriate flags to disable Celery functionality that does not seem integral, and should prevent bloat of our message broker

Cc @yarikoptic @satra 