### PR TITLE
Don't use django setting to store allowed schema versions

### DIFF
--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.metadata
 from urllib.parse import ParseResult, urlencode, urlparse, urlunparse
 
+from dandischema.consts import ALLOWED_INPUT_SCHEMAS
 from django.conf import settings
 from django.urls import reverse
 from drf_yasg.utils import no_body, swagger_auto_schema
@@ -74,7 +75,7 @@ def info_view(request):
         data={
             'schema_version': settings.DANDI_SCHEMA_VERSION,
             'schema_url': get_schema_url(),
-            'allowed_schema_versions': settings.ALLOWED_DANDI_SCHEMA_VERSIONS,
+            'allowed_schema_versions': ALLOWED_INPUT_SCHEMAS,
             'version': importlib.metadata.version('dandiapi'),
             'cli-minimal-version': '0.60.0',
             'cli-bad-versions': [],

--- a/dandiapi/settings/base.py
+++ b/dandiapi/settings/base.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, cast
 from urllib.parse import urlunparse
 
 from corsheaders.defaults import default_headers
-from dandischema.consts import ALLOWED_INPUT_SCHEMAS
 from dandischema.consts import DANDI_SCHEMA_VERSION as _DEFAULT_DANDI_SCHEMA_VERSION
 import django_stubs_ext
 from environ import Env
@@ -176,7 +175,6 @@ logging.getLogger('dandiapi').setLevel(_dandi_log_level)
 DANDI_SCHEMA_VERSION: str = env.str(
     'DJANGO_DANDI_SCHEMA_VERSION', default=_DEFAULT_DANDI_SCHEMA_VERSION
 )
-ALLOWED_DANDI_SCHEMA_VERSIONS: list[str] = ALLOWED_INPUT_SCHEMAS
 
 DANDI_ZARR_PREFIX_NAME: str = env.str('DJANGO_DANDI_ZARR_PREFIX_NAME', default='zarr')
 


### PR DESCRIPTION
Follow up to #2625

As pointed out by @mvandenburgh, there is actually no reason to use a setting for this value, since it is entirely determined by `dandischema`. 