### PR TITLE
Don't retry _delete_object_tags

### DIFF
--- a/dandiapi/api/services/embargo/utils.py
+++ b/dandiapi/api/services/embargo/utils.py
@@ -53,7 +53,6 @@ def retry(times: int, exceptions: tuple[type[Exception]]):
     return decorator
 
 
-@retry(times=3, exceptions=(Exception,))
 def _delete_object_tags(blob: str):
     existing_tags: dict[str, str] = default_storage.get_tags(blob)
     filtered_tags = {key: val for key, val in existing_tags.items() if key != 'embargoed'}


### PR DESCRIPTION
Boto3 does automatically retries failed requests, and so including the `retry` decorator on the `_delete_object_tags` function can cause many more retries/requests to occur than is desirable.