### PR TITLE
Update sorting controls for Dandisets page

### DIFF
--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -11,6 +11,7 @@
         <template #activator="{ props: menuProps }">
           <v-icon
             v-bind="menuProps"
+            class="mr-6"
           >
             mdi-cog
           </v-icon>
@@ -39,33 +40,53 @@
           </v-list-item>
         </v-list>
       </v-menu>
-      <div class="mx-6">
-        Sort By:
-      </div>
-      <v-chip-group
-        :model-value="sortOption"
-        selected-class="white text-light-blue bg-white"
-        dark
-        mandatory
-        style="min-width: 25%"
+      <DandisetSearchField class="flex-grow-1 mr-2" />
+      <v-btn-group
+        variant="flat"
+        density="comfortable"
+        divided
+        class="btn-group--sort-options"
       >
-        <v-chip
-          v-for="(option, i) in sortingOptions"
-          :key="option.name"
-          @click="changeSort(i)"
+        <v-btn class="btn--sort-option">
+          <v-icon>mdi-sort-variant</v-icon>
+          <v-tooltip
+            location="top"
+            activator="parent"
+          >
+            <span>Sorting Options</span>
+          </v-tooltip>
+          <v-menu activator="parent">
+            <v-list>
+              <v-list-item
+                v-for="(option, i) in sortingOptions"
+                :key="option.name"
+                :value="option"
+                :append-icon="option.name === sortingOptions[sortOption].name ? 'mdi-check' : ''"
+                :class="option.name === sortingOptions[sortOption].name ? 'v-list-item--active': ''"
+                @click="changeSort(i)"
+              >
+                <v-list-item-title >{{ option.name }}</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </v-btn>
+        <v-btn
+          class="pa-0 btn--sort-order bg-grey-lighten-2"
+          @click="changeSortDir"
         >
-          {{ option.name }}
-          <v-icon end>
-            <template v-if="sortDir === -1 || sortOption !== i">
-              mdi-sort-variant
-            </template>
-            <template v-else>
-              mdi-sort-reverse-variant
-            </template>
+          <v-icon v-if="sortDir === 1">
+            mdi-arrow-up-thin
           </v-icon>
-        </v-chip>
-      </v-chip-group>
-      <DandisetSearchField class="flex-grow-1" />
+          <v-icon v-else>mdi-arrow-down-thin</v-icon>
+          <v-tooltip
+            location="top"
+            activator="parent"
+          >
+            <span v-if="sortDir === 1">Ascending</span>
+            <span v-else>Descending</span>
+          </v-tooltip>
+        </v-btn>
+      </v-btn-group>
     </v-toolbar>
     <div
       v-if="props.search && djangoDandisetRequest"
@@ -205,14 +226,26 @@ watch(queryParams, (params) => {
 });
 
 function changeSort(index: number) {
-  if (sortOption.value === index) {
-    sortDir.value *= -1;
-  } else {
-    sortOption.value = index;
-    sortDir.value = -1;
-  }
-
+  sortOption.value = index;
   page.value = 1;
 }
 
+function changeSortDir() {
+  sortDir.value = -1 * sortDir.value;
+}
+
 </script>
+
+<style scoped>
+.btn-group--sort-options {
+  min-width: 84px;
+}
+
+.btn--sort-option {
+  min-width: 56px;
+}
+
+.btn--sort-order {
+  min-width: 28px;
+}
+</style>

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -41,64 +41,93 @@
         </v-list>
       </v-menu>
       <DandisetSearchField class="flex-grow-1 mr-2" />
-      <v-btn-group
+      <v-btn
         variant="flat"
-        density="comfortable"
-        divided
-        class="btn-group--sort-options"
       >
-        <v-btn class="btn--sort-option">
-          <v-icon>mdi-sort-variant</v-icon>
-          <v-tooltip
-            location="top"
-            activator="parent"
+        <span class="pr-2">
+          <span
+            v-if="sortDir === 1"
           >
-            <span>Sorting Options</span>
-          </v-tooltip>
-          <v-menu activator="parent">
-            <v-item-group v-model="sortOption">
-              <v-list>
-                <v-item
-                  v-for="(option, i) in sortingOptions"
-                  :key="option.name"
-                  v-slot="{ isSelected, toggle }"
-                  :value="i"
-                >
-                  <v-list-item
-                    :active="isSelected"
-                    @click="toggle"
-                  >
-                    <template #append>
-                      <v-icon v-if="isSelected">
-                        mdi-check
-                      </v-icon>
-                    </template>
-                    <v-list-item-title>{{ option.name }}</v-list-item-title>
-                  </v-list-item>
-                </v-item>
-              </v-list>
-            </v-item-group>
-          </v-menu>
-        </v-btn>
-        <v-btn
-          class="pa-0 btn--sort-order bg-grey-lighten-2"
-          @click="changeSortDir"
+            <v-icon>mdi-sort-reverse-variant</v-icon>
+            <v-icon>mdi-arrow-up-thin</v-icon>
+          </span>
+          <span v-else>
+            <v-icon>mdi-sort-variant</v-icon>
+            <v-icon>mdi-arrow-down-thin</v-icon>
+          </span>
+        </span>
+        <span
+          class="d-none d-sm-inline"
         >
-          <v-icon v-if="sortDir === 1">
-            mdi-arrow-up-thin
-          </v-icon>
-          <v-icon v-else>
-            mdi-arrow-down-thin
-          </v-icon>
-          <v-tooltip
-            location="top"
-            activator="parent"
-          >
-            <span v-if="sortDir === 1">Ascending</span>
-            <span v-else>Descending</span>
-          </v-tooltip>
-        </v-btn>
-      </v-btn-group>
+          {{ sortingOptions[sortOption].name }}
+        </span>
+        <v-tooltip
+          location="top"
+          activator="parent"
+        >
+          <span>Sorting Options</span>
+        </v-tooltip>
+        <v-menu activator="parent">
+          <v-list>
+            <v-item-group v-model="sortOption">
+              <v-list-subheader>Sort by</v-list-subheader>
+              <v-item
+                v-for="(option, i) in sortingOptions"
+                :key="option.name"
+                v-slot="{ isSelected, toggle }"
+                :value="i"
+              >
+                <v-list-item
+                  :active="isSelected"
+                  @click="toggle"
+                >
+                  <template #append>
+                    <v-icon v-if="isSelected">
+                      mdi-check
+                    </v-icon>
+                  </template>
+                  <v-list-item-title>{{ option.name }}</v-list-item-title>
+                </v-list-item>
+              </v-item>
+            </v-item-group>
+            <v-item-group v-model="sortDir">
+              <v-list-subheader>Order</v-list-subheader>
+              <v-item
+                v-slot="{ isSelected, toggle }"
+                :value="1"
+              >
+                <v-list-item
+                  :active="isSelected"
+                  @click="toggle"
+                >
+                  <template #append>
+                    <v-icon v-if="sortDir === 1">
+                      mdi-check
+                    </v-icon>
+                  </template>
+                  <v-list-item-title>Ascending</v-list-item-title>
+                </v-list-item>
+              </v-item>
+              <v-item
+                v-slot="{ isSelected, toggle }"
+                :value="-1"
+              >
+                <v-list-item
+                  :active="isSelected"
+                  @click="toggle"
+                >
+                  <template #append>
+                    <v-icon v-if="sortDir === -1">
+                      mdi-check
+                    </v-icon>
+                  </template>
+                  <v-list-item-title>Descending</v-list-item-title>
+                </v-list-item>
+              </v-item>
+            </v-item-group>
+          </v-list>
+        </v-menu>
+      </v-btn>
     </v-toolbar>
     <div
       v-if="props.search && djangoDandisetRequest"
@@ -236,11 +265,6 @@ watch(queryParams, (params) => {
     },
   });
 });
-
-function changeSortDir() {
-  sortDir.value = -1 * sortDir.value;
-}
-
 </script>
 
 <style scoped>

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -62,7 +62,7 @@
                 :key="option.name"
                 :value="option"
                 :append-icon="option.name === sortingOptions[sortOption].name ? 'mdi-check' : ''"
-                :class="option.name === sortingOptions[sortOption].name ? 'v-list-item--active': ''"
+                :active="option.name === sortingOptions[sortOption].name"
                 @click="changeSort(i)"
               >
                 <v-list-item-title >{{ option.name }}</v-list-item-title>

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -70,7 +70,11 @@
         <v-menu activator="parent">
           <v-list>
             <v-item-group v-model="sortOption">
-              <v-list-subheader>Sort by</v-list-subheader>
+              <v-list-subheader
+                class="text-high-emphasis font-weight-bold"
+              >
+                Sort by
+              </v-list-subheader>
               <v-item
                 v-for="(option, i) in sortingOptions"
                 :key="option.name"
@@ -78,6 +82,7 @@
                 :value="i"
               >
                 <v-list-item
+                  class="pl-8"
                   :active="isSelected"
                   @click="toggle"
                 >
@@ -90,13 +95,19 @@
                 </v-list-item>
               </v-item>
             </v-item-group>
+            <v-divider />
             <v-item-group v-model="sortDir">
-              <v-list-subheader>Order</v-list-subheader>
+              <v-list-subheader
+                class="text-high-emphasis font-weight-bold"
+              >
+                Order
+              </v-list-subheader>
               <v-item
                 v-slot="{ isSelected, toggle }"
                 :value="1"
               >
                 <v-list-item
+                  class="pl-8"
                   :active="isSelected"
                   @click="toggle"
                 >
@@ -113,6 +124,7 @@
                 :value="-1"
               >
                 <v-list-item
+                  class="pl-8"
                   :active="isSelected"
                   @click="toggle"
                 >

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -56,18 +56,28 @@
             <span>Sorting Options</span>
           </v-tooltip>
           <v-menu activator="parent">
-            <v-list>
-              <v-list-item
-                v-for="(option, i) in sortingOptions"
-                :key="option.name"
-                :value="option"
-                :append-icon="option.name === sortingOptions[sortOption].name ? 'mdi-check' : ''"
-                :active="option.name === sortingOptions[sortOption].name"
-                @click="changeSort(i)"
-              >
-                <v-list-item-title >{{ option.name }}</v-list-item-title>
-              </v-list-item>
-            </v-list>
+            <v-item-group v-model="sortOption">
+              <v-list>
+                <v-item
+                  v-for="(option, i) in sortingOptions"
+                  :key="option.name"
+                  v-slot="{ isSelected, toggle }"
+                  :value="i"
+                >
+                  <v-list-item
+                    :active="isSelected"
+                    @click="toggle"
+                  >
+                    <template #append>
+                      <v-icon v-if="isSelected">
+                        mdi-check
+                      </v-icon>
+                    </template>
+                    <v-list-item-title>{{ option.name }}</v-list-item-title>
+                  </v-list-item>
+                </v-item>
+              </v-list>
+            </v-item-group>
           </v-menu>
         </v-btn>
         <v-btn
@@ -77,7 +87,9 @@
           <v-icon v-if="sortDir === 1">
             mdi-arrow-up-thin
           </v-icon>
-          <v-icon v-else>mdi-arrow-down-thin</v-icon>
+          <v-icon v-else>
+            mdi-arrow-down-thin
+          </v-icon>
           <v-tooltip
             location="top"
             activator="parent"
@@ -224,11 +236,6 @@ watch(queryParams, (params) => {
     },
   });
 });
-
-function changeSort(index: number) {
-  sortOption.value = index;
-  page.value = 1;
-}
 
 function changeSortDir() {
   sortDir.value = -1 * sortDir.value;


### PR DESCRIPTION
Fix #1764 
Fix #2176 

### Changes

Replaces the current sorting controls on the Dandisets page with a more compact, mobile-friendly widget. Based on the design by @jtomeck outlined in #1764.

### Demo video
https://github.com/user-attachments/assets/153f07c2-dc81-4f8c-a239-b882aa40e0e6

