### PR TITLE
Add support to open NIfTI and Zarr assets in NeuroGlass ephemeral mode

### DIFF
--- a/web/src/utils/externalServices.ts
+++ b/web/src/utils/externalServices.ts
@@ -71,6 +71,14 @@ const EXTERNAL_SERVICES: ExternalService[] = [
     regex: /\.nii(\.gz)?$|\.zarr$/,
     maxsize: Infinity,
     endpoint: redirectNeuroglancerUrl,
+  },
+
+  {
+    name: "NeuroGlass",
+    regex: /\.nii(\.gz)?$|\.(ome|nii)\.zarr$/,
+    maxsize: Infinity,
+    endpoint:
+      "https://www.neuroglass.io/new?resource=$asset_dandi_url$",
   }
 ];
 


### PR DESCRIPTION
Supported formats include `.nii`, `.nii.gz`, `.ome.zarr`, and `.nii.zarr`.

Here is a [link](https://www.neuroglass.io/new?resource=https://api.dandiarchive.org/api/assets/012dd675-6bc9-429b-920d-5d8ac8afa681) to an example DANDI asset opened in NeuroGlass.

cc @satra @ayendiki @balbasty