### PR TITLE
Remove `DANDI_SCHEMA_VERSION` as a setting

### DIFF
--- a/dandiapi/api/management/commands/create_dev_dandiset.py
+++ b/dandiapi/api/management/commands/create_dev_dandiset.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from uuid import uuid4
 
 from dandischema.conf import get_instance_config
-from django.conf import settings
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 import djclick as click
@@ -69,7 +69,7 @@ def create_dev_dandiset(*, name: str, email: str, num_extra_owners: int):
         calculate_sha256(blob_id=asset_blob.blob_id)
         asset_blob.refresh_from_db()
     asset_metadata = {
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'encodingFormat': 'text/plain',
         'schemaKey': 'Asset',
         'path': 'foo/bar.txt',

--- a/dandiapi/api/services/version/metadata.py
+++ b/dandiapi/api/services/version/metadata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.conf import settings
+from dandischema.consts import DANDI_SCHEMA_VERSION
 
 from dandiapi.api.models.version import Version
 
@@ -18,7 +18,7 @@ def _normalize_version_metadata(raw_version_metadata: dict, name: str, email: st
     # not specified in the version_metadata
     return {
         'schemaKey': 'Dandiset',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'contributor': [
             {
                 'name': name,

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -5,8 +5,8 @@ import hashlib
 
 from allauth.socialaccount.models import SocialAccount
 from dandischema.conf import get_instance_config
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from dandischema.models import AccessType
-from django.conf import settings
 from django.contrib.auth.models import User
 import factory
 import faker
@@ -118,7 +118,7 @@ class BaseVersionFactory(factory.django.DjangoModelFactory):
 
         metadata = {
             **faker.Faker().pydict(value_types=['str', 'float', 'int']),
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
             'schemaKey': 'Dandiset',
             'description': faker.Faker().sentence(),
             'access': [
@@ -234,7 +234,7 @@ class DraftAssetFactory(factory.django.DjangoModelFactory):
     def metadata(self) -> dict:
         metadata = {
             **faker.Faker().pydict(value_types=['str', 'float', 'int']),
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
             'encodingFormat': 'application/x-nwb',
             'schemaKey': 'Asset',
         }

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from uuid import uuid4
 
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from dandischema.models import AccessType
 from django.conf import settings
 from django.db.utils import IntegrityError
@@ -179,7 +180,7 @@ def test_asset_total_size(asset_factory, asset_blob_factory, zarr_archive_factor
 def test_asset_full_metadata(draft_asset_factory):
     raw_metadata = {
         'foo': 'bar',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
     }
     asset: Asset = draft_asset_factory(metadata=raw_metadata)
 
@@ -199,7 +200,7 @@ def test_asset_full_metadata(draft_asset_factory):
         'contentUrl': [download_url, blob_url],
         'contentSize': asset.blob.size,
         'digest': asset.blob.digest,
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{DANDI_SCHEMA_VERSION}/context.json',
     }
 
 
@@ -208,7 +209,7 @@ def test_asset_full_metadata_zarr(draft_asset_factory):
     zarr_archive = ZarrArchiveFactory.create()
     raw_metadata = {
         'foo': 'bar',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
     }
     asset: Asset = draft_asset_factory(metadata=raw_metadata, blob=None, zarr=zarr_archive)
 
@@ -230,7 +231,7 @@ def test_asset_full_metadata_zarr(draft_asset_factory):
         'digest': asset.digest,
         # This should be injected on all zarr assets
         'encodingFormat': 'application/x-zarr',
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{DANDI_SCHEMA_VERSION}/context.json',
     }
 
 
@@ -240,7 +241,7 @@ def test_asset_full_metadata_access(
 ):
     raw_metadata = {
         'foo': 'bar',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
     }
     embargoed_zarr_asset: Asset = draft_asset_factory(
         metadata=raw_metadata, blob=None, zarr=embargoed_zarr_archive_factory()
@@ -786,7 +787,7 @@ def test_asset_create_path_validation(api_client, asset_blob, path, expected_sta
     api_client.force_authenticate(user=user)
 
     metadata = {
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'encodingFormat': 'application/x-nwb',
         'path': path,
     }
@@ -813,7 +814,7 @@ def test_asset_create_conflicting_path(api_client, asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'foo/bar.txt',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
 
@@ -825,7 +826,7 @@ def test_asset_create_conflicting_path(api_client, asset_blob):
             asset_blob=asset_blob,
             metadata={
                 'path': 'foo/bar.txt/baz.txt',
-                'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+                'schemaVersion': DANDI_SCHEMA_VERSION,
             },
         )
 
@@ -837,7 +838,7 @@ def test_asset_create_conflicting_path(api_client, asset_blob):
             asset_blob=asset_blob,
             metadata={
                 'path': 'foo',
-                'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+                'schemaVersion': DANDI_SCHEMA_VERSION,
             },
         )
 
@@ -1253,7 +1254,7 @@ def test_asset_rest_rename(api_client, asset_blob):
     api_client.force_authenticate(user=user)
 
     # Create asset
-    metadata = {'path': 'foo/bar', 'schemaVersion': settings.DANDI_SCHEMA_VERSION}
+    metadata = {'path': 'foo/bar', 'schemaVersion': DANDI_SCHEMA_VERSION}
     asset = add_asset_to_version(
         user=user, version=draft_version, asset_blob=asset_blob, metadata=metadata
     )
@@ -1650,7 +1651,7 @@ def test_asset_rest_delete_zarr_modified(
         {
             'metadata': {
                 'path': 'sample.zarr',
-                'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+                'schemaVersion': DANDI_SCHEMA_VERSION,
             },
             'zarr_id': zarr_archive.zarr_id,
         },

--- a/dandiapi/api/tests/test_asset_paths.py
+++ b/dandiapi/api/tests/test_asset_paths.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.conf import settings
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from django.db.models import Q, QuerySet
 import pytest
 
@@ -383,7 +383,7 @@ def test_asset_path_ordering(asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'a/z',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
     add_asset_to_version(
@@ -392,7 +392,7 @@ def test_asset_path_ordering(asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'aa/z',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from dandischema.conf import get_instance_config
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
@@ -465,8 +466,8 @@ def test_dandiset_rest_create(api_client):
             f'{user.last_name}, {user.first_name} ({year}) {name} '
             f'(Version draft) [Data set]. DANDI Archive. {url}'
         ),
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{DANDI_SCHEMA_VERSION}/context.json',
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'schemaKey': 'Dandiset',
         'access': [{'schemaKey': 'AccessRequirements', 'status': 'dandi:OpenAccess'}],
         'repository': settings.DANDI_WEB_APP_URL,
@@ -548,8 +549,8 @@ def test_dandiset_rest_create_with_identifier(api_client):
             f'{user.last_name}, {user.first_name} ({year}) {name} '
             f'(Version draft) [Data set]. DANDI Archive. {url}'
         ),
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{DANDI_SCHEMA_VERSION}/context.json',
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'schemaKey': 'Dandiset',
         'access': [{'schemaKey': 'AccessRequirements', 'status': 'dandi:OpenAccess'}],
         'repository': settings.DANDI_WEB_APP_URL,
@@ -642,8 +643,8 @@ def test_dandiset_rest_create_with_contributor(api_client):
         'url': url,
         'dateCreated': UTC_ISO_TIMESTAMP_RE,
         'citation': (f'Jane Doe ({year}) {name} (Version draft) [Data set]. DANDI Archive. {url}'),
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{DANDI_SCHEMA_VERSION}/context.json',
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'schemaKey': 'Dandiset',
         'access': [{'schemaKey': 'AccessRequirements', 'status': 'dandi:OpenAccess'}],
         'repository': settings.DANDI_WEB_APP_URL,
@@ -725,8 +726,8 @@ def test_dandiset_rest_create_embargoed(api_client):
             f'{user.last_name}, {user.first_name} ({year}) {name} '
             f'(Version draft) [Data set]. DANDI Archive. {url}'
         ),
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{DANDI_SCHEMA_VERSION}/context.json',
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'schemaKey': 'Dandiset',
         'access': [
             {

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -5,6 +5,7 @@ from time import sleep
 from typing import TYPE_CHECKING
 
 from dandischema.conf import get_instance_config
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from dandischema.models import AccessType
 from django.conf import settings
 from freezegun import freeze_time
@@ -68,7 +69,7 @@ def test_version_next_published_version_preexisting():
 @pytest.mark.django_db
 def test_draft_version_metadata_computed():
     draft_version = DraftVersionFactory.create()
-    original_metadata = {'schemaVersion': settings.DANDI_SCHEMA_VERSION}
+    original_metadata = {'schemaVersion': DANDI_SCHEMA_VERSION}
     draft_version.metadata = original_metadata
 
     # Save the version to add computed properties to the metadata
@@ -91,7 +92,7 @@ def test_draft_version_metadata_computed():
         'repository': settings.DANDI_WEB_APP_URL,
         'dateCreated': draft_version.dandiset.created.isoformat(),
         'access': [{'schemaKey': 'AccessRequirements', 'status': AccessType.OpenAccess.value}],
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{DANDI_SCHEMA_VERSION}/context.json',
         'assetsSummary': {
             'numberOfBytes': 0,
             'numberOfFiles': 0,
@@ -106,7 +107,7 @@ def test_draft_version_metadata_computed():
 @pytest.mark.django_db
 def test_published_version_metadata_computed():
     published_version = PublishedVersionFactory.create()
-    original_metadata = {'schemaVersion': settings.DANDI_SCHEMA_VERSION}
+    original_metadata = {'schemaVersion': DANDI_SCHEMA_VERSION}
     published_version.metadata = original_metadata
 
     # Save the version to add computed properties to the metadata
@@ -134,7 +135,7 @@ def test_published_version_metadata_computed():
         'repository': settings.DANDI_WEB_APP_URL,
         'dateCreated': published_version.dandiset.created.isoformat(),
         'access': [{'schemaKey': 'AccessRequirements', 'status': AccessType.OpenAccess.value}],
-        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{DANDI_SCHEMA_VERSION}/context.json',
         'assetsSummary': {
             'numberOfBytes': 0,
             'numberOfFiles': 0,
@@ -555,9 +556,9 @@ def test_version_rest_update(api_client):
     new_metadata = {
         '@context': (
             'https://raw.githubusercontent.com/dandi/schema/master/releases/'
-            f'{settings.DANDI_SCHEMA_VERSION}/context.json'
+            f'{DANDI_SCHEMA_VERSION}/context.json'
         ),
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'foo': 'bar',
         'num': 123,
         'list': ['a', 'b', 'c'],
@@ -576,7 +577,7 @@ def test_version_rest_update(api_client):
     url = f'{settings.DANDI_WEB_APP_URL}/dandiset/{draft_version.dandiset.identifier}/draft'
     saved_metadata = {
         **new_metadata,
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'manifestLocation': [
             f'{settings.DANDI_API_URL}/api/dandisets/{draft_version.dandiset.identifier}/versions/draft/assets/'
         ],
@@ -646,9 +647,9 @@ def test_version_rest_update_unembargo_in_progress(api_client):
     new_metadata = {
         '@context': (
             'https://raw.githubusercontent.com/dandi/schema/master/releases/'
-            f'{settings.DANDI_SCHEMA_VERSION}/context.json'
+            f'{DANDI_SCHEMA_VERSION}/context.json'
         ),
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': DANDI_SCHEMA_VERSION,
         'num': 123,
     }
 

--- a/dandiapi/api/tests/test_webdav.py
+++ b/dandiapi/api/tests/test_webdav.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.conf import settings
+from dandischema.consts import DANDI_SCHEMA_VERSION
 import pytest
 
 from dandiapi.api.models.dandiset import Dandiset
@@ -18,7 +18,7 @@ def test_asset_atpath_root_path(api_client, asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'a.txt',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
     add_asset_to_version(
@@ -27,7 +27,7 @@ def test_asset_atpath_root_path(api_client, asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'b.txt',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
 
@@ -73,7 +73,7 @@ def test_asset_atpath_asset(api_client, asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': path,
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
 
@@ -140,7 +140,7 @@ def test_asset_atpath_folder(api_client, asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'foo/bar.txt',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
     add_asset_to_version(
@@ -149,7 +149,7 @@ def test_asset_atpath_folder(api_client, asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'foo/baz.txt',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
 
@@ -209,7 +209,7 @@ def test_asset_atpath_trailing_slash(api_client, asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'foo',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
 
@@ -237,7 +237,7 @@ def test_asset_atpath_path_missing(api_client, asset_blob):
         asset_blob=asset_blob,
         metadata={
             'path': 'foo/bar.txt',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
 

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, cast
 
-from django.conf import settings
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from django.db import transaction
 from django.http import HttpResponse, HttpResponseRedirect
 from django_filters import rest_framework as filters
@@ -220,7 +220,7 @@ class AssetRequestSerializer(serializers.Serializer):
         # will be caught further up the stack and be converted to a DRF ValidationError
         validate_asset_path(data['metadata']['path'])
 
-        data['metadata'].setdefault('schemaVersion', settings.DANDI_SCHEMA_VERSION)
+        data['metadata'].setdefault('schemaVersion', DANDI_SCHEMA_VERSION)
         return data
 
 

--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -4,7 +4,7 @@ import importlib.metadata
 from urllib.parse import ParseResult, urlencode, urlparse, urlunparse
 
 from dandischema.conf import get_instance_config
-from dandischema.consts import ALLOWED_INPUT_SCHEMAS
+from dandischema.consts import ALLOWED_INPUT_SCHEMAS, DANDI_SCHEMA_VERSION
 from django.conf import settings
 from django.urls import reverse
 from drf_yasg.utils import no_body, swagger_auto_schema
@@ -80,7 +80,7 @@ def info_view(request):
             # Set exclude_none=False to prevent any fields set to `None` from being set to a
             # different default value when the JSON is de-serialized into a Pydantic model.
             'instance_config': get_instance_config().model_dump(mode='json', exclude_none=False),
-            'schema_version': settings.DANDI_SCHEMA_VERSION,
+            'schema_version': DANDI_SCHEMA_VERSION,
             'schema_url': get_schema_url(),
             'allowed_schema_versions': ALLOWED_INPUT_SCHEMAS,
             'version': importlib.metadata.version('dandiapi'),

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import TYPE_CHECKING, Any
 
-from django.conf import settings
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.db.models.query_utils import Q
 from django.utils import timezone
@@ -145,7 +145,7 @@ class VersionMetadataSerializer(serializers.ModelSerializer):
         validators = []
 
     def validate(self, data):
-        data['metadata'].setdefault('schemaVersion', settings.DANDI_SCHEMA_VERSION)
+        data['metadata'].setdefault('schemaVersion', DANDI_SCHEMA_VERSION)
         return super().validate(data)
 
 

--- a/dandiapi/settings/base.py
+++ b/dandiapi/settings/base.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, cast
 from urllib.parse import urlunparse
 
 from corsheaders.defaults import default_headers
-from dandischema.consts import DANDI_SCHEMA_VERSION as _DEFAULT_DANDI_SCHEMA_VERSION
 import django_stubs_ext
 from environ import Env
 from resonant_settings.allauth import *
@@ -169,12 +168,6 @@ _dandi_log_level: str = env.str('DJANGO_DANDI_LOG_LEVEL', default='INFO')
 # Configure the logging level on all DANDI loggers.
 logging.getLogger('dandiapi').setLevel(_dandi_log_level)
 
-# This is where the schema version should be set.
-# It can optionally be overwritten with the environment variable, but that should only be
-# considered a temporary fix.
-DANDI_SCHEMA_VERSION: str = env.str(
-    'DJANGO_DANDI_SCHEMA_VERSION', default=_DEFAULT_DANDI_SCHEMA_VERSION
-)
 DANDI_ZARR_PREFIX_NAME: str = env.str('DJANGO_DANDI_ZARR_PREFIX_NAME', default='zarr')
 
 # Required environment variables

--- a/dandiapi/zarr/tests/test_ingest_zarr_archive.py
+++ b/dandiapi/zarr/tests/test_ingest_zarr_archive.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.conf import settings
+from dandischema.consts import DANDI_SCHEMA_VERSION
 import pytest
 from zarr_checksum.checksum import EMPTY_CHECKSUM
 
@@ -127,7 +127,7 @@ def test_ingest_zarr_archive_modified(zarr_archive_factory, zarr_file_factory):
         zarr_archive=zarr_archive,
         metadata={
             'path': 'sample.zarr',
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            'schemaVersion': DANDI_SCHEMA_VERSION,
         },
     )
     assert asset.size == 100


### PR DESCRIPTION
Depends on #2584

For historical reasons, we have a way to specify the dandi schema version as an env var. However, this is never used and is rather nonsensical, since we'd be defining the dandi schema version in conflict with whatever the actual schema version is. As it stands now, the version is pulled from `dandischema.consts` anyway. This PR simply imports that value directly from `dandischema`, replaces all uses of the setting with that value, and removes the setting.