### PR TITLE
Revert "Temporarily point CLI tests at PR branch"

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -54,8 +54,7 @@ jobs:
         python:
           - "3.13"
         dandi-version:
-          # TODO: re-enable this when https://github.com/dandi/dandi-cli/pull/1678 is merged
-          # - release
+          - release
           - master
     env:
       DANDI_TESTS_PULL_DOCKER_COMPOSE: 0
@@ -83,8 +82,7 @@ jobs:
 
       - name: Install dev dandi
         if: matrix.dandi-version == 'master'
-        # TODO: set back to `master` after https://github.com/dandi/dandi-cli/pull/1678 is merged
-        run: pip install "dandi[test] @ git+https://github.com/dandi/dandi-cli@update-"
+        run: pip install "dandi[test] @ git+https://github.com/dandi/dandi-cli"
 
       - name: Run dandi-api tests in dandi-cli
         run: |


### PR DESCRIPTION
This reverts commit e56151570fbb0a80b9dcca3f6920d67ff8fece54.

This can be merged after the CLI repo is updated by https://github.com/dandi/dandi-cli/pull/1678.