### PR TITLE
Update copyright year in footer

### DIFF
--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -4,7 +4,7 @@
       <CookieBanner />
       <v-row>
         <v-col offset="2">
-          &copy; 2019 - 2025 The DANDI Team<br>
+          &copy; 2019 - {{ currentYear }} The DANDI Team<br>
           <a
             target="_blank"
             rel="noopener"
@@ -103,6 +103,7 @@ import { dandiDocumentationUrl } from '@/utils/constants';
 
 const version = import.meta.env.VITE_APP_VERSION;
 const githubLink = import.meta.env.VITE_APP_GIT_REVISION ? `https://github.com/dandi/dandi-archive/commit/${import.meta.env.VITE_APP_GIT_REVISION}` : 'https://github.com/dandi/dandi-archive';
+const currentYear = new Date().getFullYear();
 </script>
 
 <style scoped>


### PR DESCRIPTION
Introducing a minor change to dynamically compute the current year.  In #2144 it was discussed that `...if a user had their system clock misconfigured it could report the wrong year`.  However I think that this is an unlikely edge case.

cc @satra