### PR TITLE
Add `celerybeat-schedule*` files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ db.sqlite3
 db.sqlite3-journal
 media
 
+### Celery ###
+celerybeat-schedule*
+
 # If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
 # in your Git repository. Update and uncomment the following line accordingly.
 # <django-project-name>/staticfiles/


### PR DESCRIPTION
These files are autogenerated by `celery beat` and should not be tracked in version control.