### PR TITLE
Revert "Switch staging back to builtin oauth `Application`"

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -201,7 +201,11 @@ class HerokuProductionConfiguration(DandiMixin, HerokuProductionBaseConfiguratio
     AUTO_APPROVE_USERS = False
 
 
+# NOTE: The staging configuration uses a custom OAuth toolkit `Application` model
+# (`StagingApplication`) to allow for wildcards in OAuth redirect URIs (to support Netlify branch
+# deploy previews, etc). Note that both the custom `StagingApplication` and default
+# `oauth2_provider.models.Application` will have Django database models and will show up on the
+# Django admin, but only one of them will be in active use depending on the environment
+# the API server is running in (production/local or staging).
 class HerokuStagingConfiguration(HerokuProductionConfiguration):
-    # The staging configuration enables wildcards in OAuth redirect URIs in order
-    # to support Netlify deploy previews.
-    ALLOW_URI_WILDCARDS = True
+    OAUTH2_PROVIDER_APPLICATION_MODEL = 'api.StagingApplication'


### PR DESCRIPTION
Reverts dandi/dandi-archive#2331

Even after merging #2331, I'm unable to create an instance of the built in `Application` model due to this error

```
django.db.utils.ProgrammingError: column oauth2_provider_application.post_logout_redirect_uris does not exist
LINE 1: ...", "oauth2_provider_application"."redirect_uris", "oauth2_pr...
```