### PR TITLE
Add content_modified field to dandiset API responses

### DIFF
--- a/dandiapi/api/tests/test_content_modified.py
+++ b/dandiapi/api/tests/test_content_modified.py
@@ -1,4 +1,4 @@
-"""Tests for the modified field reflecting version content changes."""
+"""Tests for the content_modified field reflecting version content changes."""
 
 from __future__ import annotations
 
@@ -7,19 +7,15 @@ import datetime
 from django.utils import timezone
 import pytest
 
-from dandiapi.api.asset_paths import add_asset_paths
 from dandiapi.api.models import Dandiset, Version
 from dandiapi.api.tests.factories import (
-    DraftAssetFactory,
     DraftVersionFactory,
-    UserFactory,
 )
 
 
 @pytest.mark.django_db
-def test_list_modified_reflects_version_modified(api_client):
-    """The listing endpoint's modified field should reflect the version's modified, not the
-    dandiset's."""
+def test_list_content_modified_reflects_version_modified(api_client):
+    """The listing endpoint's content_modified field should reflect the version's modified."""
     draft_version = DraftVersionFactory.create()
     dandiset = draft_version.dandiset
 
@@ -33,16 +29,15 @@ def test_list_modified_reflects_version_modified(api_client):
     assert response.status_code == 200
     result = response.data['results'][0]
 
-    # The API modified should match the version's modified, not the dandiset's stale one
-    dandiset.refresh_from_db()
     draft_version.refresh_from_db()
-    assert result['modified'] != dandiset.modified.isoformat().replace('+00:00', 'Z')
-    assert result['modified'] == draft_version.modified.isoformat().replace('+00:00', 'Z')
+    assert result['content_modified'] == draft_version.modified.isoformat().replace(
+        '+00:00', 'Z'
+    )
 
 
 @pytest.mark.django_db
-def test_retrieve_modified_reflects_version_modified(api_client):
-    """The retrieve endpoint's modified field should reflect the version's modified."""
+def test_retrieve_content_modified_reflects_version_modified(api_client):
+    """The retrieve endpoint's content_modified field should reflect the version's modified."""
     draft_version = DraftVersionFactory.create()
     dandiset = draft_version.dandiset
 
@@ -53,81 +48,14 @@ def test_retrieve_modified_reflects_version_modified(api_client):
     assert response.status_code == 200
 
     draft_version.refresh_from_db()
-    assert response.data['modified'] == draft_version.modified.isoformat().replace('+00:00', 'Z')
-
-
-@pytest.mark.django_db
-def test_modified_updates_on_metadata_edit(api_client):
-    """The version modified timestamp should update when metadata is edited via the API."""
-    user = UserFactory.create()
-    draft_version = DraftVersionFactory.create(dandiset__owners=[user])
-    dandiset = draft_version.dandiset
-    api_client.force_authenticate(user=user)
-
-    original_modified = draft_version.modified
-
-    api_client.put(
-        f'/api/dandisets/{dandiset.identifier}/versions/{draft_version.version}/',
-        {'metadata': {'foo': 'bar'}, 'name': 'Updated Name'},
-        format='json',
+    assert response.data['content_modified'] == draft_version.modified.isoformat().replace(
+        '+00:00', 'Z'
     )
 
-    draft_version.refresh_from_db()
-    assert draft_version.modified > original_modified
-
 
 @pytest.mark.django_db
-def test_modified_updates_on_asset_add(api_client, asset_blob):
-    """The version modified timestamp should update when an asset is added."""
-    user = UserFactory.create()
-    draft_version = DraftVersionFactory.create(dandiset__owners=[user])
-    dandiset = draft_version.dandiset
-    api_client.force_authenticate(user=user)
-
-    original_modified = draft_version.modified
-
-    api_client.post(
-        f'/api/dandisets/{dandiset.identifier}/versions/{draft_version.version}/assets/',
-        {
-            'metadata': {
-                'encodingFormat': 'application/x-nwb',
-                'path': 'test/asset.nwb',
-            },
-            'blob_id': asset_blob.blob_id,
-        },
-        format='json',
-    )
-
-    draft_version.refresh_from_db()
-    assert draft_version.modified > original_modified
-
-
-@pytest.mark.django_db
-def test_modified_updates_on_asset_remove(api_client):
-    """The version modified timestamp should update when an asset is removed."""
-    user = UserFactory.create()
-    draft_version = DraftVersionFactory.create(dandiset__owners=[user])
-    dandiset = draft_version.dandiset
-    asset = DraftAssetFactory.create()
-    draft_version.assets.add(asset)
-    add_asset_paths(asset, draft_version)
-    api_client.force_authenticate(user=user)
-
-    draft_version.refresh_from_db()
-    original_modified = draft_version.modified
-
-    api_client.delete(
-        f'/api/dandisets/{dandiset.identifier}'
-        f'/versions/{draft_version.version}/assets/{asset.asset_id}/',
-    )
-
-    draft_version.refresh_from_db()
-    assert draft_version.modified > original_modified
-
-
-@pytest.mark.django_db
-def test_ordering_by_modified(api_client):
-    """Ordering by modified should sort by version modified timestamps."""
+def test_ordering_by_content_modified(api_client):
+    """Ordering by content_modified should sort by version modified timestamps."""
     now = timezone.now()
 
     # Create 3 dandisets with draft versions
@@ -148,7 +76,8 @@ def test_ordering_by_modified(api_client):
 
     # Ascending
     response = api_client.get(
-        '/api/dandisets/', {'ordering': 'modified', 'draft': 'true', 'empty': 'true'}
+        '/api/dandisets/',
+        {'ordering': 'content_modified', 'draft': 'true', 'empty': 'true'},
     )
     assert response.status_code == 200
     ids = [r['identifier'] for r in response.data['results']]
@@ -160,7 +89,8 @@ def test_ordering_by_modified(api_client):
 
     # Descending
     response = api_client.get(
-        '/api/dandisets/', {'ordering': '-modified', 'draft': 'true', 'empty': 'true'}
+        '/api/dandisets/',
+        {'ordering': '-content_modified', 'draft': 'true', 'empty': 'true'},
     )
     assert response.status_code == 200
     ids = [r['identifier'] for r in response.data['results']]

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -73,10 +73,11 @@ if TYPE_CHECKING:
 
 
 class DandisetOrderingFilter(filters.OrderingFilter):
-    ordering_fields = ['id', 'name', 'modified', 'size', 'stars']
+    ordering_fields = ['id', 'name', 'modified', 'content_modified', 'size', 'stars']
     ordering_description = (
         'Which field to use when ordering the results. '
-        'Options are id, -id, name, -name, modified, -modified, size, -size, stars, -stars.'
+        'Options are id, -id, name, -name, modified, -modified, '
+        'content_modified, -content_modified, size, -size, stars, -stars.'
     )
 
     def filter_queryset(self, request, queryset, view):
@@ -96,17 +97,17 @@ class DandisetOrderingFilter(filters.OrderingFilter):
             queryset = queryset.annotate(
                 name=Subquery(latest_version.values('metadata__name'))
             ).order_by(ordering)
-        elif ordering.endswith('modified'):
-            # modified refers to the modification timestamp of the most
+        elif ordering.endswith('content_modified') or ordering.endswith('modified'):
+            # content_modified/modified refers to the modification timestamp of the most
             # recent version, so a subquery is required
             latest_version = Version.objects.filter(dandiset=OuterRef('pk')).order_by('-created')[
                 :1
             ]
             # get the `modified` field of the most recent version.
-            # '_version' is appended because the Dandiset model already has a `modified` field
+            prefix = '-' if ordering.startswith('-') else ''
             queryset = queryset.annotate(
-                modified_version=Subquery(latest_version.values('modified'))
-            ).order_by(f'{ordering}_version')
+                _content_modified=Subquery(latest_version.values('modified'))
+            ).order_by(f'{prefix}_content_modified')
         elif ordering.endswith('size'):
             latest_version = Version.objects.filter(dandiset=OuterRef('pk')).order_by('-created')[
                 :1

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -200,7 +200,7 @@ class DandisetListSerializer(DandisetSerializer):
     """The dandiset serializer to be used in the listing endpoint."""
 
     class Meta(DandisetSerializer.Meta):
-        fields = [*DandisetSerializer.Meta.fields, 'most_recent_published_version', 'draft_version']
+        fields = [*DandisetSerializer.Meta.fields, 'content_modified', 'most_recent_published_version', 'draft_version']
 
     @swagger_serializer_method(serializer_or_field=DandisetVersionSerializer)
     def get_draft_version(self, dandiset):
@@ -230,8 +230,8 @@ class DandisetListSerializer(DandisetSerializer):
 
         return contact
 
-    def get_modified(self, dandiset):
-        """Return the most recent version's modified timestamp instead of the dandiset's."""
+    def get_content_modified(self, dandiset):
+        """Return the most recent version's modified timestamp (content change time)."""
         draft = self.context['dandisets'].get(dandiset.id, {}).get('draft')
         if draft is not None:
             return draft.modified
@@ -246,7 +246,7 @@ class DandisetListSerializer(DandisetSerializer):
     def get_is_starred(self, dandiset):
         return self.context['stars'][dandiset.id]['starred_by_current_user']
 
-    modified = serializers.SerializerMethodField()
+    content_modified = serializers.SerializerMethodField()
     most_recent_published_version = serializers.SerializerMethodField()
     draft_version = serializers.SerializerMethodField()
 
@@ -263,10 +263,10 @@ class DandisetSearchResultListSerializer(DandisetListSerializer):
 
 class DandisetDetailSerializer(DandisetSerializer):
     class Meta(DandisetSerializer.Meta):
-        fields = [*DandisetSerializer.Meta.fields, 'most_recent_published_version', 'draft_version']
+        fields = [*DandisetSerializer.Meta.fields, 'content_modified', 'most_recent_published_version', 'draft_version']
 
-    def get_modified(self, dandiset):
-        """Return the most recent version's modified timestamp instead of the dandiset's."""
+    def get_content_modified(self, dandiset):
+        """Return the most recent version's modified timestamp (content change time)."""
         try:
             return dandiset.draft_version.modified
         except Version.DoesNotExist:
@@ -276,7 +276,7 @@ class DandisetDetailSerializer(DandisetSerializer):
             return mrpv.modified
         return dandiset.modified
 
-    modified = serializers.SerializerMethodField()
+    content_modified = serializers.SerializerMethodField()
     most_recent_published_version = VersionSerializer(read_only=True, child_context=True)
     draft_version = VersionSerializer(read_only=True, child_context=True)
 


### PR DESCRIPTION
## Summary

Add a new `content_modified` field to the dandiset list and detail API endpoints that returns the most recent version's `modified` timestamp — representing when the dandiset's content was last meaningfully changed (metadata edits, asset add/remove).

This is additive and non-breaking: the existing `modified` field remains unchanged (still the dandiset model's own auto-updated timestamp). Also supports `ordering=content_modified` / `-content_modified` in the listing endpoint.

### Changes (2 production files, no migration)

- **`views/serializers.py`**: Add `content_modified` SerializerMethodField to `DandisetListSerializer` and `DandisetDetailSerializer`
- **`views/dandiset.py`**: Add `content_modified` to `DandisetOrderingFilter`

Addresses #458, #1227, #1864

## Test plan

- [ ] Verify `content_modified` in list endpoint reflects the draft version's modification time
- [ ] Verify `content_modified` in retrieve endpoint reflects the draft version's modification time
- [ ] Verify `ordering=content_modified` / `-content_modified` sorts correctly
- [ ] Verify existing `modified` field is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)