### PR TITLE
Use `placeholder` instead of `label` for dandiset search bar

### DIFF
--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -5,7 +5,7 @@
   >
     <v-text-field
       :model-value="$route.query.search"
-      label="Search Dandisets by name, description, identifier, or contributor name"
+      placeholder="Search Dandisets by name, description, identifier, or contributor name"
       variant="outlined"
       hide-details
       :density="dense ? 'compact' : undefined"


### PR DESCRIPTION
Fixes #2248

The `label` prop incorrectly behaves as a `placeholder` in the Vuetify 2 `v-text-field` component. Vuetify 3 changes it and makes `label` behave correctly, so we need to use `placeholder` instead.