### PR TITLE
Fix position of Manage Owners button

### DIFF
--- a/web/src/components/DLP/DandisetOwnersDialog.vue
+++ b/web/src/components/DLP/DandisetOwnersDialog.vue
@@ -4,7 +4,7 @@
     :max-height="isXsDisplay ? undefined : '90vh'"
     :height="isXsDisplay ? '100%' : undefined"
   >
-    <v-card-title class="justify-space-between">
+    <v-card-title class="d-flex justify-space-between">
       <span class="font-weight-light">Manage Owners</span>
       <v-btn
         :size="isXsDisplay ? 'small' : undefined"


### PR DESCRIPTION
Fixes #2254 

In Vuetify 2, v-card-title was a flexbox container. It seems they've changed this in Vuetify 3, so we must now explicitly set it to flexbox in order for `justify-space-between` to work.