### PR TITLE
Only search by etag in AssetBlob `get_or_create`

### DIFF
--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -246,8 +246,8 @@ def upload_validate_view(request: AuthenticatedRequest, upload_id: str) -> HttpR
         # Avoid a race condition where two clients are uploading the same blob at the same time.
         asset_blob, created = AssetBlob.objects.get_or_create(
             etag=upload.etag,
-            size=upload.size,
             defaults={
+                'size': upload.size,
                 'embargoed': upload.embargoed,
                 'blob_id': upload.upload_id,
                 'blob': upload.blob,


### PR DESCRIPTION
Follow up to #2478 

It seems that #2478 missed this spot in `upload.py`. If there was a race condition where to clients were attempting to upload the same blob at the same time, this code would be reached (as otherwise the upload would be rejected [here](https://github.com/dandi/dandi-archive/blob/master/dandiapi/api/views/upload.py#L152-L158)). Since we choose the `etag` field alone to distinguish asset blobs, we should do the same here. The chance of accidentally uploading two blobs with matching etags but differing sizes is essentially zero, but still, in that remote case a `MultipleObjectsReturned` exception would be raised here.