### PR TITLE
Improve Zarr upload tests

### DIFF
--- a/dandiapi/zarr/tests/test_zarr_upload.py
+++ b/dandiapi/zarr/tests/test_zarr_upload.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import requests
 from zarr_checksum.checksum import EMPTY_CHECKSUM
 
 from dandiapi.api.models.dandiset import Dandiset
@@ -11,8 +12,14 @@ from dandiapi.zarr.models import ZarrArchive, ZarrArchiveStatus
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('embargoed', [False, True])
-def test_zarr_rest_upload_start(authenticated_api_client, user, zarr_archive_factory, embargoed):
+def test_zarr_rest_upload_start(
+    authenticated_api_client,
+    user,
+    zarr_archive_factory,
+    embargoed: bool,  # noqa: FBT001
+):
     zarr_archive = zarr_archive_factory(
+        dandiset__owners=[user],
         dandiset__embargo_status=Dandiset.EmbargoStatus.EMBARGOED
         if embargoed
         else Dandiset.EmbargoStatus.OPEN,
@@ -22,39 +29,46 @@ def test_zarr_rest_upload_start(authenticated_api_client, user, zarr_archive_fac
         file_count=1,
         size=100,
     )
-    add_dandiset_owner(zarr_archive.dandiset, user)
 
-    # Request upload files
     resp = authenticated_api_client.post(
-        f'/api/zarr/{zarr_archive.zarr_id}/files/', [{'path': 'foo/bar.txt', 'base64md5': '12345'}]
+        f'/api/zarr/{zarr_archive.zarr_id}/files/',
+        [{'path': 'foo/bar.txt', 'base64md5': 'DMF1ucDxtqgxw5niaXcmYQ=='}],
     )
     assert resp.status_code == 200
-    assert resp.json() == [HTTP_URL_RE]
-
-    if embargoed:
-        assert 'x-amz-tagging' in resp.json()[0]
-    else:
-        assert 'x-amz-tagging' not in resp.json()[0]
-
-    # Assert fields updated
+    upload_urls = resp.json()
+    assert upload_urls == [HTTP_URL_RE]
     zarr_archive.refresh_from_db()
     assert zarr_archive.status == ZarrArchiveStatus.PENDING
     assert zarr_archive.checksum is None
     assert zarr_archive.file_count == 0
     assert zarr_archive.size == 0
 
-    # Request more
-    resp = authenticated_api_client.post(
-        f'/api/zarr/{zarr_archive.zarr_id}/files/', [{'path': 'foo/bar2.txt', 'base64md5': '12345'}]
+    upload_extra_headers = {}
+    if embargoed:
+        upload_extra_headers['x-amz-tagging'] = 'embargoed=true'
+    upload_resp = requests.put(
+        upload_urls[0],
+        data=b'a',
+        headers={
+            'Content-MD5': 'DMF1ucDxtqgxw5niaXcmYQ==',
+            **upload_extra_headers,
+        },
     )
-    assert resp.status_code == 200
-    assert resp.json() == [HTTP_URL_RE]
+    assert upload_resp.status_code == 200
+    object_path = zarr_archive.s3_path('foo/bar.txt')
+    assert ZarrArchive.storage.exists(object_path)
+    tags = ZarrArchive.storage.get_tags(object_path)
+    if embargoed:
+        assert tags == {'embargoed': 'true'}
+    else:
+        assert tags == {}
 
 
 @pytest.mark.django_db
 def test_zarr_rest_upload_start_not_an_owner(authenticated_api_client, zarr_archive: ZarrArchive):
     resp = authenticated_api_client.post(
-        f'/api/zarr/{zarr_archive.zarr_id}/files/', [{'path': 'foo/bar.txt', 'base64md5': '12345'}]
+        f'/api/zarr/{zarr_archive.zarr_id}/files/',
+        [{'path': 'foo/bar.txt', 'base64md5': 'DMF1ucDxtqgxw5niaXcmYQ=='}],
     )
     assert resp.status_code == 403
 


### PR DESCRIPTION
* Improve coverage of `test_zarr_rest_upload_start`, by actually uploading a file
* Remove unnecessary code from `test_audit` tests, outside the scope of testing audit records