### PR TITLE
Remove references to `DANDI_ALLOW_LOCALHOST_URLS` env var

### DIFF
--- a/dandiapi/settings/development.py
+++ b/dandiapi/settings/development.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 from django_extensions.utils import InternalIPS
 
 from .base import *
@@ -64,11 +62,6 @@ SHELL_PLUS_IMPORTS = [
 
 # This allows django-debug-toolbar to run in swagger and show the last made request
 DEBUG_TOOLBAR_CONFIG['UPDATE_ON_FETCH'] = True
-
-# If this environment variable is set, the pydantic model will allow URLs with localhost
-# in them. This is important for development and testing environments, where URLs will
-# frequently point to localhost.
-os.environ['DANDI_ALLOW_LOCALHOST_URLS'] = 'True'
 
 DANDI_AUTO_APPROVE_USERS = True
 

--- a/dandiapi/settings/testing.py
+++ b/dandiapi/settings/testing.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 from .base import *
 
 # Import these afterwards, to override
@@ -24,8 +22,6 @@ DANDI_DANDISETS_BUCKET_PREFIX = 'test-prefix/'
 # Run celery tasks synchronously in tests
 CELERY_TASK_EAGER_PROPAGATES = True
 CELERY_TASK_ALWAYS_EAGER = True
-
-os.environ['DANDI_ALLOW_LOCALHOST_URLS'] = 'True'
 
 DANDI_ZARR_PREFIX_NAME = 'test-zarr'
 


### PR DESCRIPTION
Fixes #2473

This is no longer used by `dandischema`, see https://github.com/dandi/dandi-schema/commit/a12f2e4ff3247c38b5ba6b479c2db0b6eaad7608