### PR TITLE
Improve and update doc regarding the `psycopg` dependency and its system dependencies

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,8 +42,7 @@ but allows developers to run Python code on their native system.
 1. Install [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
 1. Run `docker compose -f ./docker-compose.yml up -d`
 1. Install Python 3.13
-1. Ensure `psycopg` local installation [prerequisites](https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation) are met.
-   (Among the prerequisites, the `libpq` requirement can be met by running the following installation.)
+1. Ensure `psycopg` local installation [prerequisites](https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation) are met. Among the prerequisites, the `libpq` requirement can be met by running the following installation.
 
     - On Ubuntu 20.04:
       ```shell

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,14 +42,19 @@ but allows developers to run Python code on their native system.
 1. Install [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
 1. Run `docker compose -f ./docker-compose.yml up -d`
 1. Install Python 3.13
-1. Install
-  [`psycopg2` build prerequisites](https://www.psycopg.org/docs/install.html#build-prerequisites).
-  Example `psycopg2` installation on Ubuntu 20.04:
-  ```
-  sudo apt install libpq-dev
-  export PATH=/usr/lib/postgresql/X.Y/bin/:$PATH
-  pip install psycopg2
-  ```
+1. Ensure `psycopg` local installation [prerequisites](https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation) are met.
+   (Among the prerequisites, the `libpq` requirement can be met by running the following installation.)
+
+    - On Ubuntu 20.04:
+      ```shell
+      sudo apt install libpq-dev
+      export PATH=/usr/lib/postgresql/X.Y/bin/:$PATH
+      ```
+    - On macOS, you can install `libpq` via Homebrew:
+      ```shell
+      brew install libpq
+      echo 'export PATH="$(brew --prefix)/opt/libpq/bin:$PATH"' >> ~/.zshrc
+      ```
 1. Create and activate a new Python virtualenv
 1. Run `pip install -e ".[dev]"`
 1. Run `source ./dev/export-env.sh`


### PR DESCRIPTION
This PR updates the instructions in `DEVELOPMENT.md` pertaining to installing this project locally for development. Specifically, it updates the dependency requirement from `psycopg2` to `psycopg` and added an example to illustrate how to install the system requirement of `libpq` in MacOS.

**Note**

- [x] The second commit in this PR is to be dropped to before merge. It is retained currently to partially test the setup instruction. (`libpq` is included GH runners; however, it is not linked in the MacOS image).