### PR TITLE
Update version regex in tests

### DIFF
--- a/dandiapi/api/tests/test_info.py
+++ b/dandiapi/api/tests/test_info.py
@@ -18,7 +18,7 @@ def test_rest_info(api_client):
         'schema_version': settings.DANDI_SCHEMA_VERSION,
         'schema_url': schema_url,
         # Matches setuptools_scm's versioning scheme "no-guess-dev"
-        'version': Re(r'\d+\.\d+\.\d+(\.post1\.dev\d+\+g[0-9a-f]{7,}(\.d\d{8})?)?'),
+        'version': Re(r'\d+(\.\d+){1,2}(\.post\d+(\.dev\d+)?\+g[0-9a-f]{7,}(\.d\d{8})?)?'),
         'cli-minimal-version': '0.60.0',
         'cli-bad-versions': [],
         'services': {


### PR DESCRIPTION
The Ember project had the following version string in their tests:

```
0.0.post1.dev7292+g6b9062efc
```
This broke the tests as the regex expects exactly **three** digits, but their version string only has **two**.

I also noticed that locally, my tests failed against this regex. I had the following version string:

```
0.11.5.post6+g54d98073.d20250709
```
This version string is missing the `dev` section, as well as has a different digit after `post` besides `1` . I updated the version regex to make that dev portion optional, and to generalize the `post` section.

@brianhelba I'm not sure if this breaks from the `no-guess-dev` versioning scheme.