### PR TITLE
feat: implement boolean search parser for dandiset queries

### DIFF
--- a/dandiapi/api/tests/test_search_parser.py
+++ b/dandiapi/api/tests/test_search_parser.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pytest
 from django.db.models import Q
 
 from dandiapi.api.views.dandiset import SearchParser

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -133,9 +133,9 @@ class DandisetOrderingFilter(filters.OrderingFilter):
 
 
 class SearchParser:
-    """
-    Parser for boolean search queries supporting AND, OR, NOT operators,
-    quoted phrases, and parentheses for grouping.
+    """Parser for boolean search queries.
+
+    Supports AND, OR, NOT operators, quoted phrases, and parentheses for grouping.
     """
 
     def __init__(self, query_string):
@@ -218,7 +218,7 @@ class SearchParser:
         start = self.pos
         while self.pos < len(self.query) and self.query[self.pos] != '"':
             self.pos += 1
-        phrase = self.query[start:self.pos]
+        phrase = self.query[start : self.pos]
         if self.pos < len(self.query):
             self.pos += 1  # consume closing quote
 
@@ -233,7 +233,7 @@ class SearchParser:
         while self.pos < len(self.query) and self.query[self.pos] not in ' ()':
             self.pos += 1
 
-        word = self.query[start:self.pos]
+        word = self.query[start : self.pos]
 
         if not word or word in ('AND', 'OR', 'NOT'):
             return Q()
@@ -258,7 +258,7 @@ class SearchParser:
         while self.pos < len(self.query) and self.query[self.pos] not in ' ()':
             self.pos += 1
 
-        word = self.query[start:self.pos]
+        word = self.query[start : self.pos]
         self.pos = saved_pos
 
         if word in ('AND', 'OR', 'NOT'):
@@ -271,7 +271,7 @@ class SearchParser:
         start = self.pos
         while self.pos < len(self.query) and self.query[self.pos] not in ' ()':
             self.pos += 1
-        word = self.query[start:self.pos]
+        word = self.query[start : self.pos]
         if word != expected:
             raise ValueError(f"Expected '{expected}', got '{word}'")
 
@@ -298,7 +298,7 @@ class DandisetSearchFilter(filters.BaseFilterBackend):
             # quoted phrases, and parentheses
             parser = SearchParser(search_term)
             q_filter = parser.parse()
-        except Exception:
+        except (ValueError, IndexError, AttributeError):
             # Fall back to simple word-based search if parsing fails
             search_words = search_term.split()
             q_filter = Q()


### PR DESCRIPTION
Add SearchParser class supporting advanced search syntax including:
- Boolean operators (AND, OR, NOT) for combining search terms
- Quoted phrases for exact matching
- Parentheses for grouping and precedence control
- Implicit AND between adjacent search terms

The parser constructs Django Q objects from search queries, replacing the previous simple word-splitting approach with a more powerful query language that enables complex filtering expressions.

This would be accompanied by a new page in docs.dandiarchive.org. Something like:

# DANDI Archive Search Guide

The DANDI Archive search supports boolean operators and phrase matching to help you find exactly the datasets you need. This guide explains how to construct effective search queries.

### Simple Searches

Just type what you're looking for. The search will find datasets that contain all of your terms:
```
hippocampus mouse
```

This finds datasets that mention both "hippocampus" and "mouse" anywhere in their metadata.

### Exact Phrases

Put quotes around phrases you want to match exactly:
```
"two-photon calcium imaging"
```

This finds only datasets that contain this exact phrase, not datasets that just happen to mention "two", "photon", "calcium", and "imaging" separately.

## Boolean Operators

### OR - Find Either Term

Use `OR` when you want datasets that match any of several alternatives:
```
mouse OR rat
```

This finds datasets about mice, datasets about rats, or datasets about both.
```
hippocampus OR cortex OR amygdala
```

This finds datasets studying any of these three brain regions.

### NOT - Exclude Terms

Use `NOT` to exclude datasets containing certain terms:
```
calcium imaging NOT anesthesia
```

This finds calcium imaging datasets but excludes any that mention anesthesia.

To exclude multiple terms, you can either chain them:
```
hippocampus NOT lesion NOT drug
```

Or group them with `OR`:
```
hippocampus NOT (lesion OR drug)
```

Both approaches exclude datasets mentioning either "lesion" or "drug".

### AND - Require All Terms

You rarely need to type `AND` because it's automatic. These two queries are identical:
```
mouse hippocampus electrophysiology
mouse AND hippocampus AND electrophysiology
```

Both find datasets that mention all three terms.

## Grouping with Parentheses

Use parentheses to control how operators combine:
```
(mouse OR rat) hippocampus
```

This finds hippocampus datasets from either mice or rats.
```
"calcium imaging" (hippocampus OR cortex) NOT lesion
```

This finds calcium imaging datasets from hippocampus or cortex, excluding lesion studies.

You can nest parentheses for complex queries:
```
((mouse OR rat) AND hippocampus) NOT (lesion OR anesthesia)
```

This finds hippocampus datasets from mice or rats, excluding those involving lesions or anesthesia.

## Operator Precedence

When you don't use parentheses, operators are evaluated in this order:

1. `NOT` (highest priority)
2. `AND` (implicit between adjacent terms)
3. `OR` (lowest priority)

This means:
```
mouse OR rat hippocampus
```

Is interpreted as:
```
mouse OR (rat AND hippocampus)
```

To get what you probably meant, use parentheses:
```
(mouse OR rat) hippocampus
```

**Best practices**: 
1. When mixing `OR` with other operators, use parentheses to make your intent clear.
2. Consider different forms of words. Using "hippocamp" will capture "hippocampus" and "hippocampal"
