### PR TITLE
Explicitly allow file overwrite

### DIFF
--- a/dandiapi/api/tests/test_storage.py
+++ b/dandiapi/api/tests/test_storage.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from django.core.files.storage import default_storage
+
+
+# This test will fail if AWS_S3_FILE_OVERWRITE == False
+def test_file_overwrite():
+    path = 'foobar.txt'
+    a = default_storage.save(path, StringIO('something'))
+    b = default_storage.save(path, StringIO('something else'))
+    assert a == b

--- a/dandiapi/settings/base.py
+++ b/dandiapi/settings/base.py
@@ -107,6 +107,9 @@ STORAGES = {
 DANDI_DANDISETS_BUCKET_NAME: str
 DANDI_DANDISETS_BUCKET_PREFIX: str = env.str('DJANGO_DANDI_DANDISETS_BUCKET_PREFIX', default='')
 
+# Allow overwriting files in S3/Minio
+AWS_S3_FILE_OVERWRITE = True
+
 STATIC_ROOT = BASE_DIR / 'staticfiles'
 # Django staticfiles auto-creates any intermediate directories, but do so here to prevent warnings.
 STATIC_ROOT.mkdir(exist_ok=True)

--- a/dandiapi/settings/production.py
+++ b/dandiapi/settings/production.py
@@ -16,6 +16,9 @@ from resonant_settings.production.email import *  # isort: skip
 from resonant_settings.production.https import *  # isort: skip
 from resonant_settings.production.s3_storage import *  # isort: skip
 
+# Re-import this after resonant_settings to override the value in s3_storage
+from .base import AWS_S3_FILE_OVERWRITE  # noqa: F401
+
 WSGI_APPLICATION = 'dandiapi.wsgi.application'
 
 SECRET_KEY: str = env.str('DJANGO_SECRET_KEY')


### PR DESCRIPTION
Closes #2534 

This bug has been present since https://github.com/dandi/dandi-archive/pull/2500 was released and deployed (September 10th). Implicitly included in that change was an upstream setting `AWS_S3_FILE_OVERWRITE = False`. This being set to `False` was eventually causing [this](https://github.com/django/django/blob/5ee651f2555f3258b136f6e8be90f018fd8ffbf0/django/core/files/storage/base.py#L67-L73) function to be called, which appends a random string to the end of the file name to prevent overwriting it. This resulted in the "junk" files mentioned in the linked issue, as instead of updating the intended manifest file, a new file was being written every time.

Once this fix is merged, I think an appropriate solution would be to re-generate manifest files for each affected dandiset, so that recent changes are once again written to the appropriate location. Then, we can simply clean up all of the junk files.