### PR TITLE
Add asset metadata URL to external services data

### DIFF
--- a/web/src/utils/externalServices.ts
+++ b/web/src/utils/externalServices.ts
@@ -132,8 +132,8 @@ export function getExternalServices(path: AssetPath, info: {dandisetId: string, 
   // Formulate the two possible asset URLs -- the direct S3 link to the relevant
   // object, and the DANDI URL that redirects to the S3 one.
   const baseApiUrl = import.meta.env.VITE_APP_DANDI_API_ROOT;
-  const assetDandiUrl = `${baseApiUrl}assets/${path.asset?.asset_id}/download/`;
   const assetDandiMetadataUrl = `${baseApiUrl}assets/${path.asset?.asset_id}/`;
+  const assetDandiUrl = `${assetDandiMetadataUrl}download/`;
   const assetS3Url = trimEnd((path.asset as AssetFile).url, '/');
   const assetId = path.asset?.asset_id;
 


### PR DESCRIPTION
It turns out that NeuroGlass needs the `/assets/{assets_id}/` endpoint and not the `/assets/{assets_id}/download/` endpoint, so I have included that change here.

See examples below:
- URL that does not work: https://www.neuroglass.io/new?resource=https://api.dandiarchive.org/api/assets/3b86f844-abac-4705-9fbf-10e911f5e177/download/
- URL that works: https://www.neuroglass.io/new?resource=https://api.dandiarchive.org/api/assets/3b86f844-abac-4705-9fbf-10e911f5e177/