### PR TITLE
Update management command for schema migration

### DIFF
--- a/dandiapi/api/management/commands/migrate_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_version_metadata.py
@@ -53,8 +53,6 @@ def migrate_version_metadata(dandisets: tuple[int, ...], *, include_all: bool):
 
             try:
                 metanew = migrate(locked_version.metadata, skip_validation=True)
-                # We set this manually due to https://github.com/dandi/dandi-schema/issues/353
-                metanew['schemaVersion'] = DANDI_SCHEMA_VERSION
             except Exception as e:
                 logger.exception('Failed to migrate %s', version, exc_info=e)
                 failed_count += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ dependencies = [
   # Runtime dependencies, always needed
   "boto3",
   "celery",
-  "dandi",  # minimal version is also provided in API /info
+  "dandi", # minimal version is also provided in API /info
   # Pin dandischema to exact version to make explicit which schema version is being used
-  "dandischema==0.12.0",  # schema version 0.7.0
+  "dandischema==0.12.1", # schema version 0.7.0
   "django[argon2]",
   "django-allauth",
   "django-auth-style",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin'",
@@ -767,7 +767,7 @@ requires-dist = [
     { name = "boto3" },
     { name = "celery" },
     { name = "dandi" },
-    { name = "dandischema", specifier = "==0.12.0" },
+    { name = "dandischema", specifier = "==0.12.1" },
     { name = "django", extras = ["argon2"] },
     { name = "django-allauth" },
     { name = "django-auth-style" },
@@ -839,7 +839,7 @@ type = [
 
 [[package]]
 name = "dandischema"
-version = "0.12.0"
+version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema", extra = ["format"] },
@@ -849,9 +849,9 @@ dependencies = [
     { name = "requests" },
     { name = "zarr-checksum" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/9e/1747cc720270d0add1dde5ce1b6ef5107df796eb59eea91ec520bd40c696/dandischema-0.12.0.tar.gz", hash = "sha256:66542da2341440f93e08510cd544b331b8959b5420338b33f32fb2c59f95a98b", size = 98740, upload-time = "2025-11-20T23:06:32.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/b7/b44244184c16c1b1cc69070b53325965285b81843ad7755c429e1ffaa341/dandischema-0.12.1.tar.gz", hash = "sha256:481ed1da9481090d8000b3b2373a0d4876043f48d4cddc3364c18e0a97bd0c22", size = 98659, upload-time = "2025-11-26T20:16:58.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/7e/de6eee89ee6cbe0a107159090a1da66d616fbdbd5de15fa72927f80af60c/dandischema-0.12.0-py3-none-any.whl", hash = "sha256:be78a49644bb56913966d478ad2d5289ef0c72522592c3c149bb34c51c964b3f", size = 118310, upload-time = "2025-11-20T23:06:30.678Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/16/959ccdc06e45781d3c41cd552baeaaf563ffb5fe240fbd24efd26b8b2b12/dandischema-0.12.1-py3-none-any.whl", hash = "sha256:88f84cefd7883ce15d5c2f6b92411b1d00fd76468b77950fff25381e17eaab44", size = 118561, upload-time = "2025-11-26T20:16:57.121Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/dandi/dandi-archive/issues/2648

The vendorization update takes effect within the archive immediately, while any existing data is validated against the _old_ schema, since the `schemaVersion` of any dandiset hasn't yet been incremented. Since the data we pass to the validation logic in `dandischema` is populated at runtime, it introduces values that are based on the _new_ schema, while `dandischema` is trying to validate that data against the  _old_ schema, causing validation errors.

This PR augments the existing `migrate_version_metadata` management command, to both fix (last modified 4 years ago) and improve the behavior.

This will be required to run on any DANDI deployment that isn't https://dandiarchive.org, as that is the only deployment where the values haven't actually changed.
