### PR TITLE
Switch staging back to builtin oauth `Application`

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -201,11 +201,7 @@ class HerokuProductionConfiguration(DandiMixin, HerokuProductionBaseConfiguratio
     AUTO_APPROVE_USERS = False
 
 
-# NOTE: The staging configuration uses a custom OAuth toolkit `Application` model
-# (`StagingApplication`) to allow for wildcards in OAuth redirect URIs (to support Netlify branch
-# deploy previews, etc). Note that both the custom `StagingApplication` and default
-# `oauth2_provider.models.Application` will have Django database models and will show up on the
-# Django admin, but only one of them will be in active use depending on the environment
-# the API server is running in (production/local or staging).
 class HerokuStagingConfiguration(HerokuProductionConfiguration):
-    OAUTH2_PROVIDER_APPLICATION_MODEL = 'api.StagingApplication'
+    # The staging configuration enables wildcards in OAuth redirect URIs in order
+    # to support Netlify deploy previews.
+    ALLOW_URI_WILDCARDS = True


### PR DESCRIPTION
Fixes #2319

This commit switches the staging environment back to using the builtin `Application` model for OAuth2 authentication, while enabling the `ALLOW_URI_WILDCARDS` setting to allow for wildcard URIs to support Netlify deploy previews.

To be extra cautious, I did not remove the custom `StagingApplication` model yet. I think we should merge this, verify it works properly, and only then remove the custom model.