### PR TITLE
Remove unnecessary `format` argument from `APIRequestFactory` instances

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -728,7 +728,6 @@ def test_asset_create(api_client, user, draft_version, asset_blob):
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': asset_blob.blob_id},
-        format='json',
     ).json()
     new_asset = Asset.objects.get(asset_id=resp['asset_id'])
     assert resp == {
@@ -799,7 +798,6 @@ def test_asset_create_path_validation(
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': asset_blob.blob_id},
-        format='json',
     )
 
     assert resp.status_code == expected_status_code, resp.data
@@ -876,7 +874,6 @@ def test_asset_create_embargo(
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': embargoed_asset_blob.blob_id},
-        format='json',
     ).json()
     new_asset = Asset.objects.get(asset_id=resp['asset_id'])
 
@@ -912,7 +909,6 @@ def test_asset_create_unembargo_in_progress(
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': embargoed_asset_blob.blob_id},
-        format='json',
     )
 
     assert resp.status_code == 400
@@ -946,7 +942,6 @@ def test_asset_create_embargoed_asset_blob_open_dandiset(
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': embargoed_asset_blob.blob_id},
-        format='json',
     ).json()
     new_asset = Asset.objects.get(asset_id=resp['asset_id'])
 
@@ -979,7 +974,6 @@ def test_asset_create_zarr(api_client, user, draft_version, zarr_archive):
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'zarr_id': zarr_archive.zarr_id},
-        format='json',
     ).json()
     new_asset = Asset.objects.get(asset_id=resp['asset_id'])
     assert resp == {
@@ -1031,7 +1025,6 @@ def test_asset_create_zarr_validated(
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'zarr_id': zarr_archive.zarr_id},
-        format='json',
     ).json()
     asset1 = Asset.objects.get(asset_id=resp['asset_id'])
 
@@ -1042,7 +1035,6 @@ def test_asset_create_zarr_validated(
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'zarr_id': zarr_archive.zarr_id},
-        format='json',
     ).json()
     asset2 = Asset.objects.get(asset_id=resp['asset_id'])
 
@@ -1081,7 +1073,6 @@ def test_asset_create_zarr_wrong_dandiset(
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'zarr_id': zarr_archive.zarr_id},
-        format='json',
     )
     assert resp.status_code == 400
     assert resp.json() == 'The zarr archive belongs to a different dandiset'
@@ -1105,7 +1096,6 @@ def test_asset_create_no_blob_or_zarr(api_client, user, draft_version):
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata},
-        format='json',
     )
     assert resp.status_code == 400
     assert resp.json() == {'blob_id': ['Exactly one of blob_id or zarr_id must be specified.']}
@@ -1129,7 +1119,6 @@ def test_asset_create_blob_and_zarr(api_client, user, draft_version, asset_blob,
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': asset_blob.blob_id, 'zarr_id': zarr_archive.zarr_id},
-        format='json',
     )
     assert resp.status_code == 400
     assert resp.json() == {'blob_id': ['Exactly one of blob_id or zarr_id must be specified.']}
@@ -1148,7 +1137,6 @@ def test_asset_create_no_valid_blob(api_client, user, draft_version):
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': uuid},
-        format='json',
     )
     assert resp.status_code == 404
 
@@ -1164,7 +1152,6 @@ def test_asset_create_no_path(api_client, user, draft_version, asset_blob):
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': asset_blob.blob_id},
-        format='json',
     )
     assert resp.status_code == 400
     assert resp.data == {'metadata': ['No path specified in metadata.']}, resp.data
@@ -1176,9 +1163,7 @@ def test_asset_create_not_an_owner(api_client, user, version):
 
     assert (
         api_client.post(
-            f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/assets/',
-            {},
-            format='json',
+            f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/assets/', {}
         ).status_code
         == 403
     )
@@ -1199,7 +1184,6 @@ def test_asset_create_published_version(api_client, user, published_version, ass
             'metadata': asset.metadata,
             'blob_id': asset.blob.blob_id,
         },
-        format='json',
     )
     assert resp.status_code == 405
     assert resp.data == 'Only draft versions can be modified.'
@@ -1226,7 +1210,6 @@ def test_asset_create_existing_path(api_client, user, draft_version, asset_blob,
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': asset_blob.blob_id},
-        format='json',
     )
     assert resp.status_code == 409
 
@@ -1253,7 +1236,6 @@ def test_asset_create_on_open_dandiset_embargoed_asset_blob(
         f'/api/dandisets/{draft_version.dandiset.identifier}'
         f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': embargoed_asset_blob.blob_id},
-        format='json',
     )
     assert resp.status_code == 200
 
@@ -1283,7 +1265,6 @@ def test_asset_rest_rename(api_client, user, draft_version, asset_blob):
         f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/'
         f'assets/{asset.asset_id}/',
         {'metadata': metadata, 'blob_id': asset.blob.blob_id},
-        format='json',
     )
 
     # Ensure new asset with new path was created
@@ -1313,7 +1294,6 @@ def test_asset_rest_update(api_client, user, draft_version, asset, asset_blob):
         f'/api/dandisets/{draft_version.dandiset.identifier}/'
         f'versions/{draft_version.version}/assets/{asset.asset_id}/',
         {'metadata': new_metadata, 'blob_id': asset_blob.blob_id},
-        format='json',
     ).json()
     new_asset = Asset.objects.get(asset_id=resp['asset_id'])
     assert resp == {
@@ -1370,7 +1350,6 @@ def test_asset_rest_update_embargo(api_client, user, draft_version, asset, embar
         f'/api/dandisets/{draft_version.dandiset.identifier}/'
         f'versions/{draft_version.version}/assets/{asset.asset_id}/',
         {'metadata': new_metadata, 'blob_id': embargoed_asset_blob.blob_id},
-        format='json',
     ).json()
     new_asset = Asset.objects.get(asset_id=resp['asset_id'])
     assert resp == {
@@ -1427,7 +1406,6 @@ def test_asset_rest_update_unembargo_in_progress(
         f'/api/dandisets/{draft_version.dandiset.identifier}/'
         f'versions/{draft_version.version}/assets/{asset.asset_id}/',
         {'metadata': new_metadata, 'blob_id': embargoed_asset_blob.blob_id},
-        format='json',
     )
     assert resp.status_code == 400
 
@@ -1465,7 +1443,6 @@ def test_asset_rest_update_zarr(
         f'/api/dandisets/{draft_version.dandiset.identifier}/'
         f'versions/{draft_version.version}/assets/{asset.asset_id}/',
         {'metadata': new_metadata, 'zarr_id': zarr_archive.zarr_id},
-        format='json',
     ).json()
     new_asset = Asset.objects.get(asset_id=resp['asset_id'])
     assert resp == {
@@ -1508,7 +1485,6 @@ def test_asset_rest_update_unauthorized(api_client, draft_version, asset):
             f'/api/dandisets/{draft_version.dandiset.identifier}/'
             f'versions/{draft_version.version}/assets/{asset.asset_id}/',
             {'metadata': new_metadata},
-            format='json',
         ).status_code
         == 401
     )
@@ -1526,7 +1502,6 @@ def test_asset_rest_update_not_an_owner(api_client, user, draft_version, asset):
             f'/api/dandisets/{draft_version.dandiset.identifier}/'
             f'versions/{draft_version.version}/assets/{asset.asset_id}/',
             {'metadata': new_metadata},
-            format='json',
         ).status_code
         == 403
     )
@@ -1544,7 +1519,6 @@ def test_asset_rest_update_published_version(api_client, user, published_version
         f'/api/dandisets/{published_version.dandiset.identifier}/'
         f'versions/{published_version.version}/assets/{asset.asset_id}/',
         {'metadata': new_metadata},
-        format='json',
     )
     assert resp.status_code == 405
     assert resp.data == 'Only draft versions can be modified.'
@@ -1566,7 +1540,6 @@ def test_asset_rest_update_to_existing(api_client, user, draft_version, asset_fa
         f'/api/dandisets/{draft_version.dandiset.identifier}/'
         f'versions/{draft_version.version}/assets/{old_asset.asset_id}/',
         {'metadata': existing_asset.metadata, 'blob_id': existing_asset.blob.blob_id},
-        format='json',
     )
     assert resp.status_code == 409
 
@@ -1680,7 +1653,6 @@ def test_asset_rest_delete_zarr_modified(
             },
             'zarr_id': zarr_archive.zarr_id,
         },
-        format='json',
     ).json()
 
     asset = Asset.objects.get(asset_id=resp['asset_id'])
@@ -1691,11 +1663,7 @@ def test_asset_rest_delete_zarr_modified(
     assert ap.aggregate_size == 100
 
     # Pretend to upload more data to the zarr
-    resp = api_client.post(
-        f'/api/zarr/{zarr_archive.zarr_id}/files/',
-        ['foo/bar.txt'],
-        format='json',
-    )
+    resp = api_client.post(f'/api/zarr/{zarr_archive.zarr_id}/files/', ['foo/bar.txt'])
 
     # Delete the asset
     resp = api_client.delete(

--- a/dandiapi/api/tests/test_audit.py
+++ b/dandiapi/api/tests/test_audit.py
@@ -54,7 +54,6 @@ def create_dandiset(
     resp = api_client.post(
         f'/api/dandisets/{"?embargo=true" if embargoed else ""}',
         {'name': name, 'metadata': metadata},
-        format='json',
     )
     assert resp.status_code == 200
 
@@ -96,7 +95,6 @@ def test_audit_change_owners(api_client, user_factory, draft_version):
     resp = api_client.put(
         f'/api/dandisets/{dandiset.identifier}/users/',
         [{'username': u.username} for u in new_owners],
-        format='json',
     )
     assert resp.status_code == 200
 
@@ -134,7 +132,6 @@ def test_audit_update_metadata(api_client, draft_version, user):
             'name': 'baz',
             'metadata': metadata,
         },
-        format='json',
     )
     assert resp.status_code == 200
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -375,9 +375,7 @@ def test_dandiset_rest_create(api_client, user):
     name = 'Test Dandiset'
     metadata = {'foo': 'bar'}
 
-    response = api_client.post(
-        '/api/dandisets/', {'name': name, 'metadata': metadata}, format='json'
-    )
+    response = api_client.post('/api/dandisets/', {'name': name, 'metadata': metadata})
     assert response.data == {
         'identifier': DANDISET_ID_RE,
         'created': TIMESTAMP_RE,
@@ -463,11 +461,7 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
     identifier = '123456'
     metadata = {'foo': 'bar', 'identifier': f'DANDI:{identifier}'}
 
-    response = api_client.post(
-        '/api/dandisets/',
-        {'name': name, 'metadata': metadata},
-        format='json',
-    )
+    response = api_client.post('/api/dandisets/', {'name': name, 'metadata': metadata})
     assert response.data == {
         'identifier': identifier,
         'created': TIMESTAMP_RE,
@@ -566,11 +560,7 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
         ],
     }
 
-    response = api_client.post(
-        '/api/dandisets/',
-        {'name': name, 'metadata': metadata},
-        format='json',
-    )
+    response = api_client.post('/api/dandisets/', {'name': name, 'metadata': metadata})
     assert response.data == {
         'identifier': identifier,
         'created': TIMESTAMP_RE,
@@ -651,9 +641,7 @@ def test_dandiset_rest_create_embargoed(api_client, user):
     name = 'Test Dandiset'
     metadata = {'foo': 'bar'}
 
-    response = api_client.post(
-        '/api/dandisets/?embargo=true', {'name': name, 'metadata': metadata}, format='json'
-    )
+    response = api_client.post('/api/dandisets/?embargo=true', {'name': name, 'metadata': metadata})
     assert response.data == {
         'identifier': DANDISET_ID_RE,
         'created': TIMESTAMP_RE,
@@ -750,9 +738,7 @@ def test_dandiset_rest_create_embargoed_with_award_info(authenticated_api_client
     }
     url = f'/api/dandisets/?{urlencode(query_params)}'
 
-    response = authenticated_api_client.post(
-        url, {'name': name, 'metadata': metadata}, format='json'
-    )
+    response = authenticated_api_client.post(url, {'name': name, 'metadata': metadata})
 
     assert response.status_code == 200
     assert response.data['embargo_status'] == 'EMBARGOED'
@@ -792,9 +778,7 @@ def test_dandiset_rest_create_embargoed_no_funding_info(authenticated_api_client
     query_params = {'embargo': 'true'}
     url = f'/api/dandisets/?{urlencode(query_params)}'
 
-    response = authenticated_api_client.post(
-        url, {'name': name, 'metadata': metadata}, format='json'
-    )
+    response = authenticated_api_client.post(url, {'name': name, 'metadata': metadata})
 
     assert response.status_code == 200
     assert response.data['embargo_status'] == 'EMBARGOED'
@@ -840,9 +824,7 @@ def test_dandiset_rest_create_embargoed_funding_no_award(authenticated_api_clien
     }
     url = f'/api/dandisets/?{urlencode(query_params)}'
 
-    response = authenticated_api_client.post(
-        url, {'name': name, 'metadata': metadata}, format='json'
-    )
+    response = authenticated_api_client.post(url, {'name': name, 'metadata': metadata})
 
     assert response.status_code == 400
 
@@ -860,9 +842,7 @@ def test_dandiset_rest_create_embargoed_award_no_funding(authenticated_api_clien
     }
     url = f'/api/dandisets/?{urlencode(query_params)}'
 
-    response = authenticated_api_client.post(
-        url, {'name': name, 'metadata': metadata}, format='json'
-    )
+    response = authenticated_api_client.post(url, {'name': name, 'metadata': metadata})
 
     assert response.status_code == 400
 
@@ -874,11 +854,7 @@ def test_dandiset_rest_create_with_duplicate_identifier(api_client, admin_user, 
     identifier = dandiset.identifier
     metadata = {'foo': 'bar', 'identifier': f'DANDI:{identifier}'}
 
-    response = api_client.post(
-        '/api/dandisets/',
-        {'name': name, 'metadata': metadata},
-        format='json',
-    )
+    response = api_client.post('/api/dandisets/', {'name': name, 'metadata': metadata})
     assert response.status_code == 400
     assert response.data == f'Dandiset {identifier} already exists'
 
@@ -890,11 +866,7 @@ def test_dandiset_rest_create_with_invalid_identifier(api_client, admin_user):
     identifier = 'abc123'
     metadata = {'foo': 'bar', 'identifier': identifier}
 
-    response = api_client.post(
-        '/api/dandisets/',
-        {'name': name, 'metadata': metadata},
-        format='json',
-    )
+    response = api_client.post('/api/dandisets/', {'name': name, 'metadata': metadata})
     assert response.status_code == 400
     assert response.data == f'Invalid Identifier {identifier}'
 
@@ -1035,7 +1007,6 @@ def test_dandiset_rest_change_owner(
     resp = api_client.put(
         f'/api/dandisets/{dandiset.identifier}/users/',
         [{'username': social_account2.extra_data['login']}],
-        format='json',
     )
 
     assert resp.status_code == 200
@@ -1080,7 +1051,6 @@ def test_dandiset_rest_change_owners_unembargo_in_progress(
             {'username': social_account1.extra_data['login']},
             {'username': social_account2.extra_data['login']},
         ],
-        format='json',
     )
 
     assert resp.status_code == 400
@@ -1108,7 +1078,6 @@ def test_dandiset_rest_add_owner(
             {'username': social_account1.extra_data['login']},
             {'username': social_account2.extra_data['login']},
         ],
-        format='json',
     )
 
     assert resp.status_code == 200
@@ -1148,7 +1117,6 @@ def test_dandiset_rest_add_owner_not_allowed(
             {'username': social_account1.extra_data['login']},
             {'username': social_account2.extra_data['login']},
         ],
-        format='json',
     )
     assert resp.status_code == 403
 
@@ -1172,7 +1140,6 @@ def test_dandiset_rest_remove_owner(
     resp = api_client.put(
         f'/api/dandisets/{dandiset.identifier}/users/',
         [{'username': social_account1.extra_data['login']}],
-        format='json',
     )
 
     assert resp.status_code == 200
@@ -1195,9 +1162,7 @@ def test_dandiset_rest_not_an_owner(api_client, dandiset, user):
     api_client.force_authenticate(user=user)
 
     resp = api_client.put(
-        f'/api/dandisets/{dandiset.identifier}/users/',
-        [{'username': user.username}],
-        format='json',
+        f'/api/dandisets/{dandiset.identifier}/users/', [{'username': user.username}]
     )
     assert resp.status_code == 403
 
@@ -1207,11 +1172,7 @@ def test_dandiset_rest_delete_all_owners_fails(api_client, dandiset, user):
     add_dandiset_owner(dandiset, user)
     api_client.force_authenticate(user=user)
 
-    resp = api_client.put(
-        f'/api/dandisets/{dandiset.identifier}/users/',
-        [],
-        format='json',
-    )
+    resp = api_client.put(f'/api/dandisets/{dandiset.identifier}/users/', [])
     assert resp.status_code == 400
     assert resp.data == ['Cannot remove all draft owners']
 
@@ -1222,11 +1183,7 @@ def test_dandiset_rest_add_owner_does_not_exist(api_client, dandiset, user):
     api_client.force_authenticate(user=user)
     fake_name = user.username + 'butnotreally'
 
-    resp = api_client.put(
-        f'/api/dandisets/{dandiset.identifier}/users/',
-        [{'username': fake_name}],
-        format='json',
-    )
+    resp = api_client.put(f'/api/dandisets/{dandiset.identifier}/users/', [{'username': fake_name}])
     assert resp.status_code == 400
     assert resp.data == [f'User {fake_name} not found']
 
@@ -1236,11 +1193,7 @@ def test_dandiset_rest_add_malformed(api_client, dandiset, user):
     add_dandiset_owner(dandiset, user)
     api_client.force_authenticate(user=user)
 
-    resp = api_client.put(
-        f'/api/dandisets/{dandiset.identifier}/users/',
-        [{'email': user.email}],
-        format='json',
-    )
+    resp = api_client.put(f'/api/dandisets/{dandiset.identifier}/users/', [{'email': user.email}])
     assert resp.status_code == 400
     assert resp.data == [{'username': ['This field is required.']}]
 

--- a/dandiapi/api/tests/test_permission.py
+++ b/dandiapi/api/tests/test_permission.py
@@ -106,9 +106,7 @@ def test_approved_or_readonly(
     # denied after reading the request body
     if url == '/api/zarr/' and method == 'post':
         response = getattr(api_client, method)(
-            url,
-            data={'name': 'test', 'dandiset': dandiset.identifier},
-            format='json',
+            url, data={'name': 'test', 'dandiset': dandiset.identifier}
         )
     else:
         response = getattr(api_client, method)(url)

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -19,9 +19,7 @@ def mb(bytes_size: int) -> int:
 @pytest.mark.django_db
 def test_blob_read(api_client, asset_blob):
     assert api_client.post(
-        '/api/blobs/digest/',
-        {'algorithm': 'dandi:dandi-etag', 'value': asset_blob.etag},
-        format='json',
+        '/api/blobs/digest/', {'algorithm': 'dandi:dandi-etag', 'value': asset_blob.etag}
     ).data == {
         'blob_id': str(asset_blob.blob_id),
         'etag': asset_blob.etag,
@@ -33,9 +31,7 @@ def test_blob_read(api_client, asset_blob):
 @pytest.mark.django_db
 def test_blob_read_sha256(api_client, asset_blob):
     assert api_client.post(
-        '/api/blobs/digest/',
-        {'algorithm': 'dandi:sha2-256', 'value': asset_blob.sha256},
-        format='json',
+        '/api/blobs/digest/', {'algorithm': 'dandi:sha2-256', 'value': asset_blob.sha256}
     ).data == {
         'blob_id': str(asset_blob.blob_id),
         'etag': asset_blob.etag,
@@ -47,9 +43,7 @@ def test_blob_read_sha256(api_client, asset_blob):
 @pytest.mark.django_db
 def test_blob_read_bad_algorithm(api_client, asset_blob):
     resp = api_client.post(
-        '/api/blobs/digest/',
-        {'algorithm': 'sha256', 'value': asset_blob.sha256},
-        format='json',
+        '/api/blobs/digest/', {'algorithm': 'sha256', 'value': asset_blob.sha256}
     )
     assert resp.status_code == 400
     assert resp.data == 'Unsupported Digest Algorithm. Supported: dandi:dandi-etag, dandi:sha2-256'
@@ -58,9 +52,7 @@ def test_blob_read_bad_algorithm(api_client, asset_blob):
 @pytest.mark.django_db
 def test_blob_read_does_not_exist(api_client):
     resp = api_client.post(
-        '/api/blobs/digest/',
-        {'algorithm': 'dandi:dandi-etag', 'value': 'not etag'},
-        format='json',
+        '/api/blobs/digest/', {'algorithm': 'dandi:dandi-etag', 'value': 'not etag'}
     )
     assert resp.status_code == 404
 
@@ -85,7 +77,6 @@ def test_upload_initialize(api_client, user, dandiset_factory, embargoed):
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.data == {
         'upload_id': UUID_RE,
@@ -123,7 +114,6 @@ def test_upload_initialize_unembargo_in_progress(api_client, user, dandiset_fact
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 400
 
@@ -140,7 +130,6 @@ def test_upload_initialize_existing_asset_blob(api_client, user, dandiset, asset
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': asset_blob.etag},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 409
     assert resp.data == 'Blob already exists.'
@@ -161,7 +150,6 @@ def test_upload_initialize_not_an_owner(api_client, user, dandiset):
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 403
     assert not Upload.objects.all().exists()
@@ -182,7 +170,6 @@ def test_upload_initialize_embargo_not_an_owner(api_client, user, dandiset_facto
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 404
     assert resp.json() == {'detail': 'Not found.'}
@@ -205,7 +192,6 @@ def test_upload_initialize_embargo_existing_asset_blob(
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': asset_blob.etag},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 409
     assert resp.data == 'Blob already exists.'
@@ -230,7 +216,6 @@ def test_upload_initialize_embargo_existing_embargoed_asset_blob(
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': embargoed_asset_blob.etag},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 409
     assert resp.data == 'Blob already exists.'
@@ -240,14 +225,7 @@ def test_upload_initialize_embargo_existing_embargoed_asset_blob(
 
 @pytest.mark.django_db
 def test_upload_initialize_unauthorized(api_client):
-    assert (
-        api_client.post(
-            '/api/uploads/initialize/',
-            {},
-            format='json',
-        ).status_code
-        == 401
-    )
+    assert api_client.post('/api/uploads/initialize/', {}).status_code == 401
 
 
 @pytest.mark.django_db(transaction=True)
@@ -261,7 +239,6 @@ def test_upload_complete(api_client, user, upload):
         {
             'parts': [{'part_number': 1, 'size': content_size, 'etag': 'test-etag'}],
         },
-        format='json',
     ).data == {
         'complete_url': HTTP_URL_RE,
         'body': Re(r'.*'),
@@ -282,7 +259,6 @@ def test_upload_complete_embargo(api_client, user, dandiset_factory, embargoed_u
         {
             'parts': [{'part_number': 1, 'size': content_size, 'etag': 'test-etag'}],
         },
-        format='json',
     ).data == {
         'complete_url': HTTP_URL_RE,
         'body': Re(r'.*'),
@@ -306,7 +282,6 @@ def test_upload_complete_embargo_not_an_owner(
             {
                 'parts': [{'part_number': 1, 'size': content_size, 'etag': 'test-etag'}],
             },
-            format='json',
         ).status_code
         == 404
     )
@@ -314,14 +289,7 @@ def test_upload_complete_embargo_not_an_owner(
 
 @pytest.mark.django_db(transaction=True)
 def test_upload_complete_unauthorized(api_client, upload):
-    assert (
-        api_client.post(
-            f'/api/uploads/{upload.upload_id}/complete/',
-            {},
-            format='json',
-        ).status_code
-        == 401
-    )
+    assert api_client.post(f'/api/uploads/{upload.upload_id}/complete/', {}).status_code == 401
 
 
 @pytest.mark.django_db(transaction=True)
@@ -338,7 +306,6 @@ def test_upload_initialize_and_complete(api_client, user, dandiset, content_size
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     ).data
 
     upload_id = initialization['upload_id']
@@ -359,7 +326,6 @@ def test_upload_initialize_and_complete(api_client, user, dandiset, content_size
         {
             'parts': transferred_parts,
         },
-        format='json',
     ).data
 
     # Complete the upload to the object store
@@ -388,7 +354,6 @@ def test_upload_initialize_and_complete_embargo(api_client, user, dandiset_facto
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
             'dandiset': dandiset.identifier,
         },
-        format='json',
     ).data
 
     upload_id = initialization['upload_id']
@@ -409,7 +374,6 @@ def test_upload_initialize_and_complete_embargo(api_client, user, dandiset_facto
         {
             'parts': transferred_parts,
         },
-        format='json',
     ).data
 
     # Complete the upload to the object store

--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -42,7 +42,6 @@ def test_user_registration_email_content(
     api_client.post(
         '/api/users/questionnaire-form/',
         {f'question_{i}': f'answer_{i}' for i in range(len(QUESTIONS))},
-        format='json',
     )
 
     assert len(mailoutbox) == 2
@@ -85,7 +84,6 @@ def test_user_registration_email_count(
     api_client.post(
         '/api/users/questionnaire-form/',
         {f'question_{i}': f'answer_{i}' for i in range(len(QUESTIONS))},
-        format='json',
     )
     assert len(mailoutbox) == email_count
 
@@ -94,10 +92,7 @@ def test_user_registration_email_count(
 def test_user_me(api_client, social_account):
     api_client.force_authenticate(user=social_account.user)
 
-    assert api_client.get(
-        '/api/users/me/',
-        format='json',
-    ).data == serialize_social_account(social_account)
+    assert api_client.get('/api/users/me/').data == serialize_social_account(social_account)
 
 
 @pytest.mark.django_db
@@ -106,10 +101,7 @@ def test_user_me_admin(api_client, admin_user, social_account_factory):
     social_account = social_account_factory(user=admin_user)
     UserMetadata.objects.create(user=admin_user)
 
-    assert api_client.get(
-        '/api/users/me/',
-        format='json',
-    ).data == serialize_social_account(social_account)
+    assert api_client.get('/api/users/me/').data == serialize_social_account(social_account)
 
 
 @pytest.mark.django_db
@@ -122,9 +114,7 @@ def test_user_search(api_client, social_account, social_account_factory):
     social_account_factory()
 
     assert api_client.get(
-        '/api/users/search/?',
-        {'username': social_account.user.username},
-        format='json',
+        '/api/users/search/?', {'username': social_account.user.username}
     ).data == [serialize_social_account(social_account)]
 
 
@@ -134,47 +124,29 @@ def test_user_search_prefer_social(api_client, user_factory, social_account):
 
     # Check that when social account is present, it is used
     assert api_client.get(
-        '/api/users/search/?',
-        {'username': social_account.user.username},
-        format='json',
+        '/api/users/search/?', {'username': social_account.user.username}
     ).data == [serialize_social_account(social_account)]
 
     # Create user without a social account
     user = user_factory()
     api_client.force_authenticate(user=user)
-    assert api_client.get(
-        '/api/users/search/?',
-        {'username': user.username},
-        format='json',
-    ).data == [user_to_dict(user)]
+    assert api_client.get('/api/users/search/?', {'username': user.username}).data == [
+        user_to_dict(user)
+    ]
 
 
 @pytest.mark.django_db
 def test_user_search_blank_username(api_client, user):
     api_client.force_authenticate(user=user)
 
-    assert (
-        api_client.get(
-            '/api/users/search/?',
-            {'username': ''},
-            format='json',
-        ).data
-        == []
-    )
+    assert api_client.get('/api/users/search/?', {'username': ''}).data == []
 
 
 @pytest.mark.django_db
 def test_user_search_no_matches(api_client, user):
     api_client.force_authenticate(user=user)
 
-    assert (
-        api_client.get(
-            '/api/users/search/?',
-            {'username': '_'},
-            format='json',
-        ).data
-        == []
-    )
+    assert api_client.get('/api/users/search/?', {'username': '_'}).data == []
 
 
 @pytest.mark.django_db
@@ -193,11 +165,9 @@ def test_user_search_multiple_matches(api_client, user, user_factory, social_acc
     users = [user_factory(username=username) for username in usernames]
     social_accounts = [social_account_factory(user=user) for user in users]
 
-    assert api_client.get(
-        '/api/users/search/?',
-        {'username': 'odysseus'},
-        format='json',
-    ).data == [serialize_social_account(social_account) for social_account in social_accounts[:3]]
+    assert api_client.get('/api/users/search/?', {'username': 'odysseus'}).data == [
+        serialize_social_account(social_account) for social_account in social_accounts[:3]
+    ]
 
 
 @pytest.mark.django_db
@@ -208,11 +178,7 @@ def test_user_search_limit_enforced(api_client, user, user_factory, social_accou
     users = [user_factory(username=username) for username in usernames]
     social_accounts = [social_account_factory(user=user) for user in users]
 
-    assert api_client.get(
-        '/api/users/search/?',
-        {'username': 'odysseus'},
-        format='json',
-    ).json() == [
+    assert api_client.get('/api/users/search/?', {'username': 'odysseus'}).json() == [
         serialize_social_account(social_account) for social_account in social_accounts[:10]
     ]
 
@@ -226,9 +192,7 @@ def test_user_search_extra_data(api_client, user, social_account, social_account
     social_accounts[-1].extra_data['test'] = social_account.extra_data['login']
 
     assert api_client.get(
-        '/api/users/search/?',
-        {'username': social_account.extra_data['login']},
-        format='json',
+        '/api/users/search/?', {'username': social_account.extra_data['login']}
     ).data == [serialize_social_account(social_account)]
 
 
@@ -300,15 +264,11 @@ def test_user_status(
     # test that only APPROVED users can create dandisets
     name = 'Test Dandiset'
     metadata = {'foo': 'bar'}
-    response: Response = api_client.post(
-        '/api/dandisets/', {'name': name, 'metadata': metadata}, format='json'
-    )
+    response: Response = api_client.post('/api/dandisets/', {'name': name, 'metadata': metadata})
     assert response.status_code == expected_status_code
 
     # test that only APPROVED users show up in search
-    response: Response = api_client.get(
-        '/api/users/search/?', {'username': user.username}, format='json'
-    )
+    response: Response = api_client.get('/api/users/search/?', {'username': user.username})
     assert response.data == expected_search_results_value
 
 

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -586,7 +586,6 @@ def test_version_rest_update(api_client, user, draft_version):
     assert api_client.put(
         f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
         {'metadata': new_metadata, 'name': new_name},
-        format='json',
     ).data == {
         'dandiset': {
             'identifier': draft_version.dandiset.identifier,
@@ -643,7 +642,6 @@ def test_version_rest_update_unembargo_in_progress(api_client, user, draft_versi
     resp = api_client.put(
         f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
         {'metadata': new_metadata, 'name': new_name},
-        format='json',
     )
     assert resp.status_code == 400
 
@@ -660,7 +658,6 @@ def test_version_rest_update_published_version(api_client, user, published_versi
         f'/api/dandisets/{published_version.dandiset.identifier}'
         f'/versions/{published_version.version}/',
         {'metadata': new_metadata, 'name': new_name},
-        format='json',
     )
     assert resp.status_code == 405
     assert resp.data == 'Only draft versions can be modified.'
@@ -677,7 +674,6 @@ def test_version_rest_update_not_an_owner(api_client, user, version):
         api_client.put(
             f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/',
             {'metadata': new_metadata, 'name': new_name},
-            format='json',
         ).status_code
         == 403
     )
@@ -704,7 +700,6 @@ def test_version_rest_update_access_values(api_client, user, draft_version, acce
     resp = api_client.put(
         f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
         {'metadata': new_metadata, 'name': draft_version.name},
-        format='json',
     )
     assert resp.status_code == 200
     draft_version.refresh_from_db()
@@ -731,7 +726,6 @@ def test_version_rest_update_access_missing(api_client, user, draft_version):
     resp = api_client.put(
         f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
         {'metadata': new_metadata, 'name': draft_version.name},
-        format='json',
     )
     assert resp.status_code == 200
     draft_version.refresh_from_db()
@@ -755,7 +749,6 @@ def test_version_rest_update_access_valid(api_client, user, draft_version):
     resp = api_client.put(
         f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
         {'metadata': new_metadata, 'name': draft_version.name},
-        format='json',
     )
     assert resp.status_code == 200
     draft_version.refresh_from_db()
@@ -954,7 +947,6 @@ def test_version_rest_update_no_changed_metadata(
     api_client.put(
         f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
         {'metadata': draft_version.metadata, 'name': draft_version.name},
-        format='json',
     )
 
     draft_version.refresh_from_db()

--- a/dandiapi/zarr/tests/test_zarr.py
+++ b/dandiapi/zarr/tests/test_zarr.py
@@ -25,7 +25,6 @@ def test_zarr_rest_create(authenticated_api_client, user, dandiset):
             'name': name,
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.json() == {
         'name': name,
@@ -51,7 +50,6 @@ def test_zarr_rest_dandiset_malformed(authenticated_api_client, user, dandiset):
             'name': 'My Zarr File!',
             'dandiset': f'{dandiset.identifier}asd',
         },
-        format='json',
     )
     assert resp.status_code == 400
     assert resp.json() == {'dandiset': ['This value does not match the required pattern.']}
@@ -65,7 +63,6 @@ def test_zarr_rest_create_not_an_owner(authenticated_api_client, zarr_archive):
             'name': zarr_archive.name,
             'dandiset': zarr_archive.dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 403
 
@@ -79,7 +76,6 @@ def test_zarr_rest_create_duplicate(authenticated_api_client, user, zarr_archive
             'name': zarr_archive.name,
             'dandiset': zarr_archive.dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 400
     assert resp.json() == ['Zarr already exists']
@@ -100,7 +96,6 @@ def test_zarr_rest_create_embargoed_dandiset(
             'name': zarr_archive.name,
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 200
 
@@ -121,7 +116,6 @@ def test_zarr_rest_create_unembargoing(
             'name': zarr_archive.name,
             'dandiset': dandiset.identifier,
         },
-        format='json',
     )
     assert resp.status_code == 400
 

--- a/dandiapi/zarr/tests/test_zarr_upload.py
+++ b/dandiapi/zarr/tests/test_zarr_upload.py
@@ -26,9 +26,7 @@ def test_zarr_rest_upload_start(authenticated_api_client, user, zarr_archive_fac
 
     # Request upload files
     resp = authenticated_api_client.post(
-        f'/api/zarr/{zarr_archive.zarr_id}/files/',
-        [{'path': 'foo/bar.txt', 'base64md5': '12345'}],
-        format='json',
+        f'/api/zarr/{zarr_archive.zarr_id}/files/', [{'path': 'foo/bar.txt', 'base64md5': '12345'}]
     )
     assert resp.status_code == 200
     assert resp.json() == [HTTP_URL_RE]
@@ -47,9 +45,7 @@ def test_zarr_rest_upload_start(authenticated_api_client, user, zarr_archive_fac
 
     # Request more
     resp = authenticated_api_client.post(
-        f'/api/zarr/{zarr_archive.zarr_id}/files/',
-        [{'path': 'foo/bar2.txt', 'base64md5': '12345'}],
-        format='json',
+        f'/api/zarr/{zarr_archive.zarr_id}/files/', [{'path': 'foo/bar2.txt', 'base64md5': '12345'}]
     )
     assert resp.status_code == 200
     assert resp.json() == [HTTP_URL_RE]
@@ -58,9 +54,7 @@ def test_zarr_rest_upload_start(authenticated_api_client, user, zarr_archive_fac
 @pytest.mark.django_db
 def test_zarr_rest_upload_start_not_an_owner(authenticated_api_client, zarr_archive: ZarrArchive):
     resp = authenticated_api_client.post(
-        f'/api/zarr/{zarr_archive.zarr_id}/files/',
-        [{'path': 'foo/bar.txt', 'base64md5': '12345'}],
-        format='json',
+        f'/api/zarr/{zarr_archive.zarr_id}/files/', [{'path': 'foo/bar.txt', 'base64md5': '12345'}]
     )
     assert resp.status_code == 403
 


### PR DESCRIPTION
The setting `"TEST_REQUEST_DEFAULT_FORMAT": "json"` in: https://github.com/kitware-resonant/cookiecutter-resonant/blob/8546ec918977f7aaca42cc290fe97632fdd87eeb/django-resonant-settings/resonant_settings/rest_framework.py#L63-L64 ensures that `APIRequestFactory` will already format request bodies with JSON:
https://www.django-rest-framework.org/api-guide/testing/#setting-the-default-format