### PR TITLE
Have the `api/info/` endpoint provide instance config info

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: |
           tox -e ${{ matrix.tox-env }}
         env:
+          DANDI_INSTANCE_NAME: DANDI
+          DANDI_DOI_PREFIX: "10.80507"
           DJANGO_DATABASE_URL: postgres://postgres:postgres@localhost:5432/django
           DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000
           DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey

--- a/dandiapi/api/tests/test_info.py
+++ b/dandiapi/api/tests/test_info.py
@@ -15,6 +15,7 @@ def test_rest_info(api_client):
     schema_url = f'http://{TEST_SERVER_NAME}{reverse("schema-dandiset-latest")}'
 
     assert resp.json() == {
+        'instance_config': {'instance_name': 'DANDI', 'doi_prefix': '10.80507'},
         'schema_version': settings.DANDI_SCHEMA_VERSION,
         'schema_url': schema_url,
         'version': __version__,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'celery',
         'dandi',
         # Pin dandischema to exact version to make explicit which schema version is being used
-        'dandischema==0.11.1',  # schema version 0.6.10
+        'dandischema @ git+https://github.com/dandi/dandi-schema.git@devendorize',
         'django~=4.2.0',
         # Pin to version where this bug is fixed
         # https://codeberg.org/allauth/django-allauth/issues/4072

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands =
 
 [testenv:test]
 passenv =
+    DANDI_*
     DJANGO_CELERY_BROKER_URL
     DJANGO_DATABASE_URL
     DJANGO_MINIO_STORAGE_ACCESS_KEY
@@ -58,6 +59,7 @@ commands =
 setenv =
     DJANGO_CONFIGURATION = TestingConfiguration
 passenv =
+    DANDI_*
     DJANGO_CELERY_BROKER_URL
     DJANGO_DATABASE_URL
     DJANGO_MINIO_STORAGE_ACCESS_KEY


### PR DESCRIPTION
This PR is a replacement of #2396, which can't be properly tested since it is coming from another repo.

This PR makes the instance config as defined in `dandischema.conf`, per https://github.com/dandi/dandi-schema/pull/294, available through the `api/info/` endpoint. The instance config, presented as serialized JSON object, can be reconstructed by calling `model_validate` or `model_validate_json` on `dandischema.conf.Config`.

**TODOs**:

- [ ] Remove the "tmp: temporarily set the dandischema dependency to the devendorize branch" commit which is a temporary measure for testing this solution.

##Release Notes

This PR makes the instance config as defined in `dandischema.conf`, per https://github.com/dandi/dandi-schema/pull/294, available through the `api/info/` endpoint.