### PR TITLE
Redirect `gui-staging` URLs to `sandbox`

### DIFF
--- a/redirector/netlify.toml
+++ b/redirector/netlify.toml
@@ -3,3 +3,7 @@ from = "https://gui.dandiarchive.org/*"
 to = "https://dandiarchive.org/:splat"
 status = 301
 
+[[redirects]]
+from = "https://gui-staging.dandiarchive.org/*"
+to = "https://sandbox.dandiarchive.org/:splat"
+status = 301

--- a/redirector/netlify.toml
+++ b/redirector/netlify.toml
@@ -1,4 +1,5 @@
 [[redirects]]
-from = "/*"
+from = "https://gui.dandiarchive.org/*"
 to = "https://dandiarchive.org/:splat"
 status = 301
+


### PR DESCRIPTION
Configures the existing netlify `redirector` app to also redirect gui-staging URLs to sandbox.

Docs: https://docs.netlify.com/configure-builds/file-based-configuration/#redirects

Notes:
- The `gui-staging-dandiarchive-org` Netlify app will need to be reconfigured to point to the `redirector/` directory once we are ready to switch over to sandbox
- The docs don't have any examples of specifying a full domain for the `from` URL as we do here, but this post does have one https://answers.netlify.com/t/need-to-redirect-custom-domain-netlify/75184/3 so there is some reason to think this will work, but we won't know for sure until this is merged.