### PR TITLE
Replace hardcoded DANDI identifiers with dynamic instance config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,11 @@ repos:
   rev: v2.3.0
   hooks:
   - id: codespell
+- repo: local
+  hooks:
+  - id: no-hardcoded-dandi-identifiers
+    name: Check for hardcoded DANDI identifiers in frontend
+    entry: scripts/check-no-hardcoded-dandi.sh
+    language: script
+    files: '\.(vue|ts)$'
+    exclude: '(node_modules|__tests__|\.test\.|\.spec\.)'

--- a/e2e/tests/dandisetLandingPage.spec.ts
+++ b/e2e/tests/dandisetLandingPage.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { clientUrl, registerNewUser, LOGOUT_BUTTON_TEXT, registerDandiset } from "../utils.ts";
+import { clientUrl, registerNewUser, LOGOUT_BUTTON_TEXT, registerDandiset, fetchInstanceConfig } from "../utils.ts";
 import { faker } from "@faker-js/faker";
 
 test.describe("dandiset landing page", async () => {
@@ -48,6 +48,14 @@ test.describe("dandiset landing page", async () => {
 
   test.describe("how to cite tab", () => {
     let dandisetId: string | undefined;
+    let instanceName: string;
+    let instanceIdentifier: string | null;
+
+    test.beforeAll(async () => {
+      const config = await fetchInstanceConfig();
+      instanceName = config.instance_name;
+      instanceIdentifier = config.instance_identifier;
+    });
 
     test.beforeEach(async ({ page }) => {
       await registerNewUser(page);
@@ -82,16 +90,20 @@ test.describe("dandiset landing page", async () => {
       await expect(page.getByRole("heading", { name: "Full Citation" })).toBeVisible();
       await expect(page.getByRole("heading", { name: "Materials and Methods" })).toBeVisible();
       await expect(page.getByRole("heading", { name: "Data Availability Statement" })).toBeVisible();
-      await expect(page.getByRole("heading", { name: "DANDI Identifier" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: `${instanceName} Identifier` })).toBeVisible();
       await expect(page.getByRole("heading", { name: "License" })).toBeVisible();
     });
 
-    test("displays DANDI identifier with correct format", async ({ page }) => {
+    test("displays instance-specific identifier with correct format", async ({ page }) => {
       await page.getByRole("tab", { name: "How to Cite" }).click();
 
-      // The identifier should follow the format DANDI:<id>/draft
-      await expect(page.getByText(`DANDI:${dandisetId}/draft`)).toBeVisible();
-      await expect(page.getByText("DANDI Archive RRID: SCR_017571")).toBeVisible();
+      // The identifier should follow the format <instance_name>:<id>/draft
+      await expect(page.getByText(`${instanceName}:${dandisetId}/draft`)).toBeVisible();
+      // The archive info should use the instance name and identifier from the API
+      const expectedArchiveInfo = instanceIdentifier
+        ? `${instanceName} Archive ${instanceIdentifier}`
+        : `${instanceName} Archive`;
+      await expect(page.getByText(expectedArchiveInfo)).toBeVisible();
     });
 
     test("displays citation format selector", async ({ page }) => {

--- a/e2e/tests/dandisetLandingPage.spec.ts
+++ b/e2e/tests/dandisetLandingPage.spec.ts
@@ -90,20 +90,27 @@ test.describe("dandiset landing page", async () => {
       await expect(page.getByRole("heading", { name: "Full Citation" })).toBeVisible();
       await expect(page.getByRole("heading", { name: "Materials and Methods" })).toBeVisible();
       await expect(page.getByRole("heading", { name: "Data Availability Statement" })).toBeVisible();
-      await expect(page.getByRole("heading", { name: `${instanceName} Identifier` })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Dandiset Identifier" })).toBeVisible();
+      if (instanceIdentifier) {
+        await expect(page.getByRole("heading", { name: "Archive Identifier" })).toBeVisible();
+      }
       await expect(page.getByRole("heading", { name: "License" })).toBeVisible();
     });
 
-    test("displays instance-specific identifier with correct format", async ({ page }) => {
+    test("displays dandiset identifier with correct format", async ({ page }) => {
       await page.getByRole("tab", { name: "How to Cite" }).click();
 
-      // The identifier should follow the format <instance_name>:<id>/draft
+      // The dandiset identifier should follow the format <instance_name>:<id>/draft
       await expect(page.getByText(`${instanceName}:${dandisetId}/draft`)).toBeVisible();
-      // The archive info should use the instance name and identifier from the API
-      const expectedArchiveInfo = instanceIdentifier
-        ? `${instanceName} Archive ${instanceIdentifier}`
-        : `${instanceName} Archive`;
-      await expect(page.getByText(expectedArchiveInfo)).toBeVisible();
+    });
+
+    test("displays archive identifier when configured", async ({ page }) => {
+      await page.getByRole("tab", { name: "How to Cite" }).click();
+
+      if (instanceIdentifier) {
+        const expectedArchiveId = `${instanceName} Archive ${instanceIdentifier}`;
+        await expect(page.getByText(expectedArchiveId)).toBeVisible();
+      }
     });
 
     test("displays citation format selector", async ({ page }) => {

--- a/e2e/tests/dandisetsPage.spec.ts
+++ b/e2e/tests/dandisetsPage.spec.ts
@@ -1,9 +1,16 @@
 import { expect, test } from "@playwright/test";
-import { registerDandiset, registerNewUser, uniqueId } from "../utils.ts";
+import { registerDandiset, registerNewUser, uniqueId, fetchInstanceConfig } from "../utils.ts";
 import moment from "moment";
 import { faker } from "@faker-js/faker";
 
 test.describe("dandisets page", async () => {
+    let instanceName: string;
+
+    test.beforeAll(async () => {
+        const config = await fetchInstanceConfig();
+        instanceName = config.instance_name;
+    });
+
     test("search for Dandisets", async ({ page }) => {
         test.slow();
         await registerNewUser(page);
@@ -28,7 +35,7 @@ test.describe("dandisets page", async () => {
             await page.getByLabel(searchFieldText).fill(name);
             await page.keyboard.press("Enter");
 
-            await expect(page.getByText(`DANDI:${id}`)).toHaveCount(1);
+            await expect(page.getByText(`${instanceName}:${id}`)).toHaveCount(1);
 
             // Clear search bar
             await page.keyboard.down("ControlLeft");
@@ -48,7 +55,7 @@ test.describe("dandisets page", async () => {
         const identifier = await registerDandiset(page, name, description);
         await page.getByRole("tab", { name: "My Dandisets" }).click();
         await expect(page.getByText(name)).toHaveCount(1);
-        await expect(page.getByText(`DANDI:${identifier}`)).toHaveCount(1);
+        await expect(page.getByText(`${instanceName}:${identifier}`)).toHaveCount(1);
         await expect(page.getByText(`Contact ${lastname}, ${firstname}`)).toHaveCount(1);
         await expect(page.getByText(`Updated on ${moment(new Date()).format("LL")}`)).toHaveCount(1);
     });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -5,6 +5,19 @@ const TEST_USER_INITIALS = "AA";
 const LOGOUT_BUTTON_TEXT = "Logout";
 const LOGIN_BUTTON_TEXT = "Log In with GitHub";
 const clientUrl = "http://localhost:8085";
+const apiUrl = "http://localhost:8000/api";
+
+interface InstanceConfig {
+  instance_name: string;
+  instance_identifier: string | null;
+  instance_url: string | null;
+}
+
+async function fetchInstanceConfig(): Promise<InstanceConfig> {
+  const resp = await fetch(`${apiUrl}/info/`);
+  const data = await resp.json();
+  return data.instance_config;
+}
 
 function uniqueId() {
   return Date.now().toString();
@@ -80,6 +93,7 @@ export {
   LOGOUT_BUTTON_TEXT,
   LOGIN_BUTTON_TEXT,
   dismissCookieBanner,
+  fetchInstanceConfig,
   gotoAndLogin,
   registerDandiset,
   registerNewUser,

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -14,7 +14,11 @@ interface InstanceConfig {
 }
 
 async function fetchInstanceConfig(): Promise<InstanceConfig> {
-  const resp = await fetch(`${apiUrl}/info/`);
+  const url = `${apiUrl}/info/`;
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch instance config from ${url}: ${resp.status} ${resp.statusText}`);
+  }
   const data = await resp.json();
   return data.instance_config;
 }

--- a/scripts/check-no-hardcoded-dandi.sh
+++ b/scripts/check-no-hardcoded-dandi.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Pre-commit hook to prevent hardcoded DANDI identifiers in frontend code.
+# Instance-specific values (instance name, RRID) should come from the
+# backend /api/info/ endpoint via the instance store, not be hardcoded.
+#
+# Patterns checked:
+#   - "DANDI:" used as an identifier prefix in string literals
+#   - "DANDI Archive" used as a publisher/archive name in string literals
+#   - "SCR_017571" hardcoded RRID
+#
+# Files excluded:
+#   - This script itself
+#   - Test files
+#   - HomeView.vue (static marketing text)
+#   - constants.ts (static URLs like dandiarchive.org are not instance-specific)
+
+set -euo pipefail
+
+ERRORS=0
+
+for file in "$@"; do
+    # Skip excluded files
+    case "$file" in
+        */check-no-hardcoded-dandi.sh) continue ;;
+        *__tests__*|*.test.*|*.spec.*) continue ;;
+        */HomeView/*) continue ;;
+        */constants.ts) continue ;;
+        */directives/index.ts) continue ;;  # fallback title before store loads
+    esac
+
+    # Check for DANDI: as identifier prefix in string/template literals
+    # Match patterns like `DANDI:${...}`, "DANDI:", 'DANDI:'
+    if grep -nE '("|'\''|`)\s*DANDI:' "$file" >/dev/null 2>&1; then
+        echo "$file: found hardcoded 'DANDI:' identifier prefix — use instanceName from the instance store"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    # Check for lowercase dandi: used as citation key prefix (followed by digits or ${)
+    # Excludes schema URIs like dandi:OpenAccess, dandi:EmbargoedAccess
+    if grep -nE '("|'\''|`)\s*dandi:\$\{' "$file" >/dev/null 2>&1 || \
+       grep -nE '("|'\''|`)\s*dandi:[0-9]' "$file" >/dev/null 2>&1; then
+        echo "$file: found hardcoded 'dandi:' identifier prefix — use instanceName.toLowerCase() from the instance store"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    # Check for "DANDI Archive" as publisher name in string literals
+    # Exclude HTML comments (<!-- ... -->)
+    if grep -nE "(\"|\`|').*DANDI Archive" "$file" | grep -vE '^\s*<!--' >/dev/null 2>&1; then
+        echo "$file: found hardcoded 'DANDI Archive' — use instanceName from the instance store"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    # Check for hardcoded RRID
+    if grep -nE 'SCR_017571' "$file" >/dev/null 2>&1; then
+        echo "$file: found hardcoded RRID 'SCR_017571' — use instanceIdentifier from the instance store"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+    echo ""
+    echo "Found $ERRORS file(s) with hardcoded DANDI identifiers."
+    echo "Use the instance store (web/src/stores/instance.ts) for dynamic values."
+    exit 1
+fi

--- a/scripts/check-no-hardcoded-dandi.sh
+++ b/scripts/check-no-hardcoded-dandi.sh
@@ -30,22 +30,22 @@ for file in "$@"; do
 
     # Check for DANDI: as identifier prefix in string/template literals
     # Match patterns like `DANDI:${...}`, "DANDI:", 'DANDI:'
-    if grep -nE '("|'\''|`)\s*DANDI:' "$file" >/dev/null 2>&1; then
+    if grep -nE '("|'\''|`)[[:space:]]*DANDI:' "$file" >/dev/null 2>&1; then
         echo "$file: found hardcoded 'DANDI:' identifier prefix — use instanceName from the instance store"
         ERRORS=$((ERRORS + 1))
     fi
 
     # Check for lowercase dandi: used as citation key prefix (followed by digits or ${)
     # Excludes schema URIs like dandi:OpenAccess, dandi:EmbargoedAccess
-    if grep -nE '("|'\''|`)\s*dandi:\$\{' "$file" >/dev/null 2>&1 || \
-       grep -nE '("|'\''|`)\s*dandi:[0-9]' "$file" >/dev/null 2>&1; then
+    if grep -nE '("|'\''|`)[[:space:]]*dandi:\$\{' "$file" >/dev/null 2>&1 || \
+       grep -nE '("|'\''|`)[[:space:]]*dandi:[0-9]' "$file" >/dev/null 2>&1; then
         echo "$file: found hardcoded 'dandi:' identifier prefix — use instanceName.toLowerCase() from the instance store"
         ERRORS=$((ERRORS + 1))
     fi
 
     # Check for "DANDI Archive" as publisher name in string literals
     # Exclude HTML comments (<!-- ... -->)
-    if grep -nE "(\"|\`|').*DANDI Archive" "$file" | grep -vE '^\s*<!--' >/dev/null 2>&1; then
+    if grep -nE "(\"|\`|').*DANDI Archive" "$file" | grep -vE '^[[:space:]]*<!--' >/dev/null 2>&1; then
         echo "$file: found hardcoded 'DANDI Archive' — use instanceName from the instance store"
         ERRORS=$((ERRORS + 1))
     fi

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,14 @@ extras =
 package = skip
 dependency_groups =
     lint
+allowlist_externals =
+    bash
+    find
+    xargs
 commands =
     ruff check
     ruff format --check
+    bash -c 'find web/src -name "*.vue" -o -name "*.ts" | xargs bash scripts/check-no-hardcoded-dandi.sh'
 
 [testenv:format]
 package = skip

--- a/web/src/components/DLP/HowToCiteTab.vue
+++ b/web/src/components/DLP/HowToCiteTab.vue
@@ -181,9 +181,9 @@
 
         <v-divider class="my-4" />
 
-        <!-- DANDI Identifier -->
+        <!-- Dandiset Identifier -->
         <h3 class="text-h6 mb-2">
-          {{ instanceName }} Identifier
+          Dandiset Identifier
         </h3>
         <div class="copy-block mb-2">
           <div class="copy-block-content copy-block-inline">
@@ -207,9 +207,39 @@
             </v-btn>
           </div>
         </div>
-        <p class="text-body-2 text-grey mb-4">
-          {{ instanceName }} Archive{{ instanceIdentifier ? ` ${instanceIdentifier}` : '' }}
-        </p>
+
+        <!-- Archive Identifier -->
+        <h3
+          v-if="archiveIdentifier"
+          class="text-h6 mb-2 mt-4"
+        >
+          Archive Identifier
+        </h3>
+        <div
+          v-if="archiveIdentifier"
+          class="copy-block mb-4"
+        >
+          <div class="copy-block-content copy-block-inline">
+            <span>{{ archiveIdentifier }}</span>
+            <v-btn
+              icon
+              size="small"
+              variant="text"
+              class="copy-btn"
+              @click="copyToClipboard(archiveIdentifier)"
+            >
+              <v-icon size="small">
+                mdi-content-copy
+              </v-icon>
+              <v-tooltip
+                activator="parent"
+                location="top"
+              >
+                Copy archive identifier to clipboard
+              </v-tooltip>
+            </v-btn>
+          </div>
+        </div>
 
         <!-- License Information -->
         <div v-if="licenses && licenses.length">
@@ -259,6 +289,12 @@ const instanceStore = useInstanceStore();
 onMounted(() => instanceStore.fetchInstanceInfo());
 const instanceName = computed(() => instanceStore.instanceName);
 const instanceIdentifier = computed(() => instanceStore.instanceIdentifier);
+const archiveIdentifier = computed(() => {
+  if (!instanceIdentifier.value) {
+    return '';
+  }
+  return `${instanceName.value} Archive ${instanceIdentifier.value}`;
+});
 const currentDandiset = computed(() => store.dandiset);
 const isDraft = computed(() => store.version === 'draft');
 const publishedVersions = computed(() => store.publishedVersions);

--- a/web/src/components/DLP/HowToCiteTab.vue
+++ b/web/src/components/DLP/HowToCiteTab.vue
@@ -187,13 +187,13 @@
         </h3>
         <div class="copy-block mb-2">
           <div class="copy-block-content copy-block-inline">
-            <span>{{ dandiIdentifier }}</span>
+            <span>{{ instanceName }}:{{ dandisetVersionIdentifier }}</span>
             <v-btn
               icon
               size="small"
               variant="text"
               class="copy-btn"
-              @click="copyToClipboard(dandiIdentifier)"
+              @click="copyToClipboard(`${instanceName}:${dandisetVersionIdentifier}`)"
             >
               <v-icon size="small">
                 mdi-content-copy
@@ -310,18 +310,18 @@ const formattedCitations = computed<Record<CitationFormat, string>>(() => {
       cff: '',
     };
   }
-  const identifier = dandiIdentifier.value;
-  const name = instanceName.value;
+  const dandiset_version_identifier = dandisetVersionIdentifier.value;
+  const instance_name = instanceName.value;
 
   return {
-    apa: cffToAPA(cffObject.value, name),
-    mla: cffToMLA(cffObject.value, name),
-    chicago: cffToChicago(cffObject.value, name),
-    harvard: cffToHarvard(cffObject.value, name),
-    vancouver: cffToVancouver(cffObject.value, name),
-    ieee: cffToIEEE(cffObject.value, name),
-    bibtex: cffToBibTeX(cffObject.value, identifier, name),
-    ris: cffToRIS(cffObject.value, identifier, name),
+    apa: cffToAPA(cffObject.value, instance_name),
+    mla: cffToMLA(cffObject.value, instance_name),
+    chicago: cffToChicago(cffObject.value, instance_name),
+    harvard: cffToHarvard(cffObject.value, instance_name),
+    vancouver: cffToVancouver(cffObject.value, instance_name),
+    ieee: cffToIEEE(cffObject.value, instance_name),
+    bibtex: cffToBibTeX(cffObject.value, dandiset_version_identifier, instance_name),
+    ris: cffToRIS(cffObject.value, dandiset_version_identifier, instance_name),
     cff: cffToYAML(cffObject.value),
   };
 });
@@ -358,14 +358,14 @@ const isCodeFormat = computed(() => {
   return ['bibtex', 'ris', 'cff'].includes(selectedCitationFormat.value);
 });
 
-const dandiIdentifier = computed(() => {
+const dandisetVersionIdentifier = computed(() => {
   if (!currentDandiset.value) {
     return '';
   }
 
   const { identifier } = currentDandiset.value.dandiset;
   const version = props.meta?.version || currentDandiset.value.version;
-  return `${instanceName.value}:${identifier}/${version}`;
+  return `${identifier}/${version}`;
 });
 
 const dandiUrl = computed(() => {

--- a/web/src/components/DLP/HowToCiteTab.vue
+++ b/web/src/components/DLP/HowToCiteTab.vue
@@ -346,18 +346,15 @@ const formattedCitations = computed<Record<CitationFormat, string>>(() => {
       cff: '',
     };
   }
-  const dandiset_version_identifier = dandisetVersionIdentifier.value;
-  const instance_name = instanceName.value;
-
   return {
-    apa: cffToAPA(cffObject.value, instance_name),
-    mla: cffToMLA(cffObject.value, instance_name),
-    chicago: cffToChicago(cffObject.value, instance_name),
-    harvard: cffToHarvard(cffObject.value, instance_name),
-    vancouver: cffToVancouver(cffObject.value, instance_name),
-    ieee: cffToIEEE(cffObject.value, instance_name),
-    bibtex: cffToBibTeX(cffObject.value, dandiset_version_identifier, instance_name),
-    ris: cffToRIS(cffObject.value, dandiset_version_identifier, instance_name),
+    apa: cffToAPA(cffObject.value, instanceName.value),
+    mla: cffToMLA(cffObject.value, instanceName.value),
+    chicago: cffToChicago(cffObject.value, instanceName.value),
+    harvard: cffToHarvard(cffObject.value, instanceName.value),
+    vancouver: cffToVancouver(cffObject.value, instanceName.value),
+    ieee: cffToIEEE(cffObject.value, instanceName.value),
+    bibtex: cffToBibTeX(cffObject.value, dandisetVersionIdentifier.value, instanceName.value),
+    ris: cffToRIS(cffObject.value, dandisetVersionIdentifier.value, instanceName.value),
     cff: cffToYAML(cffObject.value),
   };
 });
@@ -413,7 +410,8 @@ const dandiUrl = computed(() => {
   }
 
   const { identifier } = currentDandiset.value.dandiset;
-  return `https://dandiarchive.org/dandiset/${identifier}`;
+  const baseUrl = instanceStore.instanceUrl || window.location.origin;
+  return `${baseUrl}/dandiset/${identifier}`;
 });
 
 const methodsText = computed(() => {

--- a/web/src/components/DLP/HowToCiteTab.vue
+++ b/web/src/components/DLP/HowToCiteTab.vue
@@ -68,8 +68,14 @@
         </div>
         <div class="copy-block mb-4">
           <div class="copy-block-content">
-            <pre v-if="isCodeFormat" class="citation-text-code">{{ currentCitation }}</pre>
-            <span v-else class="citation-text">{{ currentCitation }}</span>
+            <pre
+              v-if="isCodeFormat"
+              class="citation-text-code"
+            >{{ currentCitation }}</pre>
+            <span
+              v-else
+              class="citation-text"
+            >{{ currentCitation }}</span>
             <v-btn
               icon
               size="small"
@@ -177,7 +183,7 @@
 
         <!-- DANDI Identifier -->
         <h3 class="text-h6 mb-2">
-          DANDI Identifier
+          {{ instanceName }} Identifier
         </h3>
         <div class="copy-block mb-2">
           <div class="copy-block-content copy-block-inline">
@@ -202,7 +208,7 @@
           </div>
         </div>
         <p class="text-body-2 text-grey mb-4">
-          DANDI Archive RRID: SCR_017571
+          {{ instanceName }} Archive{{ instanceIdentifier ? ` ${instanceIdentifier}` : '' }}
         </p>
 
         <!-- License Information -->
@@ -224,16 +230,16 @@
             </v-chip>
           </p>
         </div>
-
       </v-card-text>
     </v-card>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType, ref } from 'vue';
+import { computed, onMounted, type PropType, ref } from 'vue';
 
 import { useDandisetStore } from '@/stores/dandiset';
+import { useInstanceStore } from '@/stores/instance';
 import type { DandisetMetadata } from '@/types';
 import { dandisetToCFF, cffToBibTeX, cffToAPA, cffToMLA, cffToChicago, cffToHarvard, cffToVancouver, cffToIEEE, cffToRIS, cffToYAML } from '@/utils/cff';
 
@@ -249,6 +255,10 @@ const props = defineProps({
 });
 
 const store = useDandisetStore();
+const instanceStore = useInstanceStore();
+onMounted(() => instanceStore.fetchInstanceInfo());
+const instanceName = computed(() => instanceStore.instanceName);
+const instanceIdentifier = computed(() => instanceStore.instanceIdentifier);
 const currentDandiset = computed(() => store.dandiset);
 const isDraft = computed(() => store.version === 'draft');
 const publishedVersions = computed(() => store.publishedVersions);
@@ -282,7 +292,7 @@ const cffObject = computed(() => {
     return null;
   }
 
-  return dandisetToCFF(props.meta, typeof doi.value === 'string' ? doi.value : undefined);
+  return dandisetToCFF(props.meta, typeof doi.value === 'string' ? doi.value : undefined, instanceName.value, instanceStore.instanceUrl || undefined);
 });
 
 // Generate citations in different formats
@@ -301,16 +311,17 @@ const formattedCitations = computed<Record<CitationFormat, string>>(() => {
     };
   }
   const identifier = dandiIdentifier.value;
+  const name = instanceName.value;
 
   return {
-    apa: cffToAPA(cffObject.value),
-    mla: cffToMLA(cffObject.value),
-    chicago: cffToChicago(cffObject.value),
-    harvard: cffToHarvard(cffObject.value),
-    vancouver: cffToVancouver(cffObject.value),
-    ieee: cffToIEEE(cffObject.value),
-    bibtex: cffToBibTeX(cffObject.value, identifier),
-    ris: cffToRIS(cffObject.value, identifier),
+    apa: cffToAPA(cffObject.value, name),
+    mla: cffToMLA(cffObject.value, name),
+    chicago: cffToChicago(cffObject.value, name),
+    harvard: cffToHarvard(cffObject.value, name),
+    vancouver: cffToVancouver(cffObject.value, name),
+    ieee: cffToIEEE(cffObject.value, name),
+    bibtex: cffToBibTeX(cffObject.value, identifier, name),
+    ris: cffToRIS(cffObject.value, identifier, name),
     cff: cffToYAML(cffObject.value),
   };
 });
@@ -354,7 +365,7 @@ const dandiIdentifier = computed(() => {
 
   const { identifier } = currentDandiset.value.dandiset;
   const version = props.meta?.version || currentDandiset.value.version;
-  return `DANDI:${identifier}/${version}`;
+  return `${instanceName.value}:${identifier}/${version}`;
 });
 
 const dandiUrl = computed(() => {
@@ -371,12 +382,14 @@ const dandiUrl = computed(() => {
 
 const methodsText = computed(() => {
   const url = dandiUrl.value;
-  return `Data associated with this study are available on the DANDI Archive (RRID:SCR_017571): ${url}`;
+  const rridPart = instanceIdentifier.value ? ` (${instanceIdentifier.value})` : '';
+  return `Data associated with this study are available on the ${instanceName.value} Archive${rridPart}: ${url}`;
 });
 
 const dataAvailabilityText = computed(() => {
   const url = dandiUrl.value;
-  return `Data are publicly available on the DANDI Archive (RRID:SCR_017571) at the following URL: ${url}`;
+  const rridPart = instanceIdentifier.value ? ` (${instanceIdentifier.value})` : '';
+  return `Data are publicly available on the ${instanceName.value} Archive${rridPart} at the following URL: ${url}`;
 });
 
 function formatLicense(license: string): string {

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -79,12 +79,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, type PropType } from 'vue';
+import { computed, onMounted, type PropType } from 'vue';
 import { useRoute } from 'vue-router';
 import moment from 'moment';
 import { filesize } from 'filesize';
 import StarButton from '@/components/StarButton.vue';
-import { dandiRest } from '@/rest';
+import { useInstanceStore } from '@/stores/instance';
 
 import type { Version } from '@/types';
 import { DANDISETS_PER_PAGE } from '@/utils/constants';
@@ -97,12 +97,9 @@ defineProps({
 });
 
 const route = useRoute();
-const archiveName = ref<string>('');
-
-onMounted(async () => {
-  const info = await dandiRest.info();
-  archiveName.value = info.instance_config.instance_name;
-});
+const instanceStore = useInstanceStore();
+onMounted(() => instanceStore.fetchInstanceInfo());
+const archiveName = computed(() => instanceStore.instanceName);
 
 // current position in search result set = items on prev pages + position on current page
 function getPos(index: number) {

--- a/web/src/directives/index.ts
+++ b/web/src/directives/index.ts
@@ -1,13 +1,19 @@
 import type { App, DirectiveBinding } from 'vue'
 
-const TITLE = 'DANDI Archive';
+import { useInstanceStore } from '@/stores/instance';
+
+function getTitle(): string {
+  const instanceStore = useInstanceStore();
+  return instanceStore.instanceName ? `${instanceStore.instanceName} Archive` : 'DANDI Archive';
+}
 
 // Function to set the page title based on the directive's binding value
 const setPageTitle = (el: HTMLElement, binding: DirectiveBinding) => {
+  const title = getTitle();
   if (binding?.value) {
-    document.title = `${binding.value} - ${TITLE}`;
+    document.title = `${binding.value} - ${title}`;
   } else {
-    document.title = TITLE;
+    document.title = title;
   }
 };
 
@@ -17,7 +23,7 @@ const directives = {
     mounted: setPageTitle,
     updated: setPageTitle,
     beforeUnmount: () => {
-      document.title = TITLE;
+      document.title = getTitle();
     },
   }
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -16,9 +16,14 @@ import App from './App.vue'
 // Composables
 import { createApp } from 'vue'
 
+import { useInstanceStore } from '@/stores/instance'
+
 const app = createApp(App)
 
 registerPlugins(app)
 registerDirectives(app)
+
+// Fetch instance config early so page titles and identifiers are available
+useInstanceStore().fetchInstanceInfo();
 
 app.mount('#app')

--- a/web/src/stores/instance.ts
+++ b/web/src/stores/instance.ts
@@ -7,6 +7,7 @@ interface InstanceState {
   instanceIdentifier: string | null;
   instanceUrl: string | null;
   loaded: boolean;
+  _fetchPromise: Promise<void> | null;
 }
 
 export const useInstanceStore = defineStore('instance', {
@@ -15,12 +16,20 @@ export const useInstanceStore = defineStore('instance', {
     instanceIdentifier: null,
     instanceUrl: null,
     loaded: false,
+    _fetchPromise: null,
   }),
   actions: {
     async fetchInstanceInfo() {
       if (this.loaded) {
         return;
       }
+      if (this._fetchPromise) {
+        return this._fetchPromise;
+      }
+      this._fetchPromise = this._doFetch();
+      return this._fetchPromise;
+    },
+    async _doFetch() {
       const info = await dandiRest.info();
       this.instanceName = info.instance_config.instance_name;
       this.instanceIdentifier = info.instance_config.instance_identifier;

--- a/web/src/stores/instance.ts
+++ b/web/src/stores/instance.ts
@@ -1,0 +1,31 @@
+import { defineStore } from 'pinia';
+
+import { dandiRest } from '@/rest';
+
+interface InstanceState {
+  instanceName: string;
+  instanceIdentifier: string | null;
+  instanceUrl: string | null;
+  loaded: boolean;
+}
+
+export const useInstanceStore = defineStore('instance', {
+  state: (): InstanceState => ({
+    instanceName: '',
+    instanceIdentifier: null,
+    instanceUrl: null,
+    loaded: false,
+  }),
+  actions: {
+    async fetchInstanceInfo() {
+      if (this.loaded) {
+        return;
+      }
+      const info = await dandiRest.info();
+      this.instanceName = info.instance_config.instance_name;
+      this.instanceIdentifier = info.instance_config.instance_identifier;
+      this.instanceUrl = info.instance_config.instance_url;
+      this.loaded = true;
+    },
+  },
+});

--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -213,9 +213,9 @@ function mapResourceTypeToCFF(resourceType?: string): string {
 /**
  * Convert CFF to BibTeX format
  */
-export function cffToBibTeX(cff: CFF, identifier: string, instanceName: string): string {
+export function cffToBibTeX(cff: CFF, dandisetVersionIdentifier: string, instanceName: string): string {
   const type = '@dataset';
-  const key = `${instanceName.toLowerCase()}:${identifier.replace('/', '_')}`;
+  const key = `${instanceName.toLowerCase()}:${dandisetVersionIdentifier.replace('/', '_')}`;
 
   const authors = cff.authors.map(author => {
     if (author.name) {
@@ -254,7 +254,7 @@ export function cffToBibTeX(cff: CFF, identifier: string, instanceName: string):
   }
 
   bibtex += `  publisher = {${instanceName} Archive},\n`;
-  bibtex += `  note = {${instanceName}:${identifier}}\n`;
+  bibtex += `  note = {${instanceName}:${dandisetVersionIdentifier}}\n`;
   bibtex += '}';
 
   return bibtex;
@@ -460,7 +460,7 @@ export function cffToIEEE(cff: CFF, instanceName: string): string {
 /**
  * Convert CFF to RIS format
  */
-export function cffToRIS(cff: CFF, identifier: string, instanceName: string): string {
+export function cffToRIS(cff: CFF, dandisetVersionIdentifier: string, instanceName: string): string {
   let ris = 'TY  - DATA\n';
   ris += `TI  - ${cff.title}\n`;
 
@@ -497,7 +497,7 @@ export function cffToRIS(cff: CFF, identifier: string, instanceName: string): st
   }
 
   ris += `PB  - ${instanceName} Archive\n`;
-  ris += `N1  - ${instanceName}:${identifier}\n`;
+  ris += `N1  - ${instanceName}:${dandisetVersionIdentifier}\n`;
 
   if (cff.version) {
     ris += `VL  - ${cff.version}\n`;

--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -85,7 +85,9 @@ function organizationToCFFAuthor(org: Organization): CFFAuthor {
 /**
  * Convert DANDI dandiset metadata to CFF format
  */
-export function dandisetToCFF(metadata: DandisetMetadata, doi?: string): CFF {
+export function dandisetToCFF(metadata: DandisetMetadata, doi?: string, instanceName?: string, instanceUrl?: string): CFF {
+  const archiveName = instanceName || 'DANDI';
+  const archiveUrl = instanceUrl || 'https://dandiarchive.org';
   const cff: CFF = {
     'cff-version': '1.2.0',
     message: 'If you use this dataset, please cite it as below.',
@@ -125,8 +127,8 @@ export function dandisetToCFF(metadata: DandisetMetadata, doi?: string): CFF {
   if (metadata.identifier) {
     cff.identifiers.push({
       type: 'url',
-      value: `https://dandiarchive.org/dandiset/${metadata.identifier}`,
-      description: 'DANDI Archive URL'
+      value: `${archiveUrl}/dandiset/${metadata.identifier}`,
+      description: `${archiveName} Archive URL`
     });
   }
 
@@ -136,7 +138,7 @@ export function dandisetToCFF(metadata: DandisetMetadata, doi?: string): CFF {
   } else if (doi) {
     cff.url = `https://doi.org/${doi}`;
   } else if (metadata.identifier) {
-    cff.url = `https://dandiarchive.org/dandiset/${metadata.identifier}`;
+    cff.url = `${archiveUrl}/dandiset/${metadata.identifier}`;
   }
 
   // Add repository
@@ -211,9 +213,9 @@ function mapResourceTypeToCFF(resourceType?: string): string {
 /**
  * Convert CFF to BibTeX format
  */
-export function cffToBibTeX(cff: CFF, identifier: string): string {
+export function cffToBibTeX(cff: CFF, identifier: string, instanceName: string): string {
   const type = '@dataset';
-  const key = `dandi:${identifier.replace('/', '_')}`;
+  const key = `${instanceName.toLowerCase()}:${identifier.replace('/', '_')}`;
 
   const authors = cff.authors.map(author => {
     if (author.name) {
@@ -251,8 +253,8 @@ export function cffToBibTeX(cff: CFF, identifier: string): string {
     bibtex += `  year = {${year}},\n`;
   }
 
-  bibtex += `  publisher = {DANDI Archive},\n`;
-  bibtex += `  note = {DANDI:${identifier}}\n`;
+  bibtex += `  publisher = {${instanceName} Archive},\n`;
+  bibtex += `  note = {${instanceName}:${identifier}}\n`;
   bibtex += '}';
 
   return bibtex;
@@ -261,7 +263,7 @@ export function cffToBibTeX(cff: CFF, identifier: string): string {
 /**
  * Convert CFF to APA format (7th edition)
  */
-export function cffToAPA(cff: CFF): string {
+export function cffToAPA(cff: CFF, instanceName: string): string {
   const authors = cff.authors.map((author) => {
     if (author.name) {
       return author.name;
@@ -288,13 +290,13 @@ export function cffToAPA(cff: CFF): string {
   const version = cff.version ? ` (Version ${cff.version})` : '';
   const doi = cff.doi ? ` https://doi.org/${cff.doi}` : '';
 
-  return `${authorString}${year}. ${cff.title}${version} [Data set]. DANDI Archive.${doi}`;
+  return `${authorString}${year}. ${cff.title}${version} [Data set]. ${instanceName} Archive.${doi}`;
 }
 
 /**
  * Convert CFF to MLA format (9th edition)
  */
-export function cffToMLA(cff: CFF): string {
+export function cffToMLA(cff: CFF, instanceName: string): string {
   const authors = cff.authors.map((author, index) => {
     if (author.name) {
       return author.name;
@@ -322,13 +324,13 @@ export function cffToMLA(cff: CFF): string {
   const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
   const doi = cff.doi ? ` doi:${cff.doi}` : '';
 
-  return `${authorString}. "${cff.title}." DANDI Archive, ${year}.${doi}`;
+  return `${authorString}. "${cff.title}." ${instanceName} Archive, ${year}.${doi}`;
 }
 
 /**
  * Convert CFF to Chicago format (17th edition, Author-Date)
  */
-export function cffToChicago(cff: CFF): string {
+export function cffToChicago(cff: CFF, instanceName: string): string {
   const authors = cff.authors.map((author, index) => {
     if (author.name) {
       return author.name;
@@ -355,13 +357,13 @@ export function cffToChicago(cff: CFF): string {
   const version = cff.version ? `, version ${cff.version}` : '';
   const doi = cff.doi ? ` https://doi.org/${cff.doi}` : '';
 
-  return `${authorString}. ${year}. "${cff.title}." Data set${version}. DANDI Archive.${doi}`;
+  return `${authorString}. ${year}. "${cff.title}." Data set${version}. ${instanceName} Archive.${doi}`;
 }
 
 /**
  * Convert CFF to Harvard format
  */
-export function cffToHarvard(cff: CFF): string {
+export function cffToHarvard(cff: CFF, instanceName: string): string {
   const authors = cff.authors.map((author) => {
     if (author.name) {
       return author.name;
@@ -389,13 +391,13 @@ export function cffToHarvard(cff: CFF): string {
   const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
   const doi = cff.doi ? ` Available at: https://doi.org/${cff.doi}` : '';
 
-  return `${authorString} (${year}) '${cff.title}', DANDI Archive. Data set.${doi}`;
+  return `${authorString} (${year}) '${cff.title}', ${instanceName} Archive. Data set.${doi}`;
 }
 
 /**
  * Convert CFF to Vancouver format (used in biomedical sciences)
  */
-export function cffToVancouver(cff: CFF): string {
+export function cffToVancouver(cff: CFF, instanceName: string): string {
   const authors = cff.authors.map((author) => {
     if (author.name) {
       return author.name;
@@ -420,13 +422,13 @@ export function cffToVancouver(cff: CFF): string {
   const year = cff['date-released'] ? cff['date-released'].split('-')[0] : '';
   const doi = cff.doi ? ` doi: ${cff.doi}` : '';
 
-  return `${authorString}. ${cff.title} [Data set]. DANDI Archive; ${year}.${doi}`;
+  return `${authorString}. ${cff.title} [Data set]. ${instanceName} Archive; ${year}.${doi}`;
 }
 
 /**
  * Convert CFF to IEEE format
  */
-export function cffToIEEE(cff: CFF): string {
+export function cffToIEEE(cff: CFF, instanceName: string): string {
   const authors = cff.authors.map((author) => {
     if (author.name) {
       return author.name;
@@ -452,13 +454,13 @@ export function cffToIEEE(cff: CFF): string {
   const year = cff['date-released'] ? cff['date-released'].split('-')[0] : '';
   const doi = cff.doi ? ` doi: ${cff.doi}` : '';
 
-  return `${authorString}, "${cff.title}," DANDI Archive, ${year}.${doi}`;
+  return `${authorString}, "${cff.title}," ${instanceName} Archive, ${year}.${doi}`;
 }
 
 /**
  * Convert CFF to RIS format
  */
-export function cffToRIS(cff: CFF, identifier: string): string {
+export function cffToRIS(cff: CFF, identifier: string, instanceName: string): string {
   let ris = 'TY  - DATA\n';
   ris += `TI  - ${cff.title}\n`;
 
@@ -494,8 +496,8 @@ export function cffToRIS(cff: CFF, identifier: string): string {
     if (dateParts[1]) ris += `Y2  - ${dateParts[0]}/${dateParts[1]}/${dateParts[2] || '01'}\n`;
   }
 
-  ris += 'PB  - DANDI Archive\n';
-  ris += `N1  - DANDI:${identifier}\n`;
+  ris += `PB  - ${instanceName} Archive\n`;
+  ris += `N1  - ${instanceName}:${identifier}\n`;
 
   if (cff.version) {
     ris += `VL  - ${cff.version}\n`;

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -161,10 +161,10 @@ const currentVersion = computed(() => store.version);
 const cliMinimalVersion = ref<string>();
 const cliRequiresPython = ref<string>();
 onMounted(async () => {
+  await instanceStore.fetchInstanceInfo();
   const info = await dandiRest.info();
   cliMinimalVersion.value = info['cli-minimal-version'];
   cliRequiresPython.value = info['cli-requires-python'];
-  await instanceStore.fetchInstanceInfo();
 });
 
 const selectedDownloadOption = ref('draft');

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -132,15 +132,19 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import { useDandisetStore } from '@/stores/dandiset';
+import { useInstanceStore } from '@/stores/instance';
 import CopyText from '@/components/CopyText.vue';
 import { dandiDocumentationUrl } from '@/utils/constants';
 import { dandiRest } from '@/rest';
 
+const instanceStore = useInstanceStore();
+
 function downloadCommand(identifier: string, version: string): string {
-  // Use the special 'DANDI:' url prefix if appropriate.
+  // Use the special instance identifier url prefix if appropriate.
   const generalUrl = `${window.location.origin}/dandiset/${identifier}`;
-  const dandiUrl = `DANDI:${identifier}`;
-  const url = window.location.origin == 'https://dandiarchive.org' ? dandiUrl : generalUrl;
+  const dandiUrl = `${instanceStore.instanceName}:${identifier}`;
+  const instanceUrl = instanceStore.instanceUrl;
+  const url = instanceUrl && window.location.origin === instanceUrl ? dandiUrl : generalUrl;
 
   // Prepare a url suffix to specify a specific version (or not).
   const versionPath = version ? `/${version}` : '';
@@ -160,6 +164,7 @@ onMounted(async () => {
   const info = await dandiRest.info();
   cliMinimalVersion.value = info['cli-minimal-version'];
   cliRequiresPython.value = info['cli-requires-python'];
+  await instanceStore.fetchInstanceInfo();
 });
 
 const selectedDownloadOption = ref('draft');


### PR DESCRIPTION
## Summary

- Replace all hardcoded `DANDI:` identifier prefixes, `DANDI Archive` publisher names, and `SCR_017571` RRID in frontend code with dynamic values from the backend `/api/info/` endpoint (`DJANGO_DANDI_INSTANCE_NAME`, `DJANGO_DANDI_INSTANCE_IDENTIFIER`)
- Add a shared Pinia store (`stores/instance.ts`) that caches instance config across components
- Add a grep-based lint check (`scripts/check-no-hardcoded-dandi.sh`) to prevent re-introducing hardcoded identifiers, wired into pre-commit and `tox -e lint`
- Update E2E tests to fetch instance config from the API instead of asserting hardcoded values
- Closes #2762
- Fixes some AI slop left for listing of identifiers and composition of them for bibtex key and notes

<details>
<summary>Files changed overview</summary> 

| File | Change |
|------|--------|
| `web/src/stores/instance.ts` | **New** — shared Pinia store for instance config |
| `web/src/utils/cff.ts` | All citation format functions accept `instanceName` parameter |
| `web/src/components/DLP/HowToCiteTab.vue` | Dynamic identifier, archive name, RRID |
| `web/src/views/DandisetLandingView/DownloadDialog.vue` | Dynamic identifier prefix and instance URL check |
| `web/src/components/DandisetList.vue` | Use shared instance store |
| `web/src/directives/index.ts` | Dynamic page title |
| `scripts/check-no-hardcoded-dandi.sh` | **New** — lint check for hardcoded identifiers |
| `.pre-commit-config.yaml` | Add `no-hardcoded-dandi-identifiers` hook |
| `tox.ini` | Run the check in `lint` environment |
| `e2e/utils.ts` | Add `fetchInstanceConfig()` helper |
| `e2e/tests/dandisetLandingPage.spec.ts` | Use API instance config in assertions |
| `e2e/tests/dandisetsPage.spec.ts` | Use API instance config in assertions |

</details>

## Tests etc plan

- [x] `npm run lint` passes (web/)
- [x] `npm run type-check` passes (web/)
- [x] `uv run tox -e lint` passes (includes hardcoded identifier check)
- [ ] Seek feedback from @dandi/archive-maintainers on the overall approach
- [x] Pre-commit hooks pass
- [x] Frontend CI passes
- [x] E2E tests pass with `DJANGO_DANDI_INSTANCE_NAME=DEV-DANDI`
- [x] Backend CI passes (no backend changes)
- [x] Move from Draft after CI turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary>I also fixed/adjusted for some left-over AI slop, as duplicate identifiers and inconsistent presentation</summary> 

e.g. compare bibtex cite as on https://dandiarchive.org/dandiset/000690?pos=5  having 
<img width="2416" height="98" alt="image" src="https://github.com/user-attachments/assets/07dd1973-82cb-43a5-9c57-6a6f4da8ba58" />

and

<img width="2676" height="292" alt="image" src="https://github.com/user-attachments/assets/ac48363d-bbd1-4bf1-8a66-2de09ae18cd1" />

to https://deploy-preview-2765--sandbox-dandiarchive-org.netlify.app/dandiset/217838?pos=2

<img width="2650" height="124" alt="image" src="https://github.com/user-attachments/assets/0bc18b22-e578-4116-8d53-56c07a0e01a3" />

and two separate copy pasteable sections for identifiers

<img width="2820" height="482" alt="image" src="https://github.com/user-attachments/assets/15b7abff-126c-4e2e-ab5d-d5e8ca988c6f" />

there is also a fix to bibtex record key. Can also look current sandbox at e.g. https://sandbox.dandiarchive.org/dandiset/217838?pos=2
</details>