### PR TITLE
Add support to open NIfTI-Zarr assets with the OME-Zarr Validator external service

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -348,7 +348,7 @@ const EXTERNAL_SERVICES = [
 
   {
     name: 'OME Zarr validator',
-    regex: /\.ome\.zarr$/,
+    regex: /\.(ome|nii)\.zarr$/,
     maxsize: Infinity,
     endpoint: 'https://ome.github.io/ome-ngff-validator/?source=$asset_url$',
   },


### PR DESCRIPTION
NIfTI-Zarr is a file format that builds on OME-Zarr - https://github.com/neuroscales/nifti-zarr.  This pull request permits NIfTI-Zarr assets to be directly opened with the OME-Zarr Validator and thereby Neuroglancer.

Here is an [example](https://ome.github.io/ome-ngff-validator/?source=https://dandiarchive.s3.amazonaws.com/zarr/4bdb98bb-bb2a-471f-983f-12e22fa4753a/) NIfTI-Zarr asset opened with the OME-Zarr Validator, which is from [Dandiset 724](https://dandiarchive.org/dandiset/000724/draft/files?location=derivatives/dwi/sub-I58&page=1).

cc @balbasty @calvinchai @satra @ayendiki