### PR TITLE
Display the correct CLI and required python version in the GUI

### DIFF
--- a/dandiapi/api/tests/test_info.py
+++ b/dandiapi/api/tests/test_info.py
@@ -39,3 +39,16 @@ def test_cli_minimal_version_matches_dandischema(api_client):
     # Ensure that local dandischema is compatible with the CLI version
     local_version = importlib.metadata.version('dandischema')
     assert version_range.contains(local_version)
+
+
+def test_cli_requires_python_compatible_with_minimal_version(api_client):
+    """Test that the CLI's required python version is compatible with the minimal version."""
+    info = api_client.get('/api/info/').json()
+    minimal_version: str = info['cli-minimal-version']
+    data = requests.get(f'https://pypi.org/pypi/dandi/{minimal_version}/json').json()
+
+    cli_requires_python: str = info['cli-requires-python']
+    dandischema_requires_python: str = data['info']['requires_python']
+
+    # Test for exact match
+    assert cli_requires_python == dandischema_requires_python

--- a/dandiapi/api/views/info.py
+++ b/dandiapi/api/views/info.py
@@ -48,6 +48,7 @@ class ApiInfoSerializer(serializers.Serializer):
         self.fields.update(
             {
                 'cli-minimal-version': serializers.CharField(),
+                'cli-requires-python': serializers.CharField(),
                 'cli-bad-versions': serializers.ListField(child=serializers.CharField()),
             }
         )
@@ -85,6 +86,7 @@ def info_view(request):
             'allowed_schema_versions': ALLOWED_INPUT_SCHEMAS,
             'version': importlib.metadata.version('dandiapi'),
             'cli-minimal-version': '0.74.0',
+            'cli-requires-python': '>=3.10',
             'cli-bad-versions': [],
             'services': {
                 'api': {'url': api_url},

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -89,6 +89,7 @@ export interface Info {
   schema_url: string;
   schema_version: string;
   'cli-minimal-version': string;
+  'cli-requires-python': string;
 }
 
 export interface DandisetStats {

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -116,7 +116,7 @@
               <v-list>
                 <v-list-item>
                   Install the Python client (DANDI CLI)
-                  in a Python 3.8+ environment using command:
+                  in a Python {{ cliRequiresPython }} environment using command:
                 </v-list-item>
                 <v-list-item>
                   <kbd>pip install "dandi>={{ cliMinimalVersion }}"</kbd>
@@ -155,9 +155,11 @@ const publishedVersions = computed(() => store.versions);
 const currentVersion = computed(() => store.version);
 
 const cliMinimalVersion = ref<string>();
+const cliRequiresPython = ref<string>();
 onMounted(async () => {
   const info = await dandiRest.info();
   cliMinimalVersion.value = info['cli-minimal-version'];
+  cliRequiresPython.value = info['cli-requires-python'];
 });
 
 const selectedDownloadOption = ref('draft');


### PR DESCRIPTION
Supersedes https://github.com/dandi/dandi-archive/pull/2704

This PR instead relies on values from the `/api/info` endpoint, including a new `cli-requires-python` version, used to convey the minimum python version for installing the minimum CLI version.

To keep these values in check, new tests have been added to ensure they are not out of date or inaccurate.