### PR TITLE
Fix avatar and new dandiset button line break issue in header

### DIFF
--- a/e2e/tests/dandisetsPage.spec.ts
+++ b/e2e/tests/dandisetsPage.spec.ts
@@ -46,7 +46,7 @@ test.describe("dandisets page", async () => {
         const name = `name ${id}`;
         const description = `description ${id}`;
         const identifier = await registerDandiset(page, name, description);
-        await page.getByRole("link", { name: "My Dandisets" }).click();
+        await page.getByRole("tab", { name: "My Dandisets" }).click();
         await expect(page.getByText(name)).toHaveCount(1);
         await expect(page.getByText(`DANDI:${identifier}`)).toHaveCount(1);
         await expect(page.getByText(`Contact ${lastname}, ${firstname}`)).toHaveCount(1);

--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -50,33 +50,34 @@
       />
     </router-link>
     <v-toolbar-items v-if="!isMobile">
-      <template v-for="navItem in navItems">
-        <v-btn
-          v-if="!navItem.external && (!navItem.if || navItem.if())"
-          :key="navItem.text"
-          :to="{name: navItem.to}"
-          exact
-          variant="text"
-        >
-          {{ navItem.text }}
-        </v-btn>
-        <v-btn
-          v-if="navItem.external && (!navItem.if || navItem.if())"
-          :key="navItem.text"
-          :href="navItem.to"
-          target="_blank"
-          rel="noopener"
-          variant="text"
-        >
-          {{ navItem.text }}
-          <v-icon
-            class="ml-1"
-            size="small"
+      <v-tabs color="primary">
+        <template v-for="navItem in navItems">
+          <v-tab
+            v-if="!navItem.external && (!navItem.if || navItem.if())"
+            :key="navItem.text"
+            :to="{name: navItem.to}"
+            class="text-xs"
           >
-            mdi-open-in-new
-          </v-icon>
-        </v-btn>
-      </template>
+            {{ navItem.text }}
+          </v-tab>
+          <v-tab
+            v-if="navItem.external && (!navItem.if || navItem.if())"
+            :key="navItem.text"
+            :href="navItem.to"
+            target="_blank"
+            rel="noopener"
+            class="text-xs"
+          >
+            {{ navItem.text }}
+            <v-icon
+              class="ml-1"
+              size="small"
+            >
+              mdi-open-in-new
+            </v-icon>
+          </v-tab>
+        </template>
+      </v-tabs>
     </v-toolbar-items>
 
     <v-spacer />

--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -50,33 +50,49 @@
       />
     </router-link>
     <v-toolbar-items v-if="!isMobile">
-      <v-tabs color="primary">
+      <v-tabs selected-class="text-primary">
         <template v-for="navItem in navItems">
           <v-tab
             v-if="!navItem.external && (!navItem.if || navItem.if())"
             :key="navItem.text"
             :to="{name: navItem.to}"
-            class="text-xs"
           >
             {{ navItem.text }}
-          </v-tab>
-          <v-tab
-            v-if="navItem.external && (!navItem.if || navItem.if())"
-            :key="navItem.text"
-            :href="navItem.to"
-            target="_blank"
-            rel="noopener"
-            class="text-xs"
-          >
-            {{ navItem.text }}
-            <v-icon
-              class="ml-1"
-              size="small"
-            >
-              mdi-open-in-new
-            </v-icon>
           </v-tab>
         </template>
+        <v-menu>
+          <template #activator="{ props }">
+            <v-btn
+              v-bind="props"
+            >
+              External Resources
+              <v-icon class="ml-1">
+                mdi-chevron-down
+              </v-icon>
+            </v-btn>
+          </template>
+
+          <v-list>
+            <template v-for="navItem in navItems">
+              <v-list-item
+                v-if="navItem.external && (!navItem.if || navItem.if())"
+                :key="navItem.text"
+                :href="navItem.to"
+                target="_blank"
+                rel="noopener"
+              >
+                <v-list-item-title>
+                  {{ navItem.text }}
+                </v-list-item-title>
+                <template #append>
+                  <v-icon size="small">
+                    mdi-open-in-new
+                  </v-icon>
+                </template>
+              </v-list-item>
+            </template>
+          </v-list>
+        </v-menu>
       </v-tabs>
     </v-toolbar-items>
 


### PR DESCRIPTION
I'm proposing a slight redesign of the navigation to close #2362.

<img width="956" height="343" alt="Screenshot 2025-08-26 at 11 27 29 AM" src="https://github.com/user-attachments/assets/3c30dae2-8571-4f93-9296-546443abf149" />

In the screenshot you'll see that the nav items have been converted to `v-tabs` and the external links now live under a dropdown menu labeled "External Resources." I'm proposing this change because I do not believe decreasing paddings or font sizes in the menu is the right solution, nor do I like the idea of writing custom CSS to do so (Vuetify's methods, like `density="compact"` only change height and do not save horizontal space).