### PR TITLE
Add Blog link to AppBar navigation

### DIFF
--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -151,7 +151,7 @@ import {
   user,
 } from '@/rest';
 import {
-  dandiAboutUrl, dandiDocumentationUrl, dandiHelpUrl, dandihubUrl,
+  dandiAboutUrl, dandiBlogUrl, dandiDocumentationUrl, dandiHelpUrl, dandihubUrl,
 } from '@/utils/constants';
 import UserMenu from '@/components/AppBar/UserMenu.vue';
 import logo from '@/assets/logo.svg';
@@ -191,6 +191,11 @@ const navItems: NavigationItem[] = [
   {
     text: 'About',
     to: dandiAboutUrl,
+    external: true,
+  },
+  {
+    text: 'Blog',
+    to: dandiBlogUrl,
     external: true,
   },
   {

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -1,5 +1,6 @@
 const dandiUrl = 'https://dandiarchive.org';
 const dandiAboutUrl = 'https://about.dandiarchive.org/';
+const dandiBlogUrl = 'https://about.dandiarchive.org/blog/';
 const dandiDocumentationUrl = 'https://docs.dandiarchive.org';
 const dandiHelpUrl = 'https://docs.dandiarchive.org/support/';
 const dandihubUrl = 'https://hub.dandiarchive.org/';
@@ -56,6 +57,7 @@ const DANDISETS_PER_PAGE = 8;
 export {
   dandiUrl,
   dandiAboutUrl,
+  dandiBlogUrl,
   dandiDocumentationUrl,
   dandihubUrl,
   sandboxDocsUrl,


### PR DESCRIPTION
I hope (didn't check) to appear among 

<img width="1810" height="638" alt="image" src="https://github.com/user-attachments/assets/47701d8d-57d3-420a-8b15-aef9288275e6" />

since it is becoming a great resource (thanks to @bendichter recent work iirc) and it should be easier to get to.