### PR TITLE
Fix heroku build

### DIFF
--- a/.github/workflows/backend-production-deploy.yml
+++ b/.github/workflows/backend-production-deploy.yml
@@ -48,7 +48,7 @@ jobs:
         run: curl https://cli-assets.heroku.com/install.sh | sh
 
       - name: Install builds plugin
-        run: heroku plugins:install heroku-builds
+        run: heroku plugins:install @heroku-cli/heroku-builds
 
       - name: Build app into tarball
         run: |

--- a/.github/workflows/backend-staging-deploy.yml
+++ b/.github/workflows/backend-staging-deploy.yml
@@ -34,7 +34,7 @@ jobs:
         run: curl https://cli-assets.heroku.com/install.sh | sh
 
       - name: Install builds plugin
-        run: heroku plugins:install heroku-builds
+        run: heroku plugins:install @heroku-cli/heroku-builds
 
       - name: Build app into tarball
         run: |


### PR DESCRIPTION
We were installing an old version of the heroku builds plugin (`v0.0.29`). This PR uses the correct installation invocation, as provided by the docs (`v1.0.9`).

This only started failing after https://github.com/dandi/dandi-archive/pull/2738.