### PR TITLE
Fix "View asset metadata" link

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -194,8 +194,8 @@
                           :href="assetMetadataURI(item.asset.asset_id)"
                           target="_blank"
                           rel="noreferrer"
-
                           v-bind="infoProps"
+                          @click.stop
                         >
                           <v-icon color="primary">
                             mdi-information


### PR DESCRIPTION
Fixes #2256

The issue was that the click event on the `v-btn` (line 191) was propagating up to the parent `v-list-item` (line 117), and causing `openItem` to get called which resulted in the page transition instead of opening a new tab.