### PR TITLE
Fix oauth2 setting

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -204,4 +204,6 @@ class HerokuProductionConfiguration(DandiMixin, HerokuProductionBaseConfiguratio
 class HerokuStagingConfiguration(HerokuProductionConfiguration):
     # The staging configuration enables wildcards in OAuth redirect URIs in order
     # to support Netlify deploy previews.
-    ALLOW_URI_WILDCARDS = True
+    OAUTH2_PROVIDER = {
+        'ALLOW_URI_WILDCARDS': True,
+    }


### PR DESCRIPTION
This setting needs to be specified using the `OAUTH2_PROVIDER` dict.

https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html#settings