### PR TITLE
Include asset size in audit record

### DIFF
--- a/dandiapi/api/services/audit/__init__.py
+++ b/dandiapi/api/services/audit/__init__.py
@@ -119,6 +119,7 @@ def _asset_details(asset: Asset) -> dict:
 
     return {
         'path': asset.path,
+        'size': asset.size,
         'asset_blob_id': asset.blob and str(asset.blob.blob_id),
         'zarr_archive_id': asset.zarr and str(asset.zarr.zarr_id),
         'asset_id': str(asset.asset_id),


### PR DESCRIPTION
Fixes #2508

This updates the asset-related audit service functions to include the asset `size` in audit records. I'll follow this up with another PR that backfills the existing audit records.