### PR TITLE
Update hardcoded staging URL

### DIFF
--- a/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
+++ b/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
@@ -77,7 +77,7 @@ const neurosiftURL = computed(() => {
   const metadata = currentDandiset.value.metadata;
   const dandisetId = currentDandiset.value.dandiset.identifier;
   const dandisetVersion = metadata.version;
-  const stagingParam = metadata.url!.startsWith('https://gui-staging.dandiarchive.org/') ? '&staging=1' : '';
+  const stagingParam = metadata.url!.startsWith('https://sandbox.dandiarchive.org/') ? '&staging=1' : '';
 
   return `https://neurosift.app/dandiset/${dandisetId}?dandisetVersion=${dandisetVersion}${stagingParam}`;
 });


### PR DESCRIPTION
I missed this in #2439. We should probably move this to a env var and set it via Terraform using a reference to the associated `aws_route53_record` resource, but this fixes it for the time being.