### PR TITLE
Include other files needed by Heroku in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,11 +79,14 @@ packages = [
   "dandiapi",
 ]
 
-# When building an sdist for upload to Heroku, also include "requirements.txt"
 [tool.hatch.build.targets.sdist]
 only-include = [
   "dandiapi",
+  # Also include files needed by Heroku:
+  "/manage.py",
   "/requirements.txt",
+  "/.python-version",
+  "/Procfile",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
Follow up to #2470. These files are required by Heroku and thus also need to be included in the sdist.

See logs on https://github.com/dandi/dandi-archive/actions/runs/16788169095/job/47543851715