### PR TITLE
Change docker volume path to accomodate postgres 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:18
     command: postgres -c log_lock_waits=on -c log_min_duration_statement=100
     shm_size: 128mb
     environment:
@@ -13,7 +13,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - postgres:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql
 
   rabbitmq:
     image: rabbitmq:management-alpine


### PR DESCRIPTION
This is a port of https://github.com/kitware-resonant/cookiecutter-resonant/pull/394.

This also pins postgres to a major version, which I think is a good idea given the difficulty of upgrading and the integration of more design-oriented folks on the project.