### PR TITLE
Temporarily override broken upstream setting

### DIFF
--- a/dandiapi/settings/production.py
+++ b/dandiapi/settings/production.py
@@ -36,6 +36,9 @@ STORAGES['default'] = {
     'BACKEND': 'dandiapi.storage.DandiS3Storage',
 }
 DANDI_DANDISETS_BUCKET_NAME = AWS_STORAGE_BUCKET_NAME
+# TODO: remove this when http://github.com/kitware-resonant/cookiecutter-resonant/pull/369/
+# is merged/released.
+AWS_QUERYSTRING_EXPIRE = int(timedelta(hours=6).total_seconds())
 
 DANDI_DEV_EMAIL: str = env.str('DJANGO_DANDI_DEV_EMAIL')
 DANDI_ADMIN_EMAIL: str = env.str('DJANGO_DANDI_ADMIN_EMAIL')


### PR DESCRIPTION
`django-resonant-settings` currently specifies this setting incorrectly as a `float`, when it should be an `int`. See https://github.com/kitware-resonant/cookiecutter-resonant/pull/369