### PR TITLE
Fix formatting of approved user message template

### DIFF
--- a/dandiapi/api/templates/api/mail/approved_user_message.txt
+++ b/dandiapi/api/templates/api/mail/approved_user_message.txt
@@ -1,8 +1,7 @@
 {% autoescape off %}
 Dear {{ greeting_name }},
 
-Your DANDI account has been approved. You can go to {{ dandi_web_app_url }} and login with your GitHub account
-to start creating dandisets and uploading data.
+Your DANDI account has been approved. You can go to {{ dandi_web_app_url }} and login with your GitHub account to start creating dandisets and uploading data.
 
 Please use the following links to post any questions or issues.
 


### PR DESCRIPTION
Since the current template results in the following message:

<img width="756" alt="image" src="https://github.com/user-attachments/assets/a3a7edc0-f7ef-4c2c-9bb8-4e93d664edde" />
