### PR TITLE
Use allauth setting to restrict prod to github auth

### DIFF
--- a/dandiapi/settings/production.py
+++ b/dandiapi/settings/production.py
@@ -25,6 +25,8 @@ INSTALLED_APPS += [
 ]
 # All login attempts in production should go straight to GitHub
 LOGIN_URL = '/accounts/github/login/'
+# Only allow GitHub auth on production, no username/password
+SOCIALACCOUNT_ONLY = True
 
 # This only needs to be defined in production. Testing will add 'testserver'. In development
 # (specifically when DEBUG is True), 'localhost' and '127.0.0.1' will be added.

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -127,6 +127,7 @@ urlpatterns = [
     *api_urlpatterns,
     *webdav_urlpatterns,
     path('admin/', admin.site.urls),
+    path('accounts/', include('allauth.urls')),
     path('dashboard/', DashboardView.as_view(), name='dashboard-index'),
     path('dashboard/user/<str:username>/', user_approval_view, name='user-approval'),
     path('dashboard/mailchimp/', mailchimp_csv_view, name='mailchimp-csv'),
@@ -155,17 +156,6 @@ urlpatterns = [
         name='webdav-schema-swagger-ui',
     ),
 ]
-
-if 'allauth.socialaccount.providers.github' in settings.INSTALLED_APPS:
-    # Include github oauth endpoints only
-    urlpatterns.append(
-        path('accounts/', include('allauth.socialaccount.providers.github.urls')),
-    )
-else:
-    # Include "account" endpoints only (i.e. endpoints needed for username/password login flow)
-    urlpatterns.append(
-        path('accounts/', include('allauth.account.urls')),
-    )
 
 if settings.DEBUG:
     import debug_toolbar.toolbar


### PR DESCRIPTION
`SOCIALACCOUNT_ONLY` allows only GitHub authentication, while not requiring any differences in `urls.py` between production and dev. https://docs.allauth.org/en/dev/socialaccount/configuration.html

Fixes #2515