### PR TITLE
Require minimum version of 2.0 for django-oauth-toolkit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'django-extensions',
         'django-filter',
         'django-guardian',
-        'django-oauth-toolkit',
+        'django-oauth-toolkit>2',
         # TODO: pin this until we figure out what the cause of
         # https://github.com/dandi/dandi-archive/issues/1894 is.
         'djangorestframework==3.14.0',


### PR DESCRIPTION
In #2320 we un-pinned `django-oauth-toolkit`, but in reality it's an backward incompatible change, because the `ClientSecretField` model was added in `v2.0`, which results in an error-ed migration if not on `2.0+`. This pins that package version to `>2`.