### PR TITLE
Remove margin around DandisetList

### DIFF
--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -149,7 +149,6 @@
     </div>
     <DandisetList
       v-if="dandisets && dandisets.length"
-      class="mx-4 mx-md-8 my-8"
       :dandisets="dandisets"
     />
     <v-container v-else>


### PR DESCRIPTION
Fix #2365 

### Changes

Previous margin (https://dandiarchive.org as of 4/30/2025):
![image](https://github.com/user-attachments/assets/003a90b8-9075-4ed5-93db-29340ad385eb)

New margin (local development environment):
![image](https://github.com/user-attachments/assets/bad92fa9-897f-42e3-a4ef-ee2599533af7)
