### PR TITLE
Fix broken/out-of-date docs links

### DIFF
--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -8,14 +8,14 @@
           <a
             target="_blank"
             rel="noopener"
-            href="https://docs.dandiarchive.org/about/terms/"
+            :href="`${dandiDocumentationUrl}/about/terms/`"
           >Terms</a>
           <v-icon size="x-small">
             mdi-open-in-new
           </v-icon> / <a
             target="_blank"
             rel="noopener"
-            href="https://docs.dandiarchive.org/about/policies/"
+            :href="`${dandiDocumentationUrl}/about/policies/`"
           >Policies</a>
           <v-icon size="x-small">
             mdi-open-in-new
@@ -99,6 +99,7 @@
 
 <script setup lang="ts">
 import CookieBanner from './CookieBanner.vue';
+import { dandiDocumentationUrl } from '@/utils/constants';
 
 const version = import.meta.env.VITE_APP_VERSION;
 const githubLink = import.meta.env.VITE_APP_GIT_REVISION ? `https://github.com/dandi/dandi-archive/commit/${import.meta.env.VITE_APP_GIT_REVISION}` : 'https://github.com/dandi/dandi-archive';

--- a/web/src/components/FileBrowser/FileUploadInstructions.vue
+++ b/web/src/components/FileBrowser/FileUploadInstructions.vue
@@ -36,7 +36,7 @@
           <span class="text-body-2 text-grey-darken-1">
             <span class="text-body-2 text-grey-darken-1">
               Follow the installation instructions in the
-              <a href="https://docs.dandiarchive.org/user-guide-sharing/uploading-data">
+              <a :href="`${dandiDocumentationUrl}/user-guide-sharing/uploading-data`">
                 DANDI Docs
               </a> .
             </span>
@@ -50,6 +50,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useDandisetStore } from '@/stores/dandiset';
+import { dandiDocumentationUrl } from '@/utils/constants';
 
 const store = useDandisetStore();
 const dandisetIdentifier = computed(() => store.dandiset?.dandiset.identifier);

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -95,7 +95,7 @@
           <div>
             Select a license under which to share the contents of this Dandiset.
             You can learn more about <a
-              href="https://docs.dandiarchive.org/35_data_licenses/"
+              :href="`${dandiDocumentationUrl}/user-guide-sharing/data-licenses`"
               target="_blank"
               rel="noopener"
             >
@@ -158,7 +158,7 @@ import { useRouter } from 'vue-router';
 import type { ComputedRef } from 'vue';
 import { dandiRest, loggedIn } from '@/rest';
 import { useDandisetStore } from '@/stores/dandiset';
-import { sandboxDocsUrl } from '@/utils/constants';
+import { dandiDocumentationUrl, sandboxDocsUrl } from '@/utils/constants';
 
 import type { IdentifierForAnAward, LicenseType, License } from '@/types';
 

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -36,7 +36,7 @@
         <v-tooltip location="right">
           <template #activator="{ props }">
             <v-btn
-              href="https://docs.dandiarchive.org/12_download/"
+              :href="`${dandiDocumentationUrl}/user-guide-using/accessing-data/downloading`"
               target="_blank"
               rel="noopener"
               variant="text"
@@ -136,6 +136,7 @@
 import { computed, ref } from 'vue';
 import { useDandisetStore } from '@/stores/dandiset';
 import CopyText from '@/components/CopyText.vue';
+import { dandiDocumentationUrl } from '@/utils/constants';
 
 function downloadCommand(identifier: string, version: string): string {
   // Use the special 'DANDI:' url prefix if appropriate.


### PR DESCRIPTION
- Fixed a few links that were referencing the old "numbered" pages
- Also replaced a few hardcoded references to https://docs.dandiarchive.org with the variable `dandiDocumentationUrl`