### PR TITLE
Remove the `dandiapi.__version__` attribute

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -55,6 +55,8 @@ jobs:
       DJANGO_DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org/
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # fetch history for all branches and tags
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Run pre-commit

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out this repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # fetch history for all branches and tags
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # fetch history for all branches and tags
 
       - uses: actions/setup-node@v5
         with:
@@ -83,6 +85,8 @@ jobs:
       VITE_APP_OAUTH_CLIENT_ID: Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl
     steps:
     - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0 # fetch history for all branches and tags
 
     - uses: actions/setup-node@v5
       with:

--- a/dandiapi/__init__.py
+++ b/dandiapi/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from importlib.metadata import version
-
 # This project module is imported for us when Django starts. To ensure that Celery app is always
 # defined prior to any shared_task definitions (so those tasks will bind to the app), import
 # the Celery module here for side effects.
@@ -9,5 +7,3 @@ from .celery import app as _celery_app  # noqa: F401
 
 # Do not import anything else from this file, to avoid interfering with the startup order of the
 # Celery app and Django's settings.
-
-__version__ = version('dandiapi')

--- a/dandiapi/api/tests/test_info.py
+++ b/dandiapi/api/tests/test_info.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from django.conf import settings
 
-from dandiapi import __version__
 from dandiapi.api.views.info import get_schema_url
+
+from .fuzzy import Re
 
 
 def test_rest_info(api_client):
@@ -16,7 +17,8 @@ def test_rest_info(api_client):
     assert resp.json() == {
         'schema_version': settings.DANDI_SCHEMA_VERSION,
         'schema_url': schema_url,
-        'version': __version__,
+        # Matches setuptools_scm's versioning scheme "no-guess-dev"
+        'version': Re(r'\d+\.\d+\.\d+(\.post1\.dev\d+\+g[0-9a-f]{7,}(\.d\d{8})?)?'),
         'cli-minimal-version': '0.60.0',
         'cli-bad-versions': [],
         'services': {

--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 from urllib.parse import ParseResult, urlencode, urlparse, urlunparse
 
 from django.conf import settings
@@ -8,8 +9,6 @@ from drf_yasg.utils import no_body, swagger_auto_schema
 from rest_framework import serializers
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
-
-from dandiapi import __version__
 
 
 def get_schema_url():
@@ -74,7 +73,7 @@ def info_view(request):
         data={
             'schema_version': settings.DANDI_SCHEMA_VERSION,
             'schema_url': get_schema_url(),
-            'version': __version__,
+            'version': importlib.metadata.version('dandiapi'),
             'cli-minimal-version': '0.60.0',
             'cli-bad-versions': [],
             'services': {


### PR DESCRIPTION
Generally, the `__version__` attribute on packages in unnecessary, preferring `importlib.metadata.version`. This is available in the Python standard library and provides a single source of truth for package versions.

For more opinionated discussion, see: https://discuss.python.org/t/please-make-package-version-go-away/58501

Relatedly, ensure that CI is always able to compute the current version from Git.