### PR TITLE
Add middleware/logger to log username on every request

### DIFF
--- a/dandiapi/api/logging.py
+++ b/dandiapi/api/logging.py
@@ -35,6 +35,9 @@ class RequestUserMiddleware:
 class DandiHandler(RichHandler):
     def render_message(self, record: logging.LogRecord, message: str) -> ConsoleRenderable:
         username = current_user.get()
+
+        # All user requests should set username, to either an actual username, or AnonymousUser.
+        # However, sometimes things are logged outside of a request. This condition handles that.
         if username:
             message = f'{username} {message}'
 

--- a/dandiapi/api/logging.py
+++ b/dandiapi/api/logging.py
@@ -24,10 +24,11 @@ class RequestUserMiddleware:
         response = self.get_response(request)
 
         # If user was authenticated, store the request.user object for later use by the logger
-        username = None
-        if hasattr(request, 'user') and request.user.is_authenticated:
-            username = request.user.username
-        current_user.set(username)
+        current_user.set(
+            request.user.username
+            if hasattr(request, 'user') and request.user.is_authenticated
+            else 'AnonymousUser'
+        )
 
         return response
 

--- a/dandiapi/api/logging.py
+++ b/dandiapi/api/logging.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
-import json
 from typing import TYPE_CHECKING
 
 from rich.logging import RichHandler
@@ -37,5 +36,6 @@ class DandiHandler(RichHandler):
     def render_message(self, record: logging.LogRecord, message: str) -> ConsoleRenderable:
         username = current_user.get()
         if username:
-            message = f'{message} {json.dumps({'username': username})}'
+            message = f'{username} {message}'
+
         return super().render_message(record, message)

--- a/dandiapi/api/logging.py
+++ b/dandiapi/api/logging.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+import json
+from typing import TYPE_CHECKING
+
+from rich.logging import RichHandler
+
+if TYPE_CHECKING:
+    import logging
+
+    from rich.console import ConsoleRenderable
+
+# Use of a ContextVar is suggested by the Python logging cookbook
+# https://docs.python.org/3/howto/logging-cookbook.html#use-of-contextvars
+current_user: ContextVar[str | None] = ContextVar('current_user', default=None)
+
+
+class RequestUserMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        # If user was authenticated, store the request.user object for later use by the logger
+        username = None
+        if hasattr(request, 'user') and request.user.is_authenticated:
+            username = request.user.username
+        current_user.set(username)
+
+        return response
+
+
+class DandiHandler(RichHandler):
+    def render_message(self, record: logging.LogRecord, message: str) -> ConsoleRenderable:
+        username = current_user.get()
+        if username:
+            message = f'{message} {json.dumps({'username': username})}'
+        return super().render_message(record, message)

--- a/dandiapi/settings/base.py
+++ b/dandiapi/settings/base.py
@@ -160,6 +160,13 @@ _dandi_log_level: str = env.str('DJANGO_DANDI_LOG_LEVEL', default='INFO')
 # Configure the logging level on all DANDI loggers.
 logging.getLogger('dandiapi').setLevel(_dandi_log_level)
 
+# Configure custom logging to log username if request is associated
+# with a user
+LOGGING['handlers']['console']['class'] = 'dandiapi.api.logging.DandiHandler'
+MIDDLEWARE += [
+    'dandiapi.api.logging.RequestUserMiddleware',
+]
+
 # This is where the schema version should be set.
 # It can optionally be overwritten with the environment variable, but that should only be
 # considered a temporary fix.


### PR DESCRIPTION
Configures Django's logging to append usernames to HTTP request logs if the request is associated with an authenticated user.

There isn't a clean way to get access to the `request.user` object globally, so I've stored it in a `ContextVar` as the Python logging cookbook outlines here https://docs.python.org/3/howto/logging-cookbook.html#use-of-contextvars.