### PR TITLE
Don't override oauth2_provider settings dict

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -202,8 +202,8 @@ class HerokuProductionConfiguration(DandiMixin, HerokuProductionBaseConfiguratio
 
 
 class HerokuStagingConfiguration(HerokuProductionConfiguration):
-    # The staging configuration enables wildcards in OAuth redirect URIs in order
-    # to support Netlify deploy previews.
-    OAUTH2_PROVIDER = {
-        'ALLOW_URI_WILDCARDS': True,
-    }
+    @staticmethod
+    def mutate_configuration(configuration: type[ComposedConfiguration]):
+        # The staging configuration enables wildcards in OAuth redirect URIs in order
+        # to support Netlify deploy previews.
+        configuration.OAUTH2_PROVIDER['ALLOW_URI_WILDCARDS'] = True


### PR DESCRIPTION
Fixes an issue introduced in #2335 that caused the upstream `OAUTH2_PROVIDER` dict in `django-composed-configuration` to get overwritten.