### PR TITLE
Flag all warnings as test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,9 +236,9 @@ addopts = [
   "--ds=dandiapi.settings.testing",
 ]
 filterwarnings = [
-  # "error",
+  "error",
   # pytest often causes unclosed socket warnings
   "ignore:unclosed <socket\\.socket:ResourceWarning",
-  # https://github.com/celery/kombu/issues/1339
-  "ignore:SelectableGroups dict interface is deprecated:DeprecationWarning:kombu",
+  # TODO: Remove this with pytest_factoryboy
+  "ignore:Using a <class 'dict'> as model type:UserWarning:pytest_factoryboy.fixture",
 ]


### PR DESCRIPTION
This ensures that all warnings (which were important enough for a library to emit) are affirmatively acted upon. False positive or WONTFIX warnings can always be ignored via `filterwarnings`.