### PR TITLE
Revert change to github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
+# TODO: enable when we switch to GITHUB_TOKEN
+# permissions:
+#   contents: write
 
 jobs:
   release:
@@ -16,6 +17,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # fetch history for all branches and tags
+          token: ${{ secrets.GH_TOKEN }}  # TODO: switch to GITHUB_TOKEN
 
       - name: Download latest auto
         run: |
@@ -25,6 +27,6 @@ jobs:
 
       - name: Create Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}  # TODO: switch to GITHUB_TOKEN
         run: |
           ~/auto shipit --message="auto shipit - CHANGELOG.md etc"


### PR DESCRIPTION
The `release` action started failing on `master` - https://github.com/dandi/dandi-archive/actions/runs/16977062954/job/48128647939

I'm not sure what's causing it yet, but the only recent change to that file was #2465, so this PR just reverts that change.