### PR TITLE
Remove deprecated version field from docker compose .yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   django:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres:
     image: postgres:latest


### PR DESCRIPTION
This field is deprecated and causes a warning to be logged whenever a `docker compose` command is invoked.
See https://github.com/compose-spec/compose-spec/blob/main/04-version-and-name.md