### PR TITLE
Include `gunicorn.conf.py` in heroku sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ only-include = [
   "/uv.lock",
   "/.python-version",
   "/Procfile",
+  "/gunicorn.conf.py",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
I left this out of #2525; we need to tell hatchling to explicitly include this file because it is not part of the `dandiapi` package.