### PR TITLE
Fix bug resulting from typo and small refactor

### DIFF
--- a/dandiapi/api/checks.py
+++ b/dandiapi/api/checks.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 from django.conf import settings
 from django.core.checks import Error, register
 
-from dandiapi.api.doi import DANDI_DOI_SETTINGS
+from dandiapi.api.doi import DANDI_DOI_SETTINGS, doi_configured
 
 
 @register()
 def check_doi_settings(app_configs, **kwargs):
-    any_doi_setting = any(setting is not None for setting, _ in DANDI_DOI_SETTINGS)
-    if not any_doi_setting:
+    if not doi_configured():
         # If no DOI settings are defined, DOIs will not be created on publish.
         return []
     errors = []

--- a/dandiapi/api/doi.py
+++ b/dandiapi/api/doi.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 # All of the required DOI configuration settings
 DANDI_DOI_SETTINGS = [
     (settings.DANDI_DOI_API_URL, 'DANDI_DOI_API_URL'),
-    (settings.DANDI_DOI_API_URL, 'DANDI_DOI_API_USER'),
+    (settings.DANDI_DOI_API_USER, 'DANDI_DOI_API_USER'),
     (settings.DANDI_DOI_API_PASSWORD, 'DANDI_DOI_API_PASSWORD'),
     (settings.DANDI_DOI_API_PREFIX, 'DANDI_DOI_API_PREFIX'),
 ]


### PR DESCRIPTION
This PR 

1. fixes a bug resulting from a typo in the definition of `DANDI_DOI_SETTINGS` in `dandiapi/api/`.
2. deduplicates code by utilizing `doi_configured()` in `check_doi_settings()` in `dandiapi/api/checks.py`.