### PR TITLE
Remove text prop from v-list-item

### DIFF
--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -25,15 +25,17 @@
               </v-list-item-title>
             </template>
             <template v-if="navItem.external">
-              <v-list-item-title class="text-md">
-                {{ navItem.text }}
-              </v-list-item-title>
-              <v-icon
-                class="ml-1"
-                size="small"
-              >
-                mdi-open-in-new
-              </v-icon>
+              <div class="d-flex justify-space-between align-center">
+                <v-list-item-title class="text-md">
+                  {{ navItem.text }}
+                </v-list-item-title>
+                <v-icon
+                  class="ml-1"
+                  size="x-small"
+                >
+                  mdi-open-in-new
+                </v-icon>
+              </div>
             </template>
           </v-list-item>
         </template>

--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -18,7 +18,6 @@
             :target="navItem.external ? '_blank' : undefined"
             :rel="navItem.external ? 'noopener' : undefined"
             exact
-            text
           >
             <template v-if="!navItem.external">
               <v-list-item-title class="text-md">


### PR DESCRIPTION
Fixes #2262

In Vuetify 2, the `text` prop of the `v-list-item` component is a boolean that applies a certain styling to the component. In Vuetify 3, the `text` prop represents the textual content of the `v-list-item` component. That resulted in it being interpreted as an empty string, resulting in those items not being displayed.