### PR TITLE
Use asset paths for dandiset list size order subquery

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -112,8 +112,13 @@ class DandisetOrderingFilter(filters.OrderingFilter):
             queryset = queryset.annotate(
                 size=Subquery(
                     latest_version.annotate(
-                        size=Coalesce(Sum('assets__blob__size'), 0)
-                        + Coalesce(Sum('assets__zarr__size'), 0)
+                        size=Coalesce(
+                            Sum(
+                                'asset_paths__aggregate_size',
+                                filter=~Q(asset_paths__path__contains='/'),
+                            ),
+                            0,
+                        )
                     ).values('size')
                 )
             ).order_by(ordering)


### PR DESCRIPTION
Ordering by size is causing severe issues with the API, as it means that, due to the implementation, essentially every dandiset in the database must have the size of all of its assets computed.

This PR uses asset paths to achieve that same function, without the enormous performance hit.