### PR TITLE
Fix embargoed dandiset creation form (Suggested Changes)

### DIFF
--- a/dandiapi/api/management/commands/create_dev_dandiset.py
+++ b/dandiapi/api/management/commands/create_dev_dandiset.py
@@ -9,7 +9,7 @@ import djclick as click
 
 from dandiapi.api.models import AssetBlob
 from dandiapi.api.services.asset import add_asset_to_version
-from dandiapi.api.services.dandiset import create_dandiset
+from dandiapi.api.services.dandiset import create_open_dandiset
 from dandiapi.api.services.metadata import validate_asset_metadata, validate_version_metadata
 from dandiapi.api.services.permissions.dandiset import add_dandiset_owner
 from dandiapi.api.tasks import calculate_sha256
@@ -34,8 +34,8 @@ def create_dev_dandiset(*, name: str, email: str, num_extra_owners: int):
         'description': 'An informative description',
         'license': ['spdx:CC0-1.0'],
     }
-    dandiset, draft_version = create_dandiset(
-        user=owner, embargo=False, version_name=name, version_metadata=version_metadata
+    dandiset, draft_version = create_open_dandiset(
+        user=owner, version_name=name, version_metadata=version_metadata
     )
 
     if num_extra_owners:

--- a/dandiapi/api/services/audit/__init__.py
+++ b/dandiapi/api/services/audit/__init__.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from dandiapi.api.models.audit import AuditRecord
+from dandiapi.api.models import AuditRecord, Dandiset
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User
 
     from dandiapi.api.models.asset import Asset
     from dandiapi.api.models.audit import AuditRecordType
-    from dandiapi.api.models.dandiset import Dandiset
     from dandiapi.zarr.models import ZarrArchive
 
 
@@ -47,13 +46,12 @@ def create_dandiset(
     dandiset: Dandiset,
     user: User | None,
     metadata: dict,
-    embargoed: bool,
     admin: bool = False,
     description: str = '',
 ):
     details = {
         'metadata': metadata,
-        'embargoed': embargoed,
+        'embargoed': dandiset.embargo_status == Dandiset.EmbargoStatus.EMBARGOED,
     }
     return _make_audit_record(
         dandiset=dandiset,

--- a/dandiapi/api/services/version/metadata.py
+++ b/dandiapi/api/services/version/metadata.py
@@ -6,9 +6,7 @@ from django.conf import settings
 from dandiapi.api.models.version import Version
 
 
-def _normalize_version_metadata(
-    raw_version_metadata: dict, name: str, email: str, *, embargo: bool
-) -> dict:
+def _normalize_version_metadata(raw_version_metadata: dict, name: str, email: str) -> dict:
     """
     Take raw version metadata and convert it into something suitable to be used in a formal Version.
 

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -28,7 +28,8 @@ from dandiapi.api.models.asset_paths import AssetPath
 from dandiapi.api.models.dandiset import DandisetStar
 from dandiapi.api.services import audit
 from dandiapi.api.services.dandiset import (
-    create_dandiset,
+    create_embargoed_dandiset,
+    create_open_dandiset,
     delete_dandiset,
     star_dandiset,
     unstar_dandiset,
@@ -432,21 +433,23 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             except ValueError:
                 return Response(f'Invalid Identifier {identifier}', status=400)
 
-        embargo_config = {
-            'embargo': query_serializer.validated_data['embargo'],
-            'funding_source': query_serializer.validated_data.get('funding_source'),
-            'award_number': query_serializer.validated_data.get('award_number'),
-            'grant_end_date': query_serializer.validated_data.get('grant_end_date'),
-            'embargo_end_date': query_serializer.validated_data.get('embargo_end_date'),
-        }
-
-        dandiset, _ = create_dandiset(
-            user=request.user,
-            identifier=identifier,
-            embargo_config=embargo_config,
-            version_name=serializer.validated_data['name'],
-            version_metadata=serializer.validated_data['metadata'],
-        )
+        if query_serializer.validated_data['embargo']:
+            dandiset, _ = create_embargoed_dandiset(
+                user=request.user,
+                identifier=identifier,
+                version_name=serializer.validated_data['name'],
+                version_metadata=serializer.validated_data['metadata'],
+                funding_source=query_serializer.validated_data.get('funding_source'),
+                award_number=query_serializer.validated_data.get('award_number'),
+                embargo_end_date=query_serializer.validated_data['embargo_end_date'],
+            )
+        else:
+            dandiset, _ = create_open_dandiset(
+                user=request.user,
+                identifier=identifier,
+                version_name=serializer.validated_data['name'],
+                version_metadata=serializer.validated_data['metadata'],
+            )
 
         serializer = DandisetDetailSerializer(instance=dandiset)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.db.models.query_utils import Q
+from django.utils import timezone
 from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 
@@ -80,8 +82,9 @@ class CreateDandisetQueryParameterSerializer(serializers.Serializer):
     embargo = serializers.BooleanField(required=False, default=False)
     funding_source = serializers.CharField(required=False, allow_blank=True)
     award_number = serializers.CharField(required=False, allow_blank=True)
-    grant_end_date = serializers.DateField(required=False)
-    embargo_end_date = serializers.DateField(required=False)
+    embargo_end_date = serializers.DateField(
+        default=lambda: timezone.now().date() + timedelta(days=730)
+    )
 
 
 class VersionMetadataSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This PR is based on top of #2462, making some refactors that I think are improvements.

The core change is splitting out the `create_dandiset()` service layer function into two separate functions - `create_open_dandiset()` and `create_embargoed_dandiset()`. I think the `create_dandiset` function has gotten too bloated, especially with all the new logic and function arguments that only apply to embargoed dandisets.