### PR TITLE
Fix star button disabled halo issue

### DIFF
--- a/web/src/components/StarButton.vue
+++ b/web/src/components/StarButton.vue
@@ -3,7 +3,7 @@
     <v-btn
       variant="plain"
       icon
-      :disabled="!loggedIn"
+      :readonly="!loggedIn"
       @click.prevent="toggleStar"
     >
       <v-icon :color="isStarred ? 'amber darken-2' : undefined">


### PR DESCRIPTION
Fixes #2245 

The `readonly` prop to `v-btn` also disables the button like `disabled` does, but without changing the style.