### PR TITLE
Don't return `null` names or usernames from user search endpoint

### DIFF
--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -157,6 +157,30 @@ def test_user_search_extra_data(api_client):
     assert api_client.get('/api/users/search/?', {'username': 'odysseus'}).data == []
 
 
+@pytest.mark.django_db
+def test_user_search_extra_data_no_name(api_client):
+    """Test that a `null` name field in extra_data doesn't result in a `null` in the output."""
+    user = UserFactory.create(social_account__extra_data__name=None)
+
+    api_client.force_authenticate(user=user)
+
+    resp = api_client.get('/api/users/search/?', {'username': user.username})
+    assert len(resp.data) == 1
+    assert resp.data[0]['name'] == user.get_full_name()
+
+
+@pytest.mark.django_db
+def test_user_search_extra_data_no_username(api_client):
+    """Test that a `null` username field in extra_data doesn't result in a `null` in the output."""
+    user = UserFactory.create(social_account__extra_data__login=None)
+
+    api_client.force_authenticate(user=user)
+
+    resp = api_client.get('/api/users/search/?', {'username': user.username})
+    assert len(resp.data) == 1
+    assert resp.data[0]['username'] == user.username
+
+
 @pytest.mark.parametrize(
     ('status', 'expected_status_code', 'expected_search_results_value'),
     [

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -67,12 +67,12 @@ def social_account_to_dict(social_account: SocialAccount):
 def serialize_user(user: User):
     """Serialize a user that's been annotated with a `social_account_data` field."""
     username = user.username
-    name = f'{user.first_name} {user.last_name}'.strip()
+    name = user.get_full_name()
 
     # Prefer social account info if present
     if user.social_account_data is not None:
-        username = user.social_account_data.get('login', username)
-        name = user.social_account_data.get('name', name)
+        username = user.social_account_data.get('login') or username
+        name = user.social_account_data.get('name') or name
 
     return {
         'admin': user.is_superuser,


### PR DESCRIPTION
There is a bug in the API, where if a user has a value of `null` in their social account `name` field, their user isn't properly displayed in the user search (used mainly in the GUI). This in theory could also exist for the `login` field, but since the response from github is guaranteed to have that field filled out with the user's github username, it should be impossible.