### PR TITLE
Apply upstream changes from Resonant 0.41.0

### DIFF
--- a/.copier-answers.resonant.yml
+++ b/.copier-answers.resonant.yml
@@ -1,0 +1,8 @@
+_commit: v0.41.0
+_src_path: gh:kitware-resonant/cookiecutter-resonant
+core_app_name: api
+include_example_code: false
+project_name: DANDI Archive
+project_slug: dandiapi
+python_package_name: dandiapi
+site_domain: api.dandiarchive.org

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 # Additional Celery Beat files
 celerybeat-schedule*
 

--- a/dandiapi/api/apps.py
+++ b/dandiapi/api/apps.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from django.apps import AppConfig
 
 
-class PublishConfig(AppConfig):
+class ApiConfig(AppConfig):
     name = 'dandiapi.api'
-    verbose_name = 'DANDI: Publish'
+    verbose_name = 'DANDI Archive: API'
 
     def ready(self):
         # RUF100 is caused by https://github.com/astral-sh/ruff/issues/60

--- a/dandiapi/api/migrations/0001_default_site.py
+++ b/dandiapi/api/migrations/0001_default_site.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+from django.db import migrations
+
+if TYPE_CHECKING:
+    from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+    from django.db.migrations.state import StateApps
+
+
+def update_default_site(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor):
+    Site = apps.get_model('sites', 'Site')
+
+    # A default site object may or may not exist.
+    # If this is a brand-new database, the post_migrate will not fire until the very end of the
+    # "migrate" command, so the sites app will not have created a default site object yet.
+    # If this is an existing database, the sites app will likely have created an default site
+    # object already.
+    Site.objects.update_or_create(
+        pk=settings.SITE_ID,
+        defaults={
+            'domain': 'api.dandiarchive.org',
+            'name': 'DANDI Archive',
+        },
+    )
+
+
+def rollback_default_site(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor):
+    Site = apps.get_model('sites', 'Site')
+
+    # This is the initial value of the default site object, as populated by the sites app.
+    # If it doesn't exist for some reason, there is nothing to roll back.
+    Site.objects.filter(pk=settings.SITE_ID).update(domain='example.com', name='example.com')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        # This is the final sites app migration
+        ('sites', '0002_alter_domain_unique'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_default_site, rollback_default_site),
+    ]

--- a/dandiapi/api/migrations/0029_merge.py
+++ b/dandiapi/api/migrations/0029_merge.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('api', '0001_default_site'),
+        ('api', '0028_default_oauth_application'),
+    ]

--- a/dandiapi/settings/base.py
+++ b/dandiapi/settings/base.py
@@ -19,6 +19,7 @@ from resonant_settings.oauth_toolkit import *
 from resonant_settings.rest_framework import *
 
 if TYPE_CHECKING:
+    from typing import Any
     from urllib.parse import ParseResult
 
 django_stubs_ext.monkeypatch()
@@ -31,7 +32,7 @@ ROOT_URLCONF = 'dandiapi.urls'
 
 INSTALLED_APPS = [
     # Install local apps first, to ensure any overridden resources are found first
-    'dandiapi.api.apps.PublishConfig',
+    'dandiapi.api.apps.ApiConfig',
     'dandiapi.search.apps.SearchConfig',
     'dandiapi.zarr.apps.ZarrConfig',
     # Apps with overrides
@@ -93,7 +94,7 @@ DATABASES = {
 }
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-STORAGES = {
+STORAGES: dict[str, dict[str, Any]] = {
     # Inject the "default" storage in particular run configurations
     'staticfiles': {
         # CompressedManifestStaticFilesStorage does not work properly with drf-

--- a/dandiapi/settings/heroku_production.py
+++ b/dandiapi/settings/heroku_production.py
@@ -9,3 +9,7 @@ os.environ['DJANGO_CELERY_BROKER_URL'] = os.environ['CLOUDAMQP_URL']
 os.environ['DJANGO_SENTRY_RELEASE'] = os.environ['SOURCE_VERSION']
 
 from .production import *  # isort: skip
+
+# This needs to be set by the HTTPS terminating reverse proxy.
+# Heroku and Render automatically set this.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/dandiapi/settings/production.py
+++ b/dandiapi/settings/production.py
@@ -48,7 +48,7 @@ DANDI_DEV_EMAIL: str = env.str('DJANGO_DANDI_DEV_EMAIL')
 DANDI_ADMIN_EMAIL: str = env.str('DJANGO_DANDI_ADMIN_EMAIL')
 
 # sentry_sdk is able to directly use environment variables like 'SENTRY_DSN', but prefix them
-# with 'DJANGO_' to avoid avoiding conflicts with other Sentry-using services.
+# with 'DJANGO_' to avoid conflicts with other Sentry-using services.
 sentry_sdk.init(
     dsn=env.str('DJANGO_SENTRY_DSN', default=None),
     environment=env.str('DJANGO_SENTRY_ENVIRONMENT', default=None),

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
       "./manage.py",
       "runserver_plus", "0.0.0.0:8000"
     ]
-    # Log printing via Rich is enhanced by a TTY
+    # Log printing is enhanced by a TTY
     tty: true
     environment:
       PYTHONDONTWRITEBYTECODE: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 classifiers = ["Private :: Do Not Upload"]
 dependencies = [
+  # Runtime dependencies, always needed
   "boto3",
   "celery",
   "dandi",  # minimal version is also provided in API /info

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@ min_version = 4.22
 requires =
     tox-uv
 envlist =
-    lint,
-    # type,
-    test,
-    check-migrations,
+    lint
+    # type
+    test
+    check-migrations
 
 [testenv]
 runner = uv-venv-lock-runner

--- a/uv.lock
+++ b/uv.lock
@@ -1078,14 +1078,14 @@ wheels = [
 
 [[package]]
 name = "django-resonant-settings"
-version = "0.33.2"
+version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django-environ" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/f0/12c6ee8d1a8924ccd07da2e002eb8a2f5774f8c72fbd24fc3a5c3b3e28cd/django_resonant_settings-0.33.2.tar.gz", hash = "sha256:a14338ba3b5c94f438dd80a976549fc01e779c3787f21cfab26557a452eed2bd", size = 17494, upload-time = "2025-09-18T14:34:53.866Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/19/4fa035cec41b5c7ceb1348f5aec7692ec6a71b0a1d79cec7746aa2e1926a/django_resonant_settings-0.41.0.tar.gz", hash = "sha256:1324c12d33329a36a198c500695434db57206ac75ee63fa8da35d390831bc8de", size = 17654, upload-time = "2025-10-16T20:11:42.172Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/21/6a6e1e76fb13b39577e5f7d4dbc3a27b83eec0c965abfa6c1e4b62a852fc/django_resonant_settings-0.33.2-py3-none-any.whl", hash = "sha256:2014938e235b872f842508401f10e30ff726af539373ef1108c8b57a252a8973", size = 23474, upload-time = "2025-09-18T14:34:52.808Z" },
+    { url = "https://files.pythonhosted.org/packages/38/d3/ac3e2ffd10139f3f209acafc1f8dd7b9d177c1b7b26b71cdd60e2f36020e/django_resonant_settings-0.41.0-py3-none-any.whl", hash = "sha256:10be63da455eaaa67a34b057dabe9f15b380917c945cb8c33f929ad1afde2b47", size = 24123, upload-time = "2025-10-16T20:11:41.112Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
In particular, this will enable support for making further upgrades from Resonant [with semi-automated tooling](https://github.com/kitware-resonant/cookiecutter-resonant#update).