### PR TITLE
fix: update robots.txt rules to allow Googlebot access to dandisets

### DIFF
--- a/dandiapi/api/tests/test_robots.py
+++ b/dandiapi/api/tests/test_robots.py
@@ -12,7 +12,7 @@ def test_robots_txt(api_client):
 
     expected_content = """# Allow Googlebot to access dandiset metadata for structured data indexing
 User-agent: Googlebot
-Allow: /api/dandisets/*/
+Allow: /api/dandisets/
 Allow: /api/info/
 Disallow: /api/dandisets/*/versions/*/assets
 Disallow: /

--- a/dandiapi/api/views/robots.py
+++ b/dandiapi/api/views/robots.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse
 def robots_txt_view(request):
     content = """# Allow Googlebot to access dandiset metadata for structured data indexing
 User-agent: Googlebot
-Allow: /api/dandisets/*/
+Allow: /api/dandisets/
 Allow: /api/info/
 Disallow: /api/dandisets/*/versions/*/assets
 Disallow: /


### PR DESCRIPTION
This will permit 


https://api.dandiarchive.org/api/dandisets/?page=2&page_size=1&ordering=-modified&search=000147&draft=true

which was not allowed previously because it does not have a slash after dandisets/