### PR TITLE
Declare  the same minimal version of dandi-cli as we announce in /info (/server-info)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license-files = ["LICENSE", "NOTICE"]
 classifiers = ["Private :: Do Not Upload"]
 dependencies = [
   "celery",
-  "dandi",
+  "dandi>=0.60.0",  # minimal version is also provided in API /info
   # Pin dandischema to exact version to make explicit which schema version is being used
   "dandischema==0.11.1",  # schema version 0.6.10
   "django~=4.2.0",


### PR DESCRIPTION
ATM installation of development environment (on python 3.11.2 on my Debian bookworm server) results in a lot of backtracking, which starts with

    INFO: pip is looking at multiple versions of dandi to determine which version is compatible with other requirements. This could take a while.
    Collecting dandi
      Downloading dandi-0.69.2-py3-none-any.whl (354 kB)
         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 354.1/354.1 kB 66.3 MB/s eta 0:00:00
      Downloading dandi-0.69.1-py3-none-any.whl (352 kB)
         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 352.2/352.2 kB 45.1 MB/s eta 0:00:00
      Downloading dandi-0.69.0-py3-none-any.whl (351 kB)
         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 351.5/351.5 kB 59.9 MB/s eta 0:00:00
    ...

Since we declare currently minimal version to be

    ❯ curl --silent https://dandiarchive.org/server-info | jq . | grep cli-minimal-version
      "cli-minimal-version": "0.60.0",

I think it would only be reasonable to declare minimal version in the project as well. It might reduce backtracking for pip a little.