### PR TITLE
Fix alignment issue with Manage Owners button

### DIFF
--- a/web/src/components/DLP/DandisetOwnersDialog.vue
+++ b/web/src/components/DLP/DandisetOwnersDialog.vue
@@ -85,7 +85,7 @@
             Clear form
           </v-btn>
           <v-btn
-            class="pa-2 py-5 bg-grey-darken-3 text-white"
+            class="pa-2 py-5 bg-grey-darken-3 text-white d-flex align-center"
             variant="flat"
             @click="addSelected"
           >


### PR DESCRIPTION
Fixes #2255

Switches the button to use flexbox + `align-items: center` to ensure the child text is vertically centered within the button.