### PR TITLE
Fix Bug in collect_garbage.py with printing

### DIFF
--- a/dandiapi/api/management/commands/collect_garbage.py
+++ b/dandiapi/api/management/commands/collect_garbage.py
@@ -13,7 +13,10 @@ def echo_report():
 
     garbage_collectable_asset_blobs = garbage_collection.asset_blob.get_queryset()
     asset_blobs_count = garbage_collectable_asset_blobs.count()
-    asset_blobs_size_in_bytes = garbage_collectable_asset_blobs.aggregate(Sum('size'))['size__sum']
+    asset_blobs_size_in_bytes = (
+        garbage_collectable_asset_blobs.aggregate(Sum('size'))['size__sum'] or 0
+    )
+    asset_blobs_size_in_gb = asset_blobs_size_in_bytes / (1024**3)
 
     garbage_collectable_uploads = garbage_collection.upload.get_queryset()
     uploads_count = garbage_collectable_uploads.count()
@@ -21,7 +24,7 @@ def echo_report():
     click.echo(f'Assets: {assets_count}')
     click.echo(
         f'AssetBlobs: {asset_blobs_count} ({asset_blobs_size_in_bytes} bytes / '
-        f'{asset_blobs_size_in_bytes / (1024 ** 3):.2f} GB)'
+        f'{asset_blobs_size_in_gb:.2f} GB)'
     )
     click.echo(f'Uploads: {uploads_count}')
     click.echo('S3 Blobs: Coming soon')


### PR DESCRIPTION
In the `echo_report()` script, there was a bug occuring when no asset blobs were found for garbage collection.

**Bug:**
Given the following,
```
    asset_blobs_size_in_bytes = garbage_collectable_asset_blobs.aggregate(Sum('size'))['size__sum']
    ...
    click.echo(
         f'AssetBlobs: {asset_blobs_count} ({asset_blobs_size_in_bytes} bytes / '
        f'{asset_blobs_size_in_bytes / (1024 ** 3):.2f} GB)'
     )
```
If `len(garbage_collectable_asset_blobs) == 0`, then `asset_blobs_size_in_bytes` is `None`, resulting in an error trying to calculate `asset_blobs_size_in_bytes / (1024**3)`.

**Solution**
I've changed the assignemnt to the following, setting `asset_blobs_size_in_bytes` to `0` rather than `None` in the case of no asset blobs found.
```
    asset_blobs_size_in_bytes = (
        garbage_collectable_asset_blobs.aggregate(Sum('size'))['size__sum'] or 0
    )
```
