### PR TITLE
Don't rely on `replaces` to avoid running migration 0028

### DIFF
--- a/dandiapi/api/migrations/0028_default_oauth_application.py
+++ b/dandiapi/api/migrations/0028_default_oauth_application.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from django.db import migrations
+from contextlib import suppress
+
+from django.db import IntegrityError, migrations
 from oauth2_provider.settings import oauth2_settings
 
 DEFAULT_NAME = 'DANDI GUI'
@@ -10,19 +12,24 @@ DEFAULT_CLIENT_ID = 'Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl'
 
 def create_application(apps, schema_editor):
     Application = apps.get_model(oauth2_settings.APPLICATION_MODEL)
-    Application.objects.create(
-        # Production instances should change this.
-        client_id=DEFAULT_CLIENT_ID,
-        # Production instances must change this.
-        redirect_uris='http://localhost:8085/',
-        # These values should not be modified.
-        client_type='public',
-        authorization_grant_type='authorization-code',
-        client_secret='',
-        name=DEFAULT_NAME,
-        # This can be turned off in production if appropriate.
-        skip_authorization=True,
-    )
+    # This work used to be done within a now-deleted "api.0003_default_oauth_application"
+    # migration, so historical databases may already have this object present; if so, this
+    # migration will silently succeed and never run again.
+    # Avoid "get_or_create" to not run an extra query every time in development.
+    with suppress(IntegrityError):
+        Application.objects.create(
+            # Production instances should change this.
+            client_id=DEFAULT_CLIENT_ID,
+            # Production instances must change this.
+            redirect_uris='http://localhost:8085/',
+            # These values should not be modified.
+            client_type='public',
+            authorization_grant_type='authorization-code',
+            client_secret='',
+            name=DEFAULT_NAME,
+            # This can be turned off in production if appropriate.
+            skip_authorization=True,
+        )
 
 
 def reverse_create_application(apps, schema_editor):
@@ -31,12 +38,6 @@ def reverse_create_application(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    replaces = [
-        # For production instances which have already applied 0003, this will not run;
-        # for new databases, this will run normally.
-        ('api', '0003_default_oauth_application'),
-    ]
-
     dependencies = [
         ('api', '0027_delete_stagingapplication'),
         # The latest oauth2_provider migration, to ensure it's fully created


### PR DESCRIPTION
Apparently, the Django migration engine will also skip earlier dependant migrations if `replaces` is used. Instead, just make migration 0028 idempotent when run on existing databases.