### PR TITLE
Add -v to uvx so we could potentially see what versions are getting installed

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run dandi-api tests in dandi-cli
         if: matrix.dandi-version == 'release'
         run: >
-          uvx --with dandi[test]
+          uvx -v --with dandi[test]
           pytest --pyargs -v --dandi-api dandi
         env:
           DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"
@@ -75,7 +75,7 @@ jobs:
       - name: Run dandi-api tests in dandi-cli
         if: matrix.dandi-version == 'master'
         run: >
-          uvx --with "dandi[test] @ git+https://github.com/dandi/dandi-cli"
+          uvx -v --with "dandi[test] @ git+https://github.com/dandi/dandi-cli"
           pytest --pyargs -v --dandi-api dandi
         env:
           DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"


### PR DESCRIPTION
ATM it is unclear what gets installed, only shows what is downloaded, and we experience odd (to me) failures of dandi-cli testing suggesting that we have outdated dandi-schema.

See e.g. https://github.com/dandi/dandi-archive/actions/runs/19838529451/job/56841589880?pr=2650 for 
- https://github.com/dandi/dandi-archive/pull/2650

which has

```
Run uvx --with dandi[test] pytest --pyargs -v --dandi-api dandi
  uvx --with dandi[test] pytest --pyargs -v --dandi-api dandi
  shell: /usr/bin/bash -e {0}
  env:
    DANDI_TESTS_PULL_DOCKER_COMPOSE: 0
    UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
    UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
    DANDI_TESTS_PERSIST_DOCKER_COMPOSE: 1
Downloading numpy (16.0MiB)
Downloading aiohttp (1.6MiB)
Downloading pygments (1.2MiB)
Downloading cryptography (4.3MiB)
Downloading opencv-python (63.9MiB)
Downloading tensorstore (19.1MiB)
Downloading pandas (12.2MiB)
Downloading numcodecs (8.2MiB)
Downloading h5py (4.5MiB)
Downloading pynwb (1.3MiB)
Downloading pycryptodomex (2.2MiB)
Downloading pydantic-core (2.0MiB)
Downloading bids-validator-deno (41.0MiB)
Downloading ml-dtypes (4.8MiB)
 Downloaded aiohttp
 Downloaded pynwb
 Downloaded pydantic-core
 Downloaded ml-dtypes
 Downloaded pygments
 Downloaded h5py
 Downloaded pycryptodomex
 Downloaded cryptography
 Downloaded numcodecs
 Downloaded tensorstore
 Downloaded numpy
 Downloaded bids-validator-deno
 Downloaded opencv-python
 Downloaded pandas
Installed 110 packages in 329ms
```

and then tests failing due to

```
E         -     '@context': 'https://raw.githubusercontent.com/dandi/schema/master/releases/0.6.10/context.json',
E         ?                                                                                   ^ -
E         +     '@context': 'https://raw.githubusercontent.com/dandi/schema/master/releases/0.7.0/context.json',
E         ?                  
```
