### PR TITLE
Parametrize e2e tests in CI to run in both prod/dev modes

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -32,7 +32,16 @@ jobs:
         run: yarn run build
 
   test-e2e:
+    name: E2E tests (${{ matrix.django_server.name }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        django_server:
+          - name: manage.py runserver
+            command: python manage.py runserver
+          - name: gunicorn
+            command: python -m gunicorn --bind 0.0.0.0:8000 dandiapi.wsgi --timeout 25  # from /Procfile
     services:
       postgres:
         image: postgres:latest
@@ -122,21 +131,20 @@ jobs:
     - name: Run Playwright tests
       run: |
           # start vue dev server
-          yarn --cwd ../web/ run dev 2> /dev/null &
+          yarn --cwd web/ run dev 2> /dev/null &
           while ! nc -z localhost 8085; do
             sleep 3
           done
 
           # start the dandi-api server
-          python ../manage.py runserver &
+          ${{ matrix.django_server.command }} &
 
           # run the tests
-          npx playwright test
-      working-directory: e2e
+          cd e2e && npx playwright test
 
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: playwright-report
+        name: playwright-report-${{ matrix.django_server.name }}
         path: e2e/playwright-report/
         retention-days: 30

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -32,16 +32,18 @@ jobs:
         run: yarn run build
 
   test-e2e:
-    name: E2E tests (${{ matrix.django_server.name }})
+    name: E2E tests (${{ matrix.mode.name }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        django_server:
-          - name: manage.py runserver
-            command: python manage.py runserver
-          - name: gunicorn
-            command: python -m gunicorn --bind 0.0.0.0:8000 dandiapi.wsgi --timeout 25  # from /Procfile
+        mode:
+          - name: Development
+            backend_server_command: python manage.py runserver
+            frontend_server_command: yarn --cwd web/ run dev 2> /dev/null
+          - name: Production
+            backend_server_command: python -m gunicorn --bind 0.0.0.0:8000 dandiapi.wsgi --timeout 25  # from /Procfile
+            frontend_server_command: yarn --cwd web/ run build 2> /dev/null && npx serve --single web/dist --listen 8085
     services:
       postgres:
         image: postgres:latest
@@ -132,13 +134,13 @@ jobs:
     - name: Run Playwright tests
       run: |
           # start vue dev server
-          yarn --cwd web/ run dev 2> /dev/null &
+          ${{ matrix.mode.frontend_server_command }} &
           while ! nc -z localhost 8085; do
             sleep 3
           done
 
           # start the dandi-api server
-          ${{ matrix.django_server.command }} &
+          ${{ matrix.mode.backend_server_command }} &
 
           # run the tests
           cd e2e && npx playwright test
@@ -146,6 +148,6 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: playwright-report-${{ matrix.django_server.name }}
+        name: playwright-report-${{ matrix.mode.name }}
         path: e2e/playwright-report/
         retention-days: 30

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -64,6 +64,7 @@ jobs:
           - 9000:9000
     env:
       # API server env vars
+      DJANGO_CONFIGURATION: DevelopmentConfiguration
       DJANGO_DATABASE_URL: postgres://postgres:postgres@localhost:5432/django
       DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000
       DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey


### PR DESCRIPTION
Inspired by the discussion we had the other day about 12 factor and dev/prod parity - currently, we only run our e2e tests with the frontend served by the vite dev server and the backend server by `manage.py runserver`. While it's not possible to get anywhere near parity between CI and the Heroku prod deployment, we can at least (a) run the backend using gunicorn, and (b) serve the statically built Vue application with a static file server. With the latter, we've seen some divergence in the past between behavior with the Vite dev server and the final bundle produced by Rollup for prod, so this is still a strict improvement regardless.