### PR TITLE
Dynamically display the DANDI Client and Python versions required from PyPI

### DIFF
--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -84,7 +84,7 @@ def info_view(request):
             'schema_url': get_schema_url(),
             'allowed_schema_versions': ALLOWED_INPUT_SCHEMAS,
             'version': importlib.metadata.version('dandiapi'),
-            'cli-minimal-version': '0.60.0',
+            'cli-minimal-version': '0.74.0',
             'cli-bad-versions': [],
             'services': {
                 'api': {'url': api_url},

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -116,10 +116,10 @@
               <v-list>
                 <v-list-item>
                   Install the Python client (DANDI CLI)
-                  in a Python 3.8+ environment using command:
+                  in a Python {{ minPythonVersion }} environment using command:
                 </v-list-item>
                 <v-list-item>
-                  <kbd>pip install "dandi>=0.60.0"</kbd>
+                  <kbd>pip install "dandi>={{ latestDandiVersion }}"</kbd>
                 </v-list-item>
               </v-list>
             </v-expansion-panel-text>
@@ -130,10 +130,26 @@
   </v-menu>
 </template>
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useDandisetStore } from '@/stores/dandiset';
 import CopyText from '@/components/CopyText.vue';
 import { dandiDocumentationUrl } from '@/utils/constants';
+
+const latestDandiVersion = ref('0.74.0');
+const minPythonVersion = ref('>=3.10');
+
+onMounted(async () => {
+  try {
+    const response = await fetch('https://pypi.org/pypi/dandi/json');
+    if (response.ok) {
+      const data = await response.json();
+      minPythonVersion.value = data.info.requires_python;
+      latestDandiVersion.value = data.info.version;
+    }
+  } catch (error) {
+    console.warn('Failed to fetch `dandi` info from PyPI:', error);
+  }
+});
 
 function downloadCommand(identifier: string, version: string): string {
   // Use the special 'DANDI:' url prefix if appropriate.


### PR DESCRIPTION
## Context
The DANDI Archive is pinned to [dandischema==0.12.1](https://github.com/dandi/dandi-archive/blob/bca4f7620cb10e622fabf2521f50f2326e229e48/pyproject.toml#L17C4-L17C23).  And the DANDI Client version [0.74.0](https://github.com/dandi/dandi-cli/releases/tag/0.74.0) pinned the `dandischema` to 0.12.0+.  And the DANDI Client requires [Python >= 3.10](https://github.com/dandi/dandi-cli/blob/a3dd9f966ba796b5b298a943601c357dcc2d35e6/pyproject.toml#L10).  So it looks like the current installation instructions on the front-end are incorrect:

<img width="395" height="349" alt="image" src="https://github.com/user-attachments/assets/ae75d102-00d0-4d29-977f-944415b297ad" />

## Proposed changes
Dynamically fetch the minimum Python version and current DANDI Client version from PyPI, and display on the front-end.

