### PR TITLE
Published asset deletion protection design doc

### DIFF
--- a/doc/design/s3-object-lock-legal-holds.md
+++ b/doc/design/s3-object-lock-legal-holds.md
@@ -15,7 +15,7 @@ Currently, while our application logic prevents modification of published assets
 - Published asset blobs MUST be immutable at the S3 infrastructure level
 - The immutability mechanism MUST not interfere with the existing trailing delete functionality (S3 Bucket Versioning)
 - The solution MUST be compatible with future garbage collection features
-- The mechanism MUST be efficient when applied to large numbers of blobs during publication
+- The mechanism SHOULD be efficient when applied to large numbers of blobs during publication
 - There MUST be some sort of "backdoor" that allows deletion of published blobs if necessary, in case of extreme circumstances that warrant deletion of a published asset and/or dandiset
 
 ## Proposed Solution


### PR DESCRIPTION
This PR proposes a design for #2501, and provides "instance protection"-like safety guards for published assets as requested in https://github.com/dandi/dandi-archive/pull/2367#issuecomment-3155960243.