### PR TITLE
Change endpoints related to serving schemas of DANDI metadata models

### DIFF
--- a/dandiapi/api/tests/test_schema.py
+++ b/dandiapi/api/tests/test_schema.py
@@ -16,7 +16,7 @@ import pytest
 )
 def test_schema_latest(api_client, model: CommonModel):
     """Test that the schema endpoints return valid schemas."""
-    resp = api_client.get('/api/schema/', {'model': model.__name__})
+    resp = api_client.get('/api/schemas/', {'model': model.__name__})
     assert resp.status_code == 200
 
     # Verify that the schema is json and has core properties
@@ -32,5 +32,5 @@ def test_schema_latest(api_client, model: CommonModel):
 
 def test_schema_unsupported_model(api_client):
     """Test that the schema endpoint returns an error when passed invalid choice."""
-    resp = api_client.get('/api/schema/', {'model': 'NotAValidModel'})
+    resp = api_client.get('/api/schemas/', {'model': 'NotAValidModel'})
     assert resp.status_code == 400

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -68,8 +68,8 @@ api_urlpatterns = [
     path('api/stats/', stats_view),
     path('api/info/', info_view),
     path('api/blobs/digest/', blob_read_view, name='blob-read'),
-    path('api/schema/available', schema_list_view, name='schema-list-view'),
-    path('api/schema/', schema_view, name='schema-view'),
+    path('api/schemas/available/', schema_list_view, name='schema-list-view'),
+    path('api/schemas/', schema_view, name='schema-view'),
     path('api/uploads/initialize/', upload_initialize_view, name='upload-initialize'),
     re_path(
         r'api/uploads/(?P<upload_id>[0-9a-f\-]{36})/complete/',

--- a/doc/design/vendored-schema-1-implementation.md
+++ b/doc/design/vendored-schema-1-implementation.md
@@ -16,7 +16,7 @@ As described in the design document, the current approach has the following issu
 
 The implemented solution addresses these issues by:
 
-1. Creating API endpoints to dynamically generate JSONSchema from the Pydantic models at runtime
+1. Creating an API endpoint to dynamically generate JSONSchema from the Pydantic models at runtime
 2. Updating the info endpoint to point to our local schema endpoint instead of GitHub
 3. Implementing proper serialization using Pydantic's TypeAdapter to generate the JSONSchema
 
@@ -24,10 +24,8 @@ The implemented solution addresses these issues by:
 
 We've added the following API endpoints:
 
-- `/api/schema/latest/dandiset/` - Returns the JSONSchema for the PublishedDandiset model
-- `/api/schema/latest/asset/` - Returns the JSONSchema for the PublishedAsset model
-- `/api/schema/{version}/dandiset/` - Returns the JSONSchema for a specific version (currently only supports the current version)
-- `/api/schema/{version}/asset/` - Returns the JSONSchema for a specific version (currently only supports the current version)
+- `/api/schemas/available/` - Returns the list of available schema models that can be used as a query parameter value for the `/api/schemas/` endpoint
+- `/api/schemas/` - Returns the JSONSchema for a queried model specified with the `model` query parameter (e.g., `?model=Dandiset`)
 
 These endpoints use Pydantic's TypeAdapter to generate the JSONSchema directly from the models, ensuring that any runtime vendorization or customization is reflected in the schema.
 

--- a/doc/design/vendored-schema-1.md
+++ b/doc/design/vendored-schema-1.md
@@ -192,9 +192,12 @@ Key changes:
 
 ### Details
 
-- create API endpoint `/api/schema/({version}|latest)/dandiset/`, with currently no `{version}` support for non-matching version(but later could expose)
-  - ideally should in the future allow for alternative content type requests, defaulting e.g. to [application/schema+json](https://json-schema.org/draft/2020-12/json-schema-core#section-14) providing JSONSchema serialization
-- `schema_url` in `/info` should point to that instance's `/api/schema/{version}/dandiset/` URL , thus web frontend would load that schema from the backend/API instead of relying on the static JSONSchema serialization in a separate `dandi/schema` repository.
+- add the following endpoints API endpoints:
+    - `/api/schemas/available/` - Returns the list of available schema models that can be used as a query parameter value for the `/api/schemas/` endpoint
+    - `/api/schemas/` - Returns the JSONSchema for a queried model specified with the `model` query parameter (e.g., `?model=Dandiset`)
+        - Currently, this endpoint only returns the schema of the queried model at the latest version. In the future, it could be extended to support different versions with a `version` query parameter.
+        - In the future, this can be extended to support request of different content type. Currently, [application/schema+json](https://json-schema.org/draft/2020-12/json-schema-core#section-14) is supported, providing JSONSchema serialization
+- `schema_url` in `/info` should point to that instance's `/api/schemas/?model=Dandiset` URL , thus web frontend would load that schema from the backend/API instead of relying on the static JSONSchema serialization in a separate `dandi/schema` repository.
 
 ## Additional considerations
 


### PR DESCRIPTION
~~This PR changes the endpoint for severing the list of available schemas from `api/schema/available` to `api/schemas`.~~

This PR changes the endpoints related to serving schemas of DANDI metadata models. From 

```
'api/schema/available'
'api/schema/'
```

to

```
'api/schemas/available/'
'api/schemas/'

Additionally, this PR also updates the documentation regarding these endpoints.