### PR TITLE
Add scrollbar to meditor component for overflowing content

### DIFF
--- a/web/src/components/Meditor/Meditor.vue
+++ b/web/src/components/Meditor/Meditor.vue
@@ -210,7 +210,8 @@
         >
           <v-card class="pa-2 px-1">
             <v-form
-              class="px-7"
+              class="px-7 overflow-y-auto"
+              style="height: 70vh;"
             >
               <v-jsf-wrapper
                 :prop-key="propKey"


### PR DESCRIPTION
## Issue
On Dandiset [001372](https://dandiarchive.org/dandiset/001372), the Dandiset contributor list is long and it is difficult to see the full list of contributors.

<img width="1648" height="908" alt="image" src="https://github.com/user-attachments/assets/45a8747d-1229-4c49-9e48-2852cd8731a5" />

## Proposed changes
- [x] Fix the component height to 70% of the viewport
- [x] Enable a vertical scrollbar when the content overflows