### PR TITLE
Make eslint fail on warning

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "type-check": "vue-tsc --build --force",
-    "lint": "eslint . --fix"
+    "lint": "eslint . --fix --max-warnings=0"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.9.3",


### PR DESCRIPTION
eslint will not fail on warnings by default, meaning that CI will pass even if there are frontend lint warnings. This commit makes `yarn run lint` fail with a nonzero exit code if there are any lint warnings.