### PR TITLE
Revert "bf(test): test_nwb2asset_remote_asset which might be stalling here"

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -68,7 +68,7 @@ jobs:
         if: matrix.dandi-version == 'release'
         run: >
           uvx --with dandi[test]
-          pytest --pyargs -v -s --dandi-api -k "not test_nwb2asset_remote_asset" dandi
+          pytest --pyargs -v -s --dandi-api dandi
         env:
           DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"
 
@@ -76,7 +76,7 @@ jobs:
         if: matrix.dandi-version == 'master'
         run: >
           uvx --with "dandi[test] @ git+https://github.com/dandi/dandi-cli"
-          pytest --pyargs -v -s --dandi-api -k "not test_nwb2asset_remote_asset" dandi
+          pytest --pyargs -v -s --dandi-api dandi
         env:
           DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"
 


### PR DESCRIPTION
This reverts commit c88d5c374f83ca12a1299acce9c7338fdcdd4158.

Should not be needed with dandi-cli 0.74.3 after

- https://github.com/dandi/dandi-cli/pull/1795

but who knows?!