### PR TITLE
Do not even bother specifying login/token for DOCKER while building/testing dandi-cli

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -22,18 +22,10 @@ jobs:
 
       - name: Build Docker image
         run: |
-          if [ -n "$DOCKER_LOGIN$DOCKER_TOKEN" ]; then
-              docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
-          else
-              echo "Not logging in to docker since no credentials were provided, might hit limits below"
-          fi
           docker build \
             -t dandiarchive/dandiarchive-api \
             -f dev/django-public.Dockerfile \
             .
-        env:
-          DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
-          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Export Docker image
         run: |


### PR DESCRIPTION
No need to expose even optionally IMHO and potentially introduces variability in runs, thus why not to avoid?