### PR TITLE
ENH: allow googlebot also /search endpoint and for filtered listing of assets

### DIFF
--- a/dandiapi/api/tests/test_robots.py
+++ b/dandiapi/api/tests/test_robots.py
@@ -14,6 +14,7 @@ def test_robots_txt(api_client):
 User-agent: Googlebot
 Allow: /api/dandisets/search
 Allow: /api/dandisets/*/
+Allow: /api/dandisets/?
 Allow: /api/info/
 Allow: /api/dandisets/*/versions/*/assets*page_size=1
 Disallow: /api/dandisets/*/versions/*/assets

--- a/dandiapi/api/tests/test_robots.py
+++ b/dandiapi/api/tests/test_robots.py
@@ -12,8 +12,10 @@ def test_robots_txt(api_client):
 
     expected_content = """# Allow Googlebot to access dandiset metadata for structured data indexing
 User-agent: Googlebot
+Allow: /api/dandisets/search
 Allow: /api/dandisets/*/
 Allow: /api/info/
+Allow: /api/dandisets/*/versions/*/assets*page_size=1
 Disallow: /api/dandisets/*/versions/*/assets
 Disallow: /
 

--- a/dandiapi/api/views/robots.py
+++ b/dandiapi/api/views/robots.py
@@ -8,6 +8,7 @@ def robots_txt_view(request):
 User-agent: Googlebot
 Allow: /api/dandisets/search
 Allow: /api/dandisets/*/
+Allow: /api/dandisets/?
 Allow: /api/info/
 Allow: /api/dandisets/*/versions/*/assets*page_size=1
 Disallow: /api/dandisets/*/versions/*/assets

--- a/dandiapi/api/views/robots.py
+++ b/dandiapi/api/views/robots.py
@@ -6,8 +6,10 @@ from django.http import HttpResponse
 def robots_txt_view(request):
     content = """# Allow Googlebot to access dandiset metadata for structured data indexing
 User-agent: Googlebot
+Allow: /api/dandisets/search
 Allow: /api/dandisets/*/
 Allow: /api/info/
+Allow: /api/dandisets/*/versions/*/assets*page_size=1
 Disallow: /api/dandisets/*/versions/*/assets
 Disallow: /
 


### PR DESCRIPTION
Continuation to try to re-enable googlebot to index our archive but without introducing heavy load on the website.  The goal here is to allow all end point hitting DLPs

filtered listing of assets is ATM to sense if dandiset has a zarr archive in it, so we could potentially disable publishing. There is a generic https://github.com/dandi/dandi-archive/issues/2404 asking to avoid that. But for now for DLP to load fully we need to allow for that end point.

The URL looks like
https://api.dandiarchive.org/api/dandisets/000026/versions/draft/assets/?zarr=true&page_size=1 and while reading
https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt I got impression that query options (after ?) are also considered, so we can just overall just allow queries which are of page_size=1.

I will now also push commit adding `/dandisets/?*` since that is what we are using to get listing of all dandisets, since otherwise googlebot cannot list all dandisets and we would need an explicit sitemap