### PR TITLE
Fix validation issue with vue/vjsf 3

### DIFF
--- a/e2e/tests/meditor.spec.ts
+++ b/e2e/tests/meditor.spec.ts
@@ -21,16 +21,11 @@ const titleTooLongSelector = async (page: Page) => {
   ).toBeVisible();
 };
 
-// For now, skip testing Dandiset 000071.
-// The UI for validation is currently not working across tabs. For this particular test
-// case, it means that the icon indicating invalid metadata will fail to show up, since
-// the only validation issue is NOT on the default meditor tab.
-// See https://github.com/dandi/dandi-archive/issues/2281
 const dandisetsToTest = [
   "000003",
   "000018",
   "000024",
-  // "000071",
+  "000071",
   "000106",
   "000107",
   "000362",

--- a/e2e/tests/meditor.spec.ts
+++ b/e2e/tests/meditor.spec.ts
@@ -48,6 +48,7 @@ test.describe("Test meditor validation errors", async () => {
 
   for (const dandisetId of dandisetsToTest) {
     test(`Test dandiset ${dandisetId}`, async ({ page }) => {
+      test.slow();
       await page.goto(`${clientUrl}/#/dandiset/${dandisetId}/draft/`);
       await page.getByRole("button", { name: "Metadata" }).click();
 

--- a/web/src/components/Meditor/Meditor.vue
+++ b/web/src/components/Meditor/Meditor.vue
@@ -229,7 +229,7 @@
 import type { JSONSchema7 } from 'json-schema';
 
 import type { ComputedRef } from 'vue';
-import { ref, computed } from 'vue';
+import { ref, computed, watchEffect } from 'vue';
 
 import jsYaml from 'js-yaml';
 import axios from 'axios';
@@ -241,7 +241,7 @@ import { useDandisetStore } from '@/stores/dandiset';
 import type { DandiModel } from './types';
 import { isJSONSchema } from './types';
 import { EditorInterface } from './editor';
-import { VJSFVuetifyDefaultProps } from './utils';
+import { validateDandisetMetadata, VJSFVuetifyDefaultProps } from './utils';
 
 import {
   clearLocalStorage,
@@ -303,6 +303,13 @@ const CommonVJSFOptions = computed(() => ({
   // Hide the read-only properties in the schema
   readOnlyPropertiesMode: 'hide',
 }));
+
+
+watchEffect(() => {
+  if (schema.value && editorInterface.value) {
+    validateDandisetMetadata(editorInterface.value)
+  }
+});
 
 // undo/redo functionality
 function undoChange() {

--- a/web/src/components/Meditor/Meditor.vue
+++ b/web/src/components/Meditor/Meditor.vue
@@ -175,9 +175,11 @@
       </v-tabs>
       <v-tabs-window
         v-model="tab"
-        eager
       >
-        <v-tabs-window-item value="tab-0">
+        <v-tabs-window-item
+          eager
+          value="tab-0"
+        >
           <v-defaults-provider :defaults="VJSFVuetifyDefaultProps">
             <v-form
               v-model="basicModelValid"
@@ -201,12 +203,13 @@
         v-for="(propKey, i) in fieldsToRender"
         :key="`tab-window-${i+1}`"
         v-model="tab"
-        eager
       >
-        <v-tabs-window-item :value="`tab-${i+1}`">
+        <v-tabs-window-item
+          eager
+          :value="`tab-${i+1}`"
+        >
           <v-card class="pa-2 px-1">
             <v-form
-              v-model="complexModelValidation[propKey]"
               class="px-7"
             >
               <v-jsf-wrapper


### PR DESCRIPTION
Fixes #2281 

We do not currently feed the entire complex model and schema into VJSF for validation. Instead, we only pass a single sub-model and schema into VJSF when it has been selected by the "Edit" button; this is done for UI/UX purposes to avoid rendering every single item in a list as a form at once, as we used to do before the Meditor redesign a few years ago. 

Take this screenshot of the contributors view in the meditor of https://gui-staging.dandiarchive.org/dandiset/200017/draft, for example -

![Screenshot from 2025-04-16 10-40-19](https://github.com/user-attachments/assets/51257c01-84de-4a71-939a-e159e4aae3ab)

The left hand side of the modal is the VJSF component, while the right hand side is a custom component that uses `vue-draggable` to enable the user to manipulate the ordering of the contributors. We do not pass the full `contributor` array to VJSF ( [this schema](https://github.com/dandi/schema/blob/master/releases/0.6.9/dandiset.json#L1226-L1249) of type `list[Person | Organization]`), but instead we only pass the subschema describing an element of the array ([this schema](https://github.com/dandi/schema/blob/master/releases/0.6.9/dandiset.json#L1229-L1243) of type `Person | Organization`). Therefore, validation rules that apply at the top level array and not the individual element level, like `"minItems": 1`, will not be checked by VJSF.

We got around this on the Vue 2 version of VJSF by wrapping the right hand side with yet another instance of the VJSF component, but this time passing the full contributor array to it. For reference - [here is the code where we wrap the right hand side with a VJSF instance that contains the full array and schema](https://github.com/dandi/dandi-archive/blob/a2a0d1aa61988a12e09b4d111148cefa85ffe9a6/web/src/components/Meditor/VJsfWrapper.vue#L71-L77), and [here is the code where we render the individual item and subschema](https://github.com/dandi/dandi-archive/blob/a2a0d1aa61988a12e09b4d111148cefa85ffe9a6/web/src/components/Meditor/VJsfWrapper.vue#L11-L22). Notice in the former, we are using the `default` slot on the VJSF component to override the rendering to display the custom draggable view, i.e. we are only using VJSF for validation purposes and not allowing it to actually render anything. VJSF 3 does not support this slot, so there is no way to replicate this on Vue 3. We could maybe explore getting this added upstream, but this PR will fix the issue for now.
