### PR TITLE
Devcontainer enhancements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
 {
-    "name": "DANDI",
+    "name": "DANDI Archive Django",
     "dockerComposeFile": [
         "../docker-compose.yml",
         "../docker-compose.override.yml"
@@ -20,8 +20,8 @@
         },
         "ghcr.io/nils-geistmann/devcontainers-features/zsh:0": {},
         "ghcr.io/devcontainers-extra/features/fish-apt-get:1": {},
-        "ghcr.io/devcontainers-extra/features/heroku-cli:1": {},
         "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/devcontainers-extra/features/heroku-cli:1.0.5": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers/features/node:1": {
             "version": "20"
@@ -44,10 +44,15 @@
                 // disable pylance type checking in lieu of using the mypy extension since
                 // it will match CI/tox.
                 "python.analysis.typeCheckingMode": "off",
+                "python.analysis.gotoDefinitionInStringLiteral": true,
                 "python.defaultInterpreterPath": "/home/vscode/uv-env/bin/python",
                 "python.testing.pytestEnabled": true,
                 "python.analysis.autoImportCompletions": true,
                 "mypy.enabled": true,
+                // allow for auto-importing from deeper symbols inside of django
+                "python.analysis.packageIndexDepths": [
+                    {"name": "django", "depth": 6}
+                ],
                 "mypy.runUsingActiveInterpreter": true,
                 "ruff.importStrategy": "fromEnvironment"
             }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,6 +12,7 @@ services:
     environment:
       PYTHONDONTWRITEBYTECODE: 1
       PYTHONUNBUFFERED: 1
+      TOX_WORK_DIR: /home/vscode/tox
       UV_ENV_FILE: ./dev/.env.docker-compose
       UV_PROJECT_ENVIRONMENT: /home/vscode/uv-env
       UV_CACHE_DIR: /home/vscode/uv/cache
@@ -51,6 +52,7 @@ services:
     environment:
       PYTHONDONTWRITEBYTECODE: 1
       PYTHONUNBUFFERED: 1
+      TOX_WORK_DIR: /home/vscode/tox
       UV_ENV_FILE: ./dev/.env.docker-compose
       UV_PROJECT_ENVIRONMENT: /home/vscode/uv-env
       UV_CACHE_DIR: /home/vscode/uv/cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     healthcheck:
       test: ["CMD", "pg_isready", "--username", "postgres"]
       start_period: 30s
-      start_interval: 2s
     ports:
       - 5432:5432
     volumes:
@@ -20,7 +19,6 @@ services:
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       start_period: 30s
-      start_interval: 2s
     ports:
       - 5672:5672
       - 15672:15672
@@ -40,7 +38,6 @@ services:
       # "mc ready" doesn't terminate on failure, so time it out
       timeout: 1s
       start_period: 30s
-      start_interval: 2s
     ports:
       - 9000:9000
       - 9001:9001


### PR DESCRIPTION
This adds a few changes that will eventually be in upstream Resonant:
1. Better python defaults for indexing/go to definition
2. Moving `.tox` inside the container
3. Remove `start_interval` for codespaces support