### PR TITLE
Don't suppress exceptions when fetching schema/logging in

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -70,17 +70,19 @@ watchEffect(() => {
 });
 
 
-onMounted(() => {
-  Promise.all([
-    store.fetchSchema(),
-    dandiRest.restoreLogin(),
-  ]).then(() => {
+onMounted(async () => {
+  try {
+    await Promise.all([
+      store.fetchSchema(),
+      dandiRest.restoreLogin(),
+    ]);
     connectedToServer.value = true;
-  }).catch(() => {
+  } catch (err) {
     connectedToServer.value = false;
-  }).finally(() => {
+    throw err;
+  } finally {
     verifiedServerConnection.value = true;
-  });
+  }
 });
 </script>
 


### PR DESCRIPTION
Currently, we explicitly catch any javascript exceptions that occur during (1) fetching of the schema and (2) refreshing the user's oauth login. We do this so that we can set a boolean that causes the "Connection to server failed" string to get rendered in case the API request fails (or, github.com in the case of the schema fetching). However, we never re-raise the exception after catching it, so it is effectively suppressed and does not propagate to Sentry.
