### PR TITLE
Temporarily pin dandi-cli integration test dependency

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -74,6 +74,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
 
+      - name: Install `numcodes<0.16.0`
+        run: |
+          # TODO: temporary fix until https://github.com/zarr-developers/numcodecs/issues/721 is resolved
+          pip install "numcodecs<0.16.0"
+
       - name: Install released dandi
         if: matrix.dandi-version == 'release'
         run: pip install "dandi[test]"


### PR DESCRIPTION
Temporary until zarr-developers/numcodecs#721 is resolved.

Related: https://github.com/dandi/dandi-cli/issues/1607