### PR TITLE
Remove `s3-log-parse` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
   "boto3[s3]",
   "more_itertools",
   "requests",
-  "s3-log-parse",
   "zarr-checksum>=0.2.8",
   # Production-only
   "django-composed-configuration[prod]>=0.25.0",


### PR DESCRIPTION
This library isn't used anymore since the s3 log parse task was removed in #2425.