### PR TITLE
DOC: fixup description of the interaction with auto for releases based on labels

### DIFF
--- a/doc/design/deployment-1.md
+++ b/doc/design/deployment-1.md
@@ -36,8 +36,8 @@ To make changes to production, developers should:
   - Pay attention to CI results, investigate any failures
   - Add increment or "type" label (`major`, `minor`, `patch`, `documentation`, `tests`) to the PR.
     This informs [`auto`](https://intuit.github.io/) which section to attribute a corresponding changelog entry and what version bump to perform.
-    See the [full of default labels for auto](https://intuit.github.io/auto/docs/configuration/autorc#labels).
-  - Add the `release` label if you want to informs [`auto`](https://intuit.github.io/) to make a release.
-    - Not all changes necessitate an immediate release. Simply leave the `release` label off if you don't want to release right away.
+    See the [full list of default labels for auto](https://intuit.github.io/auto/docs/configuration/autorc#labels).
+  - Add the `release` label to trigger [`auto`](https://intuit.github.io/) to make a release on merge.
+    - Not all changes necessitate an immediate release. Simply leave the `release` label off if you don't want to release right away. The increment/type label will still be accounted for in a future auto release.
 - Once the PR is approved, merge it.
   - If the appropriate release labels are present, `auto` will increment the version number, create a new git tag with that version, and create a new GitHub release.

--- a/doc/design/deployment-1.md
+++ b/doc/design/deployment-1.md
@@ -34,7 +34,10 @@ To make changes to production, developers should:
 - Create a PR that will merge the PR branch to `master`.
   - Assign reviewers
   - Pay attention to CI results, investigate any failures
-  - Add the `release` label and an increment label (`major`, `minor`, `patch`) to the PR. This informs [`auto`](https://intuit.github.io/) that it should make a release.
-    - Not all changes necessitate an immediate release. Simply leave the labels off if you don't want to release right away.
+  - Add increment or "type" label (`major`, `minor`, `patch`, `documentation`, `tests`) to the PR.
+    This informs [`auto`](https://intuit.github.io/) which section to attribute a corresponding changelog entry and what version bump to perform.
+    See the [full of default labels for auto](https://intuit.github.io/auto/docs/configuration/autorc#labels).
+  - Add the `release` label if you want to informs [`auto`](https://intuit.github.io/) to make a release.
+    - Not all changes necessitate an immediate release. Simply leave the `release` label off if you don't want to release right away.
 - Once the PR is approved, merge it.
   - If the appropriate release labels are present, `auto` will increment the version number, create a new git tag with that version, and create a new GitHub release.


### PR DESCRIPTION
Inspired by @mvandenburgh removing a label in  https://github.com/dandi/dandi-archive/pull/2241#issuecomment-2776759964 .

We do have

     "onlyPublishWithReleaseLabel": true

in the https://github.com/dandi/dandi-archive/blob/HEAD/.autorc . So there would be no release unless "release" label is added. All PRs ideally should be annotated with the appropriate labels for the changelog sectioning. See e.g. https://github.com/dandi/dandi-cli/blob/master/CHANGELOG.md#0670-mon-mar-03-2025 and other changelog entries there for how sectioning would look, and compare to current https://github.com/dandi/dandi-archive/blob/master/CHANGELOG.md where all changes are "Bug Fix" and only rarely appropriately annotated like in https://github.com/dandi/dandi-archive/blob/master/CHANGELOG.md#v040-mon-dec-16-2024 where PR with "tests" label "sneaked in"