### PR TITLE
Truncate long filenames in file browser

### DIFF
--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -110,8 +110,8 @@
                   >
                     mdi-folder
                   </v-icon>
-                  ..
                 </template>
+                <v-list-item-title>..</v-list-item-title>
               </v-list-item>
 
               <v-list-item
@@ -132,8 +132,10 @@
                       mdi-file
                     </template>
                   </v-icon>
-                  {{ item.name }}
                 </template>
+                <v-list-item-title :title="item.name">
+                  {{ item.name }}
+                </v-list-item-title>
 
                 <template #append>
                   <v-list-item-action>


### PR DESCRIPTION
## Summary
- Fixes #2725
- Moves filename text from the `#prepend` slot (which has no width constraints) into a `v-list-item-title` element, which has built-in CSS for `text-overflow: ellipsis` + `overflow: hidden` + `white-space: nowrap`
- Adds a `title` attribute so the full filename is visible on hover

## Before
![Image](https://github.com/user-attachments/assets/b328dba4-ace6-4bb7-96b5-e8ebab3a33c5)

## Test plan
- [x] Navigate to a dandiset with long filenames (e.g. dandiset 000409, sub-CSH-ZAD-001)
- [x] Verify long filenames truncate with ellipsis instead of overflowing
- [x] Verify full filename appears on hover tooltip
- [x] Verify folder names and ".." navigation still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)