### PR TITLE
Integrate `garbage_collection` service into `collect_garbage.py`

### DIFF
--- a/dandiapi/api/management/commands/collect_garbage.py
+++ b/dandiapi/api/management/commands/collect_garbage.py
@@ -39,13 +39,13 @@ def collect_garbage(*, assets: bool, assetblobs: bool, uploads: bool, s3blobs: b
     if doing_deletes:
         echo_report()
 
-    if assetblobs:
+    if assetblobs and click.confirm('This will delete all AssetBlobs. Are you sure?'):
         garbage_collection.asset_blob.garbage_collect()
-    if uploads:
+    if uploads and click.confirm('This will delete all Uploads. Are you sure?'):
         garbage_collection.upload.garbage_collect()
-    if s3blobs:
+    if s3blobs and click.confirm('This will delete all S3 Blobs. Are you sure?'):
         raise click.NoSuchOption('Deleting S3 Blobs is not yet implemented')
-    if assets:
+    if assets and click.confirm('This will delete all Assets. Are you sure?'):
         assets_to_delete = stale_assets()
         if click.confirm(f'This will delete {assets_to_delete.count()} assets. Are you sure?'):
             assets_to_delete.delete()

--- a/dandiapi/api/services/garbage_collection/__init__.py
+++ b/dandiapi/api/services/garbage_collection/__init__.py
@@ -1,21 +1,13 @@
 from __future__ import annotations
 
-from concurrent.futures import Future, ThreadPoolExecutor, wait
 from datetime import timedelta
-import json
 
 from celery.utils.log import get_task_logger
-from django.core import serializers
 from django.db import transaction
 from django.utils import timezone
-from more_itertools import chunked
 
-from dandiapi.api.models import (
-    AssetBlob,
-    GarbageCollectionEvent,
-    GarbageCollectionEventRecord,
-    Upload,
-)
+from dandiapi.api.models import GarbageCollectionEvent
+from dandiapi.api.services.garbage_collection import asset_blob, upload
 from dandiapi.api.storage import DandiMultipartMixin
 
 logger = get_task_logger(__name__)
@@ -33,85 +25,10 @@ RESTORATION_WINDOW = timedelta(
 )  # TODO: pick this up from env var set by Terraform to ensure consistency?
 
 
-def _garbage_collect_uploads() -> int:
-    qs = Upload.objects.filter(
-        created__lt=timezone.now() - UPLOAD_EXPIRATION_TIME,
-    )
-    if not qs.exists():
-        return 0
-
-    deleted_records = 0
-    futures: list[Future] = []
-
-    with transaction.atomic(), ThreadPoolExecutor() as executor:
-        event = GarbageCollectionEvent.objects.create(type=Upload.__name__)
-        for uploads_chunk in chunked(qs.iterator(), GARBAGE_COLLECTION_EVENT_CHUNK_SIZE):
-            GarbageCollectionEventRecord.objects.bulk_create(
-                GarbageCollectionEventRecord(
-                    event=event, record=json.loads(serializers.serialize('json', [u]))[0]
-                )
-                for u in uploads_chunk
-            )
-
-            # Delete the blobs from S3
-            futures.append(
-                executor.submit(
-                    lambda chunk: [u.blob.delete(save=False) for u in chunk],
-                    uploads_chunk,
-                )
-            )
-
-            deleted_records += Upload.objects.filter(
-                pk__in=[u.pk for u in uploads_chunk],
-            ).delete()[0]
-
-        wait(futures)
-
-    return deleted_records
-
-
-def _garbage_collect_asset_blobs() -> int:
-    qs = AssetBlob.objects.filter(
-        assets__isnull=True,
-        created__lt=timezone.now() - ASSET_BLOB_EXPIRATION_TIME,
-    )
-    if not qs.exists():
-        return 0
-
-    deleted_records = 0
-    futures: list[Future] = []
-
-    with transaction.atomic(), ThreadPoolExecutor() as executor:
-        event = GarbageCollectionEvent.objects.create(type=AssetBlob.__name__)
-        for asset_blobs_chunk in chunked(qs.iterator(), GARBAGE_COLLECTION_EVENT_CHUNK_SIZE):
-            GarbageCollectionEventRecord.objects.bulk_create(
-                GarbageCollectionEventRecord(
-                    event=event, record=json.loads(serializers.serialize('json', [a]))[0]
-                )
-                for a in asset_blobs_chunk
-            )
-
-            # Delete the blobs from S3
-            futures.append(
-                executor.submit(
-                    lambda chunk: [a.blob.delete(save=False) for a in chunk],
-                    asset_blobs_chunk,
-                )
-            )
-
-            deleted_records += AssetBlob.objects.filter(
-                pk__in=[a.pk for a in asset_blobs_chunk],
-            ).delete()[0]
-
-        wait(futures)
-
-    return deleted_records
-
-
 def garbage_collect():
     with transaction.atomic():
-        garbage_collected_uploads = _garbage_collect_uploads()
-        garbage_collected_asset_blobs = _garbage_collect_asset_blobs()
+        garbage_collected_uploads = upload.garbage_collect()
+        garbage_collected_asset_blobs = asset_blob.garbage_collect()
 
         GarbageCollectionEvent.objects.filter(
             timestamp__lt=timezone.now() - RESTORATION_WINDOW

--- a/dandiapi/api/services/garbage_collection/asset_blob.py
+++ b/dandiapi/api/services/garbage_collection/asset_blob.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from datetime import timedelta
+import json
+
+from celery.utils.log import get_task_logger
+from django.core import serializers
+from django.db import transaction
+from django.utils import timezone
+from more_itertools import chunked
+
+from dandiapi.api.models import (
+    AssetBlob,
+    GarbageCollectionEvent,
+    GarbageCollectionEventRecord,
+)
+from dandiapi.api.services.garbage_collection import GARBAGE_COLLECTION_EVENT_CHUNK_SIZE
+
+logger = get_task_logger(__name__)
+
+ASSET_BLOB_EXPIRATION_TIME = timedelta(days=7)
+
+
+def garbage_collect() -> int:
+    qs = AssetBlob.objects.filter(
+        assets__isnull=True,
+        created__lt=timezone.now() - ASSET_BLOB_EXPIRATION_TIME,
+    )
+    if not qs.exists():
+        return 0
+
+    deleted_records = 0
+    futures: list[Future] = []
+
+    with transaction.atomic(), ThreadPoolExecutor() as executor:
+        event = GarbageCollectionEvent.objects.create(type=AssetBlob.__name__)
+        for asset_blobs_chunk in chunked(qs.iterator(), GARBAGE_COLLECTION_EVENT_CHUNK_SIZE):
+            GarbageCollectionEventRecord.objects.bulk_create(
+                GarbageCollectionEventRecord(
+                    event=event, record=json.loads(serializers.serialize('json', [a]))[0]
+                )
+                for a in asset_blobs_chunk
+            )
+
+            # Delete the blobs from S3
+            futures.append(
+                executor.submit(
+                    lambda chunk: [a.blob.delete(save=False) for a in chunk],
+                    asset_blobs_chunk,
+                )
+            )
+
+            deleted_records += AssetBlob.objects.filter(
+                pk__in=[a.pk for a in asset_blobs_chunk],
+            ).delete()[0]
+
+        wait(futures)
+
+    return deleted_records

--- a/dandiapi/api/services/garbage_collection/upload.py
+++ b/dandiapi/api/services/garbage_collection/upload.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+import json
+
+from celery.utils.log import get_task_logger
+from django.core import serializers
+from django.db import transaction
+from django.utils import timezone
+from more_itertools import chunked
+
+from dandiapi.api.models import (
+    GarbageCollectionEvent,
+    GarbageCollectionEventRecord,
+    Upload,
+)
+from dandiapi.api.services.garbage_collection import GARBAGE_COLLECTION_EVENT_CHUNK_SIZE
+from dandiapi.api.storage import DandiMultipartMixin
+
+logger = get_task_logger(__name__)
+
+UPLOAD_EXPIRATION_TIME = DandiMultipartMixin._url_expiration  # noqa: SLF001
+
+
+def garbage_collect() -> int:
+    qs = Upload.objects.filter(
+        created__lt=timezone.now() - UPLOAD_EXPIRATION_TIME,
+    )
+    if not qs.exists():
+        return 0
+
+    deleted_records = 0
+    futures: list[Future] = []
+
+    with transaction.atomic(), ThreadPoolExecutor() as executor:
+        event = GarbageCollectionEvent.objects.create(type=Upload.__name__)
+        for uploads_chunk in chunked(qs.iterator(), GARBAGE_COLLECTION_EVENT_CHUNK_SIZE):
+            GarbageCollectionEventRecord.objects.bulk_create(
+                GarbageCollectionEventRecord(
+                    event=event, record=json.loads(serializers.serialize('json', [u]))[0]
+                )
+                for u in uploads_chunk
+            )
+
+            # Delete the blobs from S3
+            futures.append(
+                executor.submit(
+                    lambda chunk: [u.blob.delete(save=False) for u in chunk],
+                    uploads_chunk,
+                )
+            )
+
+            deleted_records += Upload.objects.filter(
+                pk__in=[u.pk for u in uploads_chunk],
+            ).delete()[0]
+
+        wait(futures)
+
+    return deleted_records

--- a/dandiapi/api/tests/test_garbage_collection.py
+++ b/dandiapi/api/tests/test_garbage_collection.py
@@ -25,7 +25,7 @@ def test_garbage_collect_uploads(upload_factory):
 
     non_expired_upload: Upload = upload_factory()
 
-    assert garbage_collection._garbage_collect_uploads() == 1
+    assert garbage_collection.upload.garbage_collect() == 1
 
     assert Upload.objects.filter(id=non_expired_upload.id).exists()
     assert not Upload.objects.filter(id=expired_upload.id).exists()
@@ -56,7 +56,7 @@ def test_garbage_collect_asset_blobs(asset_factory, asset_blob_factory):
     asset_factory(blob=non_orphaned_non_expired_asset_blob)
 
     # Only Case 1 should be garbage collected
-    assert garbage_collection._garbage_collect_asset_blobs() == 1
+    assert garbage_collection.asset_blob.garbage_collect() == 1
     assert not AssetBlob.objects.filter(id=orphaned_expired_asset_blob.id).exists()
     assert AssetBlob.objects.filter(id=orphaned_non_expired_asset_blob.id).exists()
     assert AssetBlob.objects.filter(id=non_orphaned_expired_asset_blob.id).exists()


### PR DESCRIPTION
This hooks up the asset blob and upload garbage collection implementations to the existing stubbed-out `collect_garbage` management command. I recommend reviewing in commit order, as there was some minor refactoring of the `garbage_collection` service layer in order to make it callable from a management command neatly.

Closes #2161
Closes #2160 

In addition to the two issues above, this also partially addresses #2166. Once this is merged I'll test the management command on staging to verify it behaves as expected, and then we can run it on production. I'll hold off on enabling the automatic GC cron job until full `Asset` garbage collection is implemented and ready to be automated as well.
