### PR TITLE
Add AI assisted metadata editor button to meditor and Open With menu

### DIFF
--- a/web/src/components/Meditor/Meditor.vue
+++ b/web/src/components/Meditor/Meditor.vue
@@ -283,7 +283,8 @@ const store = useDandisetStore();
 
 const currentDandiset = computed(() => store.dandiset);
 const id = computed(() => currentDandiset.value?.dandiset.identifier);
-const aiEditorURL = computed(() => `https://medit.dandiarchive.org/?dandiset=${id.value}`);
+const baseApiUrl = import.meta.env.VITE_APP_DANDI_API_ROOT;
+const aiEditorURL = computed(() => `https://medit.dandiarchive.org/?dandiset=${id.value}&instance=${baseApiUrl}`);
 const schema: ComputedRef<JSONSchema7> = computed(() => store.schema);
 const model = computed(() => currentDandiset.value?.metadata);
 const readonly = computed(() => !store.userCanModifyDandiset);

--- a/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
+++ b/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
@@ -110,7 +110,8 @@ const aiEditorURL = computed(() => {
   }
 
   const dandisetId = currentDandiset.value.dandiset.identifier;
-  return `https://medit.dandiarchive.org/?dandiset=${dandisetId}`;
+  const baseApiUrl = import.meta.env.VITE_APP_DANDI_API_ROOT;
+  return `https://medit.dandiarchive.org/?dandiset=${dandisetId}&instance=${baseApiUrl}`;
 });
 
 </script>


### PR DESCRIPTION
## Summary

- Adds a **"Beta feature: try AI assisted metadata editing"** button to the top-right of the
 meditor toolbar, linking to `https://medit.dandiarchive.org/?dandiset=<id>`
- Adds an **"AI Metadata Editor (Beta)"** entry to the **Open with** menu in the dandiset landing
 page, also linking to `https://medit.dandiarchive.org/?dandiset=<id>`

Closes #2717                                                                                    

## Test plan                                                                                     

- [ ] Open a dandiset page and click "Open with" — verify "AI Metadata Editor (Beta)" appears in
 the dropdown and links to `https://medit.dandiarchive.org/?dandiset=<dandiset-id>`
- [ ] Click the "Metadata" button to open the meditor — verify the "Beta feature: try AI assisted
 metadata editing" button appears in the toolbar and links to   
 `https://medit.dandiarchive.org/?dandiset=<dandiset-id>`
- [ ] Verify both links open in a new tab
                              
🤖 Generated with [Claude Code](https://claude.com/claude-code)