### PR TITLE
Annotate hardcoded branding touchpoints with TODO: BRANDING markers

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -154,6 +154,19 @@ This creates a dummy dandiset with valid metadata and a single dummy asset.
 The dandiset should be valid and publishable out of the box.
 This script is a simple way to get test data into your DB without having to use dandi-cli.
 
+## Branding Annotations
+
+All locations where instance-specific branding is hardcoded are marked with
+`TODO: BRANDING` comments (`TODO: BRANDING START`/`TODO: BRANDING END` for
+multi-line blocks). To find all branding touchpoints:
+
+```bash
+git grep -rn "TODO: BRANDING"
+```
+
+See [doc/design/branding.md](doc/design/branding.md) for the full inventory,
+annotation conventions, and design notes.
+
 ## Abbreviations
 
 - DLP: Dataset Landing Page (e.g. https://dandiarchive.org/dandiset/000027)

--- a/dandiapi/api/admin.py
+++ b/dandiapi/api/admin.py
@@ -35,6 +35,7 @@ from dandiapi.zarr.tasks import ingest_dandiset_zarrs
 if TYPE_CHECKING:
     from django.http.request import HttpRequest
 
+# TODO: BRANDING(name) - hardcoded admin site header/title
 admin.site.site_header = 'DANDI Admin'
 admin.site.site_title = 'DANDI Admin'
 

--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -97,6 +97,7 @@ def send_ownership_change_emails(dandiset, removed_owners, added_owners):
 def build_registered_message(user: User, socialaccount: SocialAccount):
     # Email sent to the DANDI list when a new user logs in for the first time
     return build_message(
+        # TODO: BRANDING(name) - hardcoded archive name in email subject
         subject=f'DANDI: New user registered: {user.email}',
         message=render_to_string(
             'api/mail/registered_message.txt',
@@ -120,6 +121,7 @@ def build_new_user_messsage(user: User, socialaccount: SocialAccount = None):
     }
     # Email sent to the DANDI list when a new user logs in for the first time
     return build_message(
+        # TODO: BRANDING(name) - hardcoded archive name in email subject
         subject=f'DANDI: Review new user: {user.username}',
         message=render_to_string('api/mail/new_user_message.txt', render_context),
         to=[settings.DANDI_ADMIN_EMAIL],
@@ -135,6 +137,7 @@ def send_new_user_message_email(user: User, socialaccount: SocialAccount):
 
 def build_approved_user_message(user: User, socialaccount: SocialAccount = None):
     return build_message(
+        # TODO: BRANDING(name) - hardcoded archive name in email subject
         subject='Your DANDI Account',
         message=render_to_string(
             'api/mail/approved_user_message.txt',
@@ -156,6 +159,7 @@ def send_approved_user_message(user: User, socialaccount: SocialAccount):
 
 def build_rejected_user_message(user: User, socialaccount: SocialAccount = None):
     return build_message(
+        # TODO: BRANDING(name) - hardcoded archive name in email subject
         subject='Your DANDI Account',
         message=render_to_string(
             'api/mail/rejected_user_message.txt',
@@ -178,6 +182,7 @@ def send_rejected_user_message(user: User, socialaccount: SocialAccount):
 def build_pending_users_message(users: Iterable[User]):
     render_context = {**BASE_RENDER_CONTEXT, 'users': users}
     return build_message(
+        # TODO: BRANDING(name) - hardcoded archive name in email subject
         subject='DANDI: new user registrations to review',
         message=render_to_string('api/mail/pending_users_message.txt', render_context),
         to=[settings.DANDI_ADMIN_EMAIL],
@@ -225,6 +230,7 @@ def build_dandiset_unembargo_failed_message(dandiset: Dandiset):
     render_context = {**BASE_RENDER_CONTEXT, 'dandiset': dandiset_context}
     html_message = render_to_string('api/mail/dandiset_unembargo_failed.html', render_context)
     return build_message(
+        # TODO: BRANDING(name) - hardcoded archive name in email subject
         subject=f'DANDI: Unembargo failed for dandiset {dandiset.identifier}',
         message=strip_tags(html_message),
         html_message=html_message,

--- a/dandiapi/api/migrations/0001_default_site.py
+++ b/dandiapi/api/migrations/0001_default_site.py
@@ -20,10 +20,12 @@ def update_default_site(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
     # object already.
     Site.objects.update_or_create(
         pk=settings.SITE_ID,
+        # TODO: BRANDING START - hardcoded site domain and name
         defaults={
             'domain': 'api.dandiarchive.org',
             'name': 'DANDI Archive',
         },
+        # TODO: BRANDING END
     )
 
 

--- a/dandiapi/api/templates/api/account/base.html
+++ b/dandiapi/api/templates/api/account/base.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
 
+  <!-- TODO: BRANDING(name) - hardcoded archive title -->
   <title>DANDI Archive</title>
 
   <style>
@@ -38,6 +39,7 @@
   <nav style="background-color: #f5f5f5;">
     <div class="nav-wrapper logo-container">
       <a href="{{ dandi_web_app_url }}" class="brand-logo">
+        <!-- TODO: BRANDING - hardcoded logo URL -->
         <img src="https://raw.githubusercontent.com/dandi/dandi.github.io/master/assets/dandi_logo.svg" class="logo">
       </a>
     </div>

--- a/dandiapi/api/templates/api/account/questionnaire_form.html
+++ b/dandiapi/api/templates/api/account/questionnaire_form.html
@@ -1,6 +1,7 @@
 {% extends 'api/account/base.html' %}
 
 {% block body %}
+  {# TODO: BRANDING - hardcoded archive name and support email #}
   <h5>Welcome to DANDI! Please take a moment to fill out this form.</h5>
   <h6><b>Note:</b> No account is necessary to access public data!</h6>
   <form method="POST" class="col s12">

--- a/dandiapi/api/templates/api/mail/approved_user_message.txt
+++ b/dandiapi/api/templates/api/mail/approved_user_message.txt
@@ -1,3 +1,4 @@
+{# TODO: BRANDING - hardcoded archive name, docs URLs, YouTube URL, team name #}
 {% autoescape off %}
 Dear {{ greeting_name }},
 

--- a/dandiapi/api/templates/api/mail/new_user_message.txt
+++ b/dandiapi/api/templates/api/mail/new_user_message.txt
@@ -1,3 +1,4 @@
+{# TODO: BRANDING(name) - hardcoded archive name #}
 {% autoescape off %}
 A new user ({{ username }}) has signed up for DANDI.
 

--- a/dandiapi/api/templates/api/mail/pending_users_message.txt
+++ b/dandiapi/api/templates/api/mail/pending_users_message.txt
@@ -1,3 +1,4 @@
+{# TODO: BRANDING(name) - hardcoded archive name #}
 {% autoescape off %}
 The following new DANDI users are awaiting approval:
 

--- a/dandiapi/api/templates/api/mail/registered_message.txt
+++ b/dandiapi/api/templates/api/mail/registered_message.txt
@@ -1,3 +1,4 @@
+{# TODO: BRANDING - hardcoded archive name, hub URL, docs URLs, YouTube URL, team name #}
 {% autoescape off %}
 Dear {{ greeting_name }},
 

--- a/dandiapi/api/templates/api/mail/rejected_user_message.txt
+++ b/dandiapi/api/templates/api/mail/rejected_user_message.txt
@@ -1,3 +1,4 @@
+{# TODO: BRANDING - hardcoded archive name, support email, docs URL, team name #}
 {% autoescape off %}
 Dear {{ greeting_name }},
 

--- a/dandiapi/api/templates/api/root_content.html
+++ b/dandiapi/api/templates/api/root_content.html
@@ -3,6 +3,7 @@
 {% block body %}
     <h5>Welcome!</h5>
 
+    {# TODO: BRANDING - hardcoded archive name, about URL, support email #}
     <p>This is the Django service that supports the DANDI API. There's
     nothing specifically valuable at this exact location. You are probably
     looking for one of the following instead:</p>

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -90,7 +90,7 @@ api_urlpatterns = [
 ]
 schema_view = get_schema_view(
     openapi.Info(
-        title='DANDI Archive',
+        title='DANDI Archive',  # TODO: BRANDING(name) - hardcoded archive name in API schema
         default_version='v1',
         description='The BRAIN Initiative archive for publishing and sharing '
         'cellular neurophysiology data',

--- a/doc/design/branding.md
+++ b/doc/design/branding.md
@@ -1,0 +1,301 @@
+# Branding Abstraction
+
+This document tracks the effort to make dandi-archive re-brandable (white-label
+capable) so that the same codebase can be deployed under different instance names,
+URLs, logos, and visual identities without forking.
+
+Related issue: https://github.com/dandi/dandi-archive/issues/2762
+
+## Current State
+
+### Existing multi-instance support
+
+The codebase already has partial support via `dandischema`'s `instance_config`:
+
+- **Backend settings** (`dandiapi/settings/base.py`):
+  `DANDI_INSTANCE_NAME`, `DANDI_INSTANCE_IDENTIFIER`, `DANDI_WEB_APP_URL`,
+  `DANDI_API_URL`, `DANDI_JUPYTERHUB_URL` — all env-var configurable.
+
+- **API endpoint** (`/api/info/`): Serves `instance_config` from `dandischema`
+  (instance_name, instance_identifier, instance_url, doi_prefix, licenses).
+
+- **Frontend store** (`web/src/stores/instance.ts`): Pinia store that fetches
+  instance config at startup; components can use `instanceName`,
+  `instanceIdentifier`, `instanceUrl`.
+
+- **[PR #2765](https://github.com/dandi/dandi-archive/pull/2765)** (`bf-2762`
+  branch): Addresses the vendorization aspect — makes `instanceName` and
+  `instanceIdentifier` dynamic wherever they appear in user-visible output.
+  This covers citation formats (`cff.ts`), `HowToCiteTab.vue`,
+  `DandisetList.vue`, `directives/index.ts`, `DownloadDialog.vue`, and e2e
+  tests. These use the existing `instance_config` from `/api/info/` and do
+  **not** require additional branding templating — they already work correctly
+  for any instance (DANDI, EMBER, etc.) as long as the backend env vars
+  `DANDI_INSTANCE_NAME` and `DANDI_INSTANCE_IDENTIFIER` are set.
+  Also adds `scripts/check-no-hardcoded-dandi.sh` lint guard + pre-commit hook.
+
+### What remains hardcoded
+
+All remaining hardcoded branding touchpoints are annotated with `TODO: BRANDING`
+comments (see [Annotation Conventions](#annotation-conventions) below).
+
+## Annotation Conventions
+
+Every location where instance-specific branding is hardcoded is marked with
+`TODO: BRANDING` comments. This makes it trivial to find all branding points:
+
+```bash
+git grep -rn "TODO: BRANDING"
+```
+
+### Marker format
+
+The marker format is the same regardless of source language — only the
+surrounding comment syntax differs:
+
+| Scope | Marker |
+|-------|--------|
+| Single line — name only (Group 1) | `TODO: BRANDING(name)` with optional `- description` |
+| Single line — needs new config (Group 2) | `TODO: BRANDING` with optional `- description` |
+| Multi-line block start | `TODO: BRANDING START` with optional `- description` |
+| Multi-line block end | `TODO: BRANDING END` |
+
+Group 1 items tagged `BRANDING(name)` can be resolved using existing
+vendorization variables (`settings.DANDI_INSTANCE_NAME` / `instanceStore.instanceName`).
+Group 2 items tagged plain `BRANDING` require new branding configuration.
+
+Examples by file type:
+
+```python
+# TODO: BRANDING - hardcoded archive name in email subject
+subject=f'DANDI: New user registered: {user.email}',
+```
+
+```python
+# TODO: BRANDING START - hardcoded site domain and name
+defaults={
+    'domain': 'api.dandiarchive.org',
+    'name': 'DANDI Archive',
+},
+# TODO: BRANDING END
+```
+
+```typescript
+// TODO: BRANDING START - hardcoded instance-specific URLs
+const dandiUrl = 'https://dandiarchive.org';
+// ...
+// TODO: BRANDING END
+```
+
+```html
+<!-- TODO: BRANDING - hardcoded archive title -->
+<title>DANDI Archive</title>
+```
+
+```html
+<!-- TODO: BRANDING START - hardcoded archive name and tagline -->
+<div>The DANDI Archive</div>
+<div>The BRAIN Initiative archive...</div>
+<!-- TODO: BRANDING END -->
+```
+
+```django
+{# TODO: BRANDING - hardcoded archive name #}
+```
+
+## Annotated Inventory
+
+Annotations are split into two groups:
+
+- **Group 1 — Instance name substitution** (`TODO: BRANDING(name)`): Can be
+  fixed now using existing vendorization variables
+  (`settings.DANDI_INSTANCE_NAME` on backend,
+  `instanceStore.instanceName` on frontend). These are pure "DANDI" →
+  `instanceName` replacements.
+
+- **Group 2 — Custom branding config needed** (`TODO: BRANDING`): Requires
+  new configuration mechanism (images, URLs, colors, custom text blocks,
+  funding info). These cannot be derived from `instanceName` alone.
+
+Some locations contain both — the instance name part (Group 1) and
+custom URLs/text (Group 2). These are listed in Group 2 with the Group 1
+portion noted.
+
+To find only Group 1 items: `git grep "BRANDING(name)"`
+To find all branding items: `git grep "TODO: BRANDING"`
+
+### Group 1 — Instance name substitution (can use existing vars)
+
+Frontend — use `instanceStore.instanceName`:
+
+| File | What to replace |
+|------|-----------------|
+| `web/index.html` | Page `<title>` ("DANDI Archive" → `instanceName + " Archive"`) |
+| `web/index.html` | Noscript message ("DANDI Archive") |
+| `web/src/components/CookieBanner.vue` | "best experience on DANDI" |
+| `web/src/views/HomeView/StatsBar.vue` | "A DANDI dataset" description |
+| `web/src/views/CreateDandisetView/CreateDandisetView.vue` | "DANDI only supports 5 years of embargo" |
+| `web/src/components/FileBrowser/FileUploadInstructions.vue` | `dandi upload` → `dandi upload -i <instanceName>` |
+| `web/src/views/DandisetLandingView/DownloadDialog.vue` (x3) | "DANDI CLI" UI text |
+
+Backend — use `settings.DANDI_INSTANCE_NAME`:
+
+| File | What to replace |
+|------|-----------------|
+| `dandiapi/api/mail.py` (x6) | "DANDI:" prefix in email subjects |
+| `dandiapi/api/admin.py` | Admin site header/title ("DANDI Admin") |
+| `dandiapi/urls.py` | OpenAPI schema title ("DANDI Archive") |
+| `dandiapi/api/templates/api/mail/new_user_message.txt` | "signed up for DANDI" |
+| `dandiapi/api/templates/api/mail/pending_users_message.txt` | "new DANDI users" |
+| `dandiapi/api/templates/api/account/base.html` | `<title>DANDI Archive</title>` (name part only) |
+
+### Group 2 — Requires new branding configuration
+
+Frontend — custom images, colors, URLs:
+
+| File | What needs config |
+|------|-------------------|
+| `web/src/components/AppBar/AppBar.vue` | Logo asset, alt text |
+| `web/src/components/AppBar/AppBar.vue` | `import logo from '@/assets/logo.svg'` |
+| `web/src/views/HomeView/HomeView.vue` | Logo asset import |
+| `web/src/views/HomeView/HomeView.vue` | Archive heading (Group 1 name + Group 2 tagline) |
+| `web/src/plugins/vuetify.ts` | Brand color palettes (light + dark themes) |
+| `web/src/utils/constants.ts` | 7 hardcoded `dandiarchive.org` URLs (about, blog, docs, help, hub, sandbox) |
+| `web/src/components/DandiFooter.vue` | Copyright line (Group 1 name + Group 2 start year, team name) |
+| `web/src/components/DandiFooter.vue` | Code of Conduct GitHub URL |
+| `web/src/components/DandiFooter.vue` | Funding section (BRAIN Initiative, NIMH, AWS, Netlify) |
+| `web/src/components/DandiFooter.vue` | Support section (`help@dandiarchive.org`, helpdesk URL) |
+| `web/src/components/DandiFooter.vue` | GitHub commit/repo URL |
+| `web/src/components/UserStatusBanner.vue` | Banner texts (Group 1 name + Group 2 support email) |
+| `web/src/views/DandisetLandingView/ShareDialog.vue` | Twitter/X handle |
+| `web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue` | `sandbox.dandiarchive.org` staging detection URL |
+| `web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue` | `medit.dandiarchive.org` AI editor URL |
+| `web/src/views/DandisetLandingView/DandisetLandingView.vue` | `help@dandiarchive.org` support email |
+
+Frontend assets (not annotatable with comments):
+
+| File | What it is |
+|------|-----------|
+| `web/src/assets/logo.svg` | Main logo displayed in AppBar and HomeView splash |
+| `web/public/favicon.ico` | Browser tab icon |
+
+Backend — custom URLs, domain, content:
+
+| File | What needs config |
+|------|-------------------|
+| `dandiapi/api/migrations/0001_default_site.py` | Site domain (`api.dandiarchive.org`) and name |
+| `dandiapi/api/templates/api/account/base.html` | Logo URL from GitHub (Group 2 image) |
+| `dandiapi/api/templates/api/root_content.html` | Group 1 name + Group 2 about URL, support email |
+| `dandiapi/api/templates/api/account/questionnaire_form.html` | Group 1 name + Group 2 support email |
+| `dandiapi/api/templates/api/mail/rejected_user_message.txt` | Group 1 name + Group 2 support email, docs URL, team name |
+| `dandiapi/api/templates/api/mail/approved_user_message.txt` | Group 1 name + Group 2 docs URLs, YouTube URL, team name |
+| `dandiapi/api/templates/api/mail/registered_message.txt` | Group 1 name + Group 2 hub URL, docs URLs, YouTube URL, team name |
+
+## Target: EMBER Archive
+
+The first (and motivating) consumer of branding abstraction is
+**EMBER** (Ecosystem for Multi-modal Brain-behavior Experimentation and Research),
+an archive instance run by JHU/APL for the NIH BBQS Program.
+
+- Web: https://emberarchive.org
+- API: https://api-dandi.emberarchive.org
+- Fork: https://github.com/aplbrain/dandi-archive (branch `prod`)
+- Support email: `help@emberarchive.org`
+- RRID: `RRID:SCR_026700`
+- DOI prefix: `10.82754`
+
+### How EMBER currently brands (from `git diff origin/master...gh-aplbrain/prod`)
+
+EMBER maintains a hard fork with ~370 lines of branding-only diff across 47
+files. The changes fall into these categories:
+
+**String replacements** (pure find-and-replace "DANDI" → "EMBER-DANDI"):
+- Email subjects in `mail.py` (6 occurrences)
+- All email templates (registered, approved, rejected, pending, new_user)
+- Admin site header/title in `admin.py`
+- OpenAPI schema title in `urls.py`
+- Page titles in `index.html`, `base.html`
+- User-facing text in `UserStatusBanner.vue`, `CookieBanner.vue`,
+  `DandisetLandingView.vue`, `root_content.html`, `questionnaire_form.html`
+- Support email `help@dandiarchive.org` → `help@emberarchive.org`
+
+**Visual identity**:
+- New logo `web/src/assets/ember-logo.png` (replaces `logo.svg`)
+- New favicon `web/public/favicon.ico`
+- Brand color palette in `vuetify.ts`: light-blue → red/orange/yellow
+- AppBar layout: added "EMBER-DANDI" text label next to logo
+- Accent colors tweaked in `UserMenu.vue`, `SingleStat.vue`
+
+**Content customization**:
+- HomeView heading: "The DANDI Archive" → "The EMBER-DANDI Archive"
+- HomeView tagline: adjusted to mention BBQS Program
+- Footer: added JHU/APL copyright, changed NIMH → BBQS Program link,
+  added Sentry and DANDI to funding sources, added `class="text-primary"` on links
+- `CreateDandisetView`: "Embargo this Dandiset" → "Mark Dandiset Private"
+- Registered message template: removed Jupyterhub/Slack references,
+  added EMBER-specific getting-started links
+
+**URL changes**:
+- Added EMBER-specific URLs in `constants.ts` (`emberAboutUrl`, `emberDocumentationUrl`, etc.)
+- AppBar nav: replaced `dandiAboutUrl`/`dandiHelpUrl` with EMBER equivalents,
+  commented out Support link
+- GitHub repo URLs: `dandi/dandi-archive` → `aplbrain/dandi-archive`
+
+**Deployment/CI config** (not branding per se, but coupled):
+- `.env.production`: OAuth, API root, Sentry DSN all point to `emberarchive.org`
+- `.env.docker-compose*`: instance name `DEV-EMBER-DANDI`, RRID, DOI prefix
+- GitHub Actions workflows: adjusted for EMBER deployment targets
+- `netlify.toml`: different redirect rules
+- `web/.env.production`: different OAuth client ID
+
+**Functional additions** (beyond branding):
+- `FileUploadInstructions.vue`: added `-i <instance>` flag to `dandi upload`
+  command (fetches instance name from API — already a proper fix)
+- `views/auth.py`: includes questionnaire answers in admin notification email
+- `scripts/embargo_dandiset_blobs.py`, `scripts/rewrite_manifest_files.py`,
+  `scripts/ember_maintenance.html`: EMBER-specific operational scripts
+
+### Assessment
+
+The EMBER fork confirms that our `TODO: BRANDING` annotations capture the
+correct set of touchpoints. Comparing the two inventories:
+
+**Already annotated and matching EMBER's changes**: all email subjects,
+email templates, constants.ts URLs, vuetify theme, AppBar logo, HomeView
+heading/tagline, CookieBanner, UserStatusBanner, DandiFooter, questionnaire
+form, admin.py, urls.py, base.html, root_content.html, migration site name.
+
+**Gaps discovered from EMBER diff** (now annotated):
+- `dandiapi/api/admin.py` — admin site header/title
+- `dandiapi/urls.py` — OpenAPI schema title
+- `dandiapi/api/templates/api/account/base.html` — title + logo URL
+- `dandiapi/api/templates/api/root_content.html` — archive name, about URL, support email
+- `web/src/views/DandisetLandingView/DandisetLandingView.vue` — support email
+- `web/src/components/FileBrowser/FileUploadInstructions.vue` — `dandi upload` command
+
+**EMBER changes that are deployment-specific** (not branding annotations):
+- `.env.production`, `.env.docker-compose*` — these are instance env configs
+- GitHub Actions workflows — deployment targets
+- `netlify.toml` — hosting configuration
+- `scripts/ember_*` — operational scripts
+
+**EMBER changes that are feature additions** (should be upstreamed separately):
+- `FileUploadInstructions.vue` `-i` flag — already properly uses instance API
+- `views/auth.py` questionnaire in email — useful for all instances
+
+## Future Implementation Notes
+
+_To be designed in detail later._ High-level direction based on research
+(Nautobot pattern, Django context processors, Vue runtime config):
+
+- **Backend**: A `BRANDING` settings dict with env-var overridable keys for
+  all display names, URLs, support contacts, social handles, etc.
+  Extend `/api/info/` to serve branding config to the frontend.
+
+- **Frontend**: A Pinia branding store loaded from `/api/info/` at startup.
+  Components replace hardcoded strings with store references. CSS custom
+  properties for brand colors. Dynamic logo/favicon from config URLs.
+
+- **CI guard**: The existing `scripts/check-no-hardcoded-dandi.sh` (from PR
+  #2765) catches regressions in `.vue`/`.ts` files. May be extended to cover
+  Python files and templates.

--- a/web/index.html
+++ b/web/index.html
@@ -5,12 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="/favicon.ico">
+    <!-- TODO: BRANDING(name) - hardcoded archive title -->
     <title>DANDI Archive</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
   </head>
   <body>
     <noscript>
+      <!-- TODO: BRANDING(name) - hardcoded archive name -->
       <strong>We're sorry but the DANDI Archive doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>

--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -42,12 +42,14 @@
       </v-list>
     </v-menu>
     <router-link to="/">
+      <!-- TODO: BRANDING START - hardcoded logo asset and alt text -->
       <v-img
         alt="DANDI logo"
         :width="100"
         :src="logo"
         class="mr-3"
       />
+      <!-- TODO: BRANDING END -->
     </router-link>
     <v-toolbar-items v-if="!isMobile">
       <v-tabs selected-class="text-primary">
@@ -154,7 +156,7 @@ import {
   dandiAboutUrl, dandiBlogUrl, dandiDocumentationUrl, dandiHelpUrl, dandihubUrl,
 } from '@/utils/constants';
 import UserMenu from '@/components/AppBar/UserMenu.vue';
-import logo from '@/assets/logo.svg';
+import logo from '@/assets/logo.svg'; // TODO: BRANDING - hardcoded logo asset
 
 interface NavigationItem {
   text: string,

--- a/web/src/components/CookieBanner.vue
+++ b/web/src/components/CookieBanner.vue
@@ -48,6 +48,7 @@ function setCookie() {
       max-width="60%"
       style="left: 50%; transform: translateX(-50%); z-index: 1;"
     >
+      <!-- TODO: BRANDING(name) - hardcoded archive name -->
       <span v-if="cookiesEnabled">We use cookies to ensure you get the best experience on DANDI.</span>
       <span v-else>We noticed you're blocking cookies - note that certain aspects of the site may not work.</span>
       <v-btn

--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -4,6 +4,7 @@
       <CookieBanner />
       <v-row>
         <v-col offset="2">
+          <!-- TODO: BRANDING - hardcoded copyright year, team name -->
           &copy; 2019 - {{ currentYear }} The DANDI Team<br>
           <a
             target="_blank"
@@ -19,11 +20,13 @@
           >Policies</a>
           <v-icon size="x-small">
             mdi-open-in-new
+          <!-- TODO: BRANDING START - hardcoded GitHub repo URL -->
           </v-icon> / <a
             target="_blank"
             rel="noopener"
             href="https://github.com/dandi/dandi-archive/blob/master/CODE_OF_CONDUCT.md"
           >Code of Conduct</a>
+          <!-- TODO: BRANDING END -->
           <v-icon size="x-small">
             mdi-open-in-new
           </v-icon>
@@ -36,6 +39,7 @@
             rel="noopener"
           >{{ version }}</a>
         </v-col>
+        <!-- TODO: BRANDING START - hardcoded funding sources and sponsor URLs -->
         <v-col>
           Funding / In-Kind Support:<br>
           - <a
@@ -72,6 +76,8 @@
             mdi-open-in-new
           </v-icon>
         </v-col>
+        <!-- TODO: BRANDING END -->
+        <!-- TODO: BRANDING START - hardcoded support email and helpdesk URL -->
         <v-col>
           Support:<br>
           - <a
@@ -92,6 +98,7 @@
             mdi-open-in-new
           </v-icon>
         </v-col>
+        <!-- TODO: BRANDING END -->
       </v-row>
     </v-container>
   </v-footer>
@@ -102,6 +109,7 @@ import CookieBanner from './CookieBanner.vue';
 import { dandiDocumentationUrl } from '@/utils/constants';
 
 const version = import.meta.env.VITE_APP_VERSION;
+// TODO: BRANDING - hardcoded GitHub repo URL
 const githubLink = import.meta.env.VITE_APP_GIT_REVISION ? `https://github.com/dandi/dandi-archive/commit/${import.meta.env.VITE_APP_GIT_REVISION}` : 'https://github.com/dandi/dandi-archive';
 const currentYear = new Date().getFullYear();
 </script>

--- a/web/src/components/FileBrowser/FileUploadInstructions.vue
+++ b/web/src/components/FileBrowser/FileUploadInstructions.vue
@@ -26,6 +26,7 @@
             <div>> cd {{ dandisetIdentifier }}</div>
             <div>> dandi organize &lt;source_folder&gt; -f dry</div>
             <div>> dandi organize &lt;source_folder&gt;</div>
+            <!-- TODO: BRANDING(name) - may need instance flag for non-default instances -->
             <div>> dandi upload</div>
           </v-sheet>
         </div>

--- a/web/src/components/UserStatusBanner.vue
+++ b/web/src/components/UserStatusBanner.vue
@@ -28,6 +28,7 @@ interface StatusBanner {
 
 const bannerInfo = computed<StatusBanner | null>(() => {
   switch (user.value?.status) {
+    // TODO: BRANDING START - hardcoded archive name and support email
     case 'PENDING':
       return {
         text: 'Your DANDI account is currently pending approval. Please allow up to 2 business days for approval and contact the DANDI admins at help@dandiarchive.org if you have any questions.',
@@ -40,6 +41,7 @@ const bannerInfo = computed<StatusBanner | null>(() => {
         icon: 'mdi-close-octagon',
         color: 'error',
       };
+    // TODO: BRANDING END
     default:
       return null;
   }

--- a/web/src/plugins/vuetify.ts
+++ b/web/src/plugins/vuetify.ts
@@ -12,6 +12,7 @@ import colors from 'vuetify/util/colors';
 // Composables
 import { createVuetify } from 'vuetify'
 
+// TODO: BRANDING START - hardcoded brand color palette
 const DandiLightTheme = {
   dark: false,
   colors: {
@@ -35,6 +36,7 @@ const DandiDarkTheme = {
     highlight: colors.grey.darken2,
   }
 };
+// TODO: BRANDING END
 
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -1,3 +1,4 @@
+// TODO: BRANDING START - hardcoded instance-specific URLs; should come from backend config
 const dandiUrl = 'https://dandiarchive.org';
 const dandiAboutUrl = 'https://about.dandiarchive.org/';
 const dandiBlogUrl = 'https://about.dandiarchive.org/blog/';
@@ -5,6 +6,7 @@ const dandiDocumentationUrl = 'https://docs.dandiarchive.org';
 const dandiHelpUrl = 'https://docs.dandiarchive.org/support/';
 const dandihubUrl = 'https://hub.dandiarchive.org/';
 const sandboxDocsUrl = `${dandiDocumentationUrl}/getting-started/creating-account/`;
+// TODO: BRANDING END
 
 const draftVersion = 'draft';
 

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -284,7 +284,7 @@ const grantEndDateRules = computed(() => [
 
     // Check if date is more than 5 years in the future
     if (selectedDate > fiveYearsFromNow) {
-      return 'DANDI only supports 5 years of embargo';
+      return 'DANDI only supports 5 years of embargo'; // TODO: BRANDING(name) - hardcoded archive name
     }
 
     return true;

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -34,6 +34,7 @@
         </span>
         <br><br>
         <span class="text-body-2">
+          <!-- TODO: BRANDING - hardcoded support email -->
           For further assistance, please contact <a href="mailto:help@dandiarchive.org">help@dandiarchive.org</a>.
         </span>
       </div>

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -53,6 +53,7 @@
       </v-card-title>
       <v-list class="pa-0">
         <v-list-item density="compact">
+          <!-- TODO: BRANDING(name) - hardcoded "DANDI CLI" name -->
           Use this command in your DANDI CLI
         </v-list-item>
         <v-list-item density="compact">
@@ -110,13 +111,15 @@
           </v-expansion-panel>
           <v-expansion-panel>
             <v-expansion-panel-title>
+              <!-- TODO: BRANDING(name) - hardcoded "DANDI CLI" name -->
               Don't have DANDI CLI?
-            </v-expansion-panel-title>
+                </v-expansion-panel-title>
             <v-expansion-panel-text>
               <v-list>
                 <v-list-item>
+                  <!-- TODO: BRANDING(name) - hardcoded "DANDI CLI" name -->
                   Install the Python client (DANDI CLI)
-                  in a Python {{ cliRequiresPython }} environment using command:
+                          in a Python {{ cliRequiresPython }} environment using command:
                 </v-list-item>
                 <v-list-item>
                   <kbd>pip install "dandi>={{ cliMinimalVersion }}"</kbd>

--- a/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
+++ b/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
@@ -99,6 +99,7 @@ const neurosiftURL = computed(() => {
   const metadata = currentDandiset.value.metadata;
   const dandisetId = currentDandiset.value.dandiset.identifier;
   const dandisetVersion = metadata.version;
+  // TODO: BRANDING - hardcoded sandbox URL for staging detection
   const stagingParam = metadata.url!.startsWith('https://sandbox.dandiarchive.org/') ? '&staging=1' : '';
 
   return `https://neurosift.app/dandiset/${dandisetId}?dandisetVersion=${dandisetVersion}${stagingParam}`;
@@ -111,6 +112,7 @@ const aiEditorURL = computed(() => {
 
   const dandisetId = currentDandiset.value.dandiset.identifier;
   const baseApiUrl = import.meta.env.VITE_APP_DANDI_API_ROOT;
+  // TODO: BRANDING - hardcoded AI metadata editor URL
   return `https://medit.dandiarchive.org/?dandiset=${dandisetId}&instance=${baseApiUrl}`;
 });
 

--- a/web/src/views/DandisetLandingView/ShareDialog.vue
+++ b/web/src/views/DandisetLandingView/ShareDialog.vue
@@ -101,7 +101,7 @@ defineProps({
   },
 });
 
-// // Twitter user to mention
+// TODO: BRANDING - hardcoded social media handle
 const twitterUser = 'DANDIarchive';
 
 const store = useDandisetStore();

--- a/web/src/views/HomeView/HomeView.vue
+++ b/web/src/views/HomeView/HomeView.vue
@@ -21,6 +21,7 @@
             align="center"
           >
             <v-col class="splash-text my-12">
+              <!-- TODO: BRANDING START - hardcoded archive name and tagline -->
               <div class="text-h2 font-weight-thin text-center text-light-blue-darken-1">
                 The DANDI Archive
               </div>
@@ -30,6 +31,7 @@
                 optophysiology, and behavioral time-series, and images from
                 immunostaining experiments.
               </div>
+              <!-- TODO: BRANDING END -->
             </v-col>
           </v-row>
         </v-container>
@@ -50,7 +52,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useDisplay } from 'vuetify';
 import StatsBar from '@/views/HomeView/StatsBar.vue';
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
-import logo from '@/assets/logo.svg';
+import logo from '@/assets/logo.svg'; // TODO: BRANDING - hardcoded logo asset
 
 const display = useDisplay();
 const isSmAndUpDisplay = computed(() => display.smAndUp.value);

--- a/web/src/views/HomeView/StatsBar.vue
+++ b/web/src/views/HomeView/StatsBar.vue
@@ -40,7 +40,7 @@ const stats = computed(() => [
   {
     name: 'dandisets',
     value: dandisets.value,
-    description: 'A DANDI dataset including files and dataset-level metadata',
+    description: 'A DANDI dataset including files and dataset-level metadata', // TODO: BRANDING(name) - hardcoded archive name
     href: '/dandiset',
   },
   { name: 'users', value: users.value },


### PR DESCRIPTION
## Summary

- Annotate every hardcoded branding touchpoint in the codebase with `TODO: BRANDING` markers (29 files, comments only, zero behavior change)
- Split annotations into two groups for phased resolution:
  - **`BRANDING(name)`** (20 spots): pure "DANDI" → instance name substitutions, fixable with existing `settings.DANDI_INSTANCE_NAME` / `instanceStore.instanceName`
  - **`BRANDING` / `BRANDING START/END`** (23 spots): require new branding config (logos, colors, URLs, funding text, support emails, etc.)
- Add `doc/design/branding.md` with full inventory, annotation conventions, and analysis of the EMBER archive fork (`git diff origin/master...gh-aplbrain/prod`)
- Add minimal "Branding Annotations" section to `DEVELOPMENT.md` pointing to the design doc
## Dependencies

This is a documentation/annotation-only PR — no code behavior changes.

However, the **next step** (resolving `BRANDING(name)` items) depends on 

- https://github.com/dandi/dandi-archive/pull/2765 
 
being merged first, since that PR introduces the frontend `instanceStore` that `BRANDING(name)` fixes will use. Planned sequence:

1. **This PR**: annotate all branding touchpoints and provides design doc/comparison against EMBER
2. ⏳ **PR #2765**: merge vendorization fixes (instanceName/instanceIdentifier dynamic in citations, HowToCite, etc.) for frontend
3. **Next PR**: resolve all `BRANDING(name)` items using existing vendorization variables
4. **Future**: design and implement new branding config for remaining `BRANDING` items (logos, URLs, colors, etc.)

## How to find annotations

```bash
# All branding touchpoints
git grep "TODO: BRANDING"

# Only Group 1 (name substitution — easy wins)
git grep "BRANDING(name)"

# Only Group 2 (needs new config)
git grep "TODO: BRANDING" | grep -v "BRANDING(name)"
```

## Test plan

- [x] Verify no behavior changes — this is comments-only, CI should remain green!
- [ ] Review `doc/design/branding.md` for completeness against EMBER fork diff  
- [ ] attn: @dandi/ember   please complement with what additional aspects to potentially bring in right away . Feel welcome to propose PR to annotate those places!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
