### PR TITLE
Remove n+1 queries from Asset.full_metadata

### DIFF
--- a/dandiapi/api/manifests.py
+++ b/dandiapi/api/manifests.py
@@ -96,7 +96,8 @@ def write_dandiset_jsonld(version: Version) -> None:
 def write_assets_jsonld(version: Version) -> None:
     # Use full metadata when writing externally
     assets_metadata = (
-        asset.full_metadata for asset in version.assets.select_related('blob', 'zarr').iterator()
+        asset.full_metadata
+        for asset in version.assets.select_related('blob', 'zarr', 'zarr__dandiset').iterator()
     )
     with _streaming_file_upload(_assets_jsonld_path(version)) as stream:
         stream.write(b'[')
@@ -122,7 +123,7 @@ def write_assets_yaml(version: Version) -> None:
             # Use full metadata when writing externally
             (
                 asset.full_metadata
-                for asset in version.assets.select_related('blob', 'zarr')
+                for asset in version.assets.select_related('blob', 'zarr', 'zarr__dandiset')
                 .order_by('created')
                 .iterator()
             ),

--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -92,7 +92,7 @@ def version_aggregate_assets_summary(version: Version) -> None:
     assets_summary = aggregate_assets_summary(
         asset.full_metadata
         for asset in version.assets.filter(status=Asset.Status.VALID)
-        .select_related('blob', 'zarr')
+        .select_related('blob', 'zarr', 'zarr__dandiset')
         .iterator()
     )
 


### PR DESCRIPTION
Determining whether a zarr is embargoed requires querying the dandiset which could result in n+1 queries.