### PR TITLE
Move banner with info blurb to top of all pages

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -5,6 +5,7 @@
   >
     <AppBar />
     <v-main v-if="connectedToServer">
+      <InfoBanner />
       <UserStatusBanner />
       <router-view />
       <DandiFooter />
@@ -47,6 +48,7 @@ import { useDandisetStore } from '@/stores/dandiset';
 import AppBar from '@/components/AppBar/AppBar.vue';
 import DandiFooter from '@/components/DandiFooter.vue';
 import UserStatusBanner from '@/components/UserStatusBanner.vue';
+import InfoBanner from '@/components/InfoBanner.vue';
 
 const store = useDandisetStore();
 

--- a/web/src/components/InfoBanner.vue
+++ b/web/src/components/InfoBanner.vue
@@ -1,7 +1,9 @@
 <template>
   <v-banner
     v-if="bannerText"
-    color="grey-darken-1"
+    bg-color="grey-lighten-6"
+    sticky
+    :style="{ top: '64px' }"
   >
     <v-icon>
       mdi-information

--- a/web/src/views/HomeView/HomeView.vue
+++ b/web/src/views/HomeView/HomeView.vue
@@ -40,7 +40,6 @@
         <DandisetSearchField :dense="false" />
       </v-col>
     </v-row>
-    <FooterBanner />
     <StatsBar />
   </v-container>
 </template>
@@ -51,7 +50,6 @@ import { useRoute, useRouter } from 'vue-router';
 import { useDisplay } from 'vuetify';
 import StatsBar from '@/views/HomeView/StatsBar.vue';
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
-import FooterBanner from '@/components/FooterBanner.vue';
 import logo from '@/assets/logo.svg';
 
 const display = useDisplay();


### PR DESCRIPTION
Fix #2302 

This moves the previously implemented `FooterBanner` component to the main `App.vue` component, making it visible on all pages.