### PR TITLE
Expose allowed schema versions at `/info/` endpoint

### DIFF
--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -53,6 +53,7 @@ class ApiInfoSerializer(serializers.Serializer):
     # Schema
     schema_version = serializers.CharField()
     schema_url = serializers.URLField()
+    allowed_schema_versions = serializers.ListField(child=serializers.CharField())
 
     # Versions
     version = serializers.CharField()
@@ -73,6 +74,7 @@ def info_view(request):
         data={
             'schema_version': settings.DANDI_SCHEMA_VERSION,
             'schema_url': get_schema_url(),
+            'allowed_schema_versions': settings.ALLOWED_DANDI_SCHEMA_VERSIONS,
             'version': importlib.metadata.version('dandiapi'),
             'cli-minimal-version': '0.60.0',
             'cli-bad-versions': [],

--- a/dandiapi/settings/base.py
+++ b/dandiapi/settings/base.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, cast
 from urllib.parse import urlunparse
 
 from corsheaders.defaults import default_headers
+from dandischema.consts import ALLOWED_INPUT_SCHEMAS
 from dandischema.consts import DANDI_SCHEMA_VERSION as _DEFAULT_DANDI_SCHEMA_VERSION
 import django_stubs_ext
 from environ import Env
@@ -175,6 +176,7 @@ logging.getLogger('dandiapi').setLevel(_dandi_log_level)
 DANDI_SCHEMA_VERSION: str = env.str(
     'DJANGO_DANDI_SCHEMA_VERSION', default=_DEFAULT_DANDI_SCHEMA_VERSION
 )
+ALLOWED_DANDI_SCHEMA_VERSIONS: list[str] = ALLOWED_INPUT_SCHEMAS
 
 DANDI_ZARR_PREFIX_NAME: str = env.str('DJANGO_DANDI_ZARR_PREFIX_NAME', default='zarr')
 


### PR DESCRIPTION
This PR closes https://github.com/dandi/dandi-archive/issues/2624


## Release Notes

The `/info/` endpoint now exposes the allowed list of DANDI schema version through `allowed_schema_versions` key value.