### PR TITLE
fix: use datePublished for citation year on published versions

### DIFF
--- a/web/src/components/DLP/HowToCiteTab.vue
+++ b/web/src/components/DLP/HowToCiteTab.vue
@@ -282,7 +282,7 @@ const cffObject = computed(() => {
     return null;
   }
 
-  return dandisetToCFF(props.meta, typeof doi.value === 'string' ? doi.value : undefined);
+  return dandisetToCFF(props.meta, typeof doi.value === 'string' ? doi.value : undefined, currentDandiset.value?.modified);
 });
 
 // Generate citations in different formats

--- a/web/src/components/DLP/HowToCiteTab.vue
+++ b/web/src/components/DLP/HowToCiteTab.vue
@@ -282,7 +282,7 @@ const cffObject = computed(() => {
     return null;
   }
 
-  return dandisetToCFF(props.meta, typeof doi.value === 'string' ? doi.value : undefined, currentDandiset.value?.modified);
+  return dandisetToCFF(props.meta, typeof doi.value === 'string' ? doi.value : undefined, isDraft.value, currentDandiset.value?.modified);
 });
 
 // Generate citations in different formats

--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -160,9 +160,10 @@ export function dandisetToCFF(metadata: DandisetMetadata, doi?: string): CFF {
     cff.version = metadata.version;
   }
 
-  // Add release date
-  if (metadata.dateModified) {
-    cff['date-released'] = metadata.dateModified.split('T')[0]; // Extract date part
+  // Add release date (prefer datePublished for published versions, fall back to dateModified)
+  const releaseDate = (metadata.datePublished || metadata.dateModified) as string | undefined;
+  if (releaseDate) {
+    cff['date-released'] = releaseDate.split('T')[0]; // Extract date part
   }
 
   // Add related resources as references

--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -160,8 +160,8 @@ export function dandisetToCFF(metadata: DandisetMetadata, doi?: string, versionM
     cff.version = metadata.version;
   }
 
-  // Add release date (datePublished for published versions, version modified date for drafts)
-  const releaseDate = (metadata.datePublished || versionModified) as string | undefined;
+  // Add release date (version modified date is most current, fall back to datePublished)
+  const releaseDate = (versionModified || metadata.datePublished) as string | undefined;
   if (releaseDate) {
     cff['date-released'] = releaseDate.split('T')[0]; // Extract date part
   }

--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -160,9 +160,8 @@ export function dandisetToCFF(metadata: DandisetMetadata, doi?: string, versionM
     cff.version = metadata.version;
   }
 
-  // Add release date (prefer datePublished for published versions, fall back to dateModified,
-  // then version-level modified date for drafts)
-  const releaseDate = (metadata.datePublished || metadata.dateModified || versionModified) as string | undefined;
+  // Add release date (datePublished for published versions, version modified date for drafts)
+  const releaseDate = (metadata.datePublished || versionModified) as string | undefined;
   if (releaseDate) {
     cff['date-released'] = releaseDate.split('T')[0]; // Extract date part
   }

--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -85,7 +85,7 @@ function organizationToCFFAuthor(org: Organization): CFFAuthor {
 /**
  * Convert DANDI dandiset metadata to CFF format
  */
-export function dandisetToCFF(metadata: DandisetMetadata, doi?: string): CFF {
+export function dandisetToCFF(metadata: DandisetMetadata, doi?: string, versionModified?: string): CFF {
   const cff: CFF = {
     'cff-version': '1.2.0',
     message: 'If you use this dataset, please cite it as below.',
@@ -160,8 +160,9 @@ export function dandisetToCFF(metadata: DandisetMetadata, doi?: string): CFF {
     cff.version = metadata.version;
   }
 
-  // Add release date (prefer datePublished for published versions, fall back to dateModified)
-  const releaseDate = (metadata.datePublished || metadata.dateModified) as string | undefined;
+  // Add release date (prefer datePublished for published versions, fall back to dateModified,
+  // then version-level modified date for drafts)
+  const releaseDate = (metadata.datePublished || metadata.dateModified || versionModified) as string | undefined;
   if (releaseDate) {
     cff['date-released'] = releaseDate.split('T')[0]; // Extract date part
   }

--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -85,7 +85,7 @@ function organizationToCFFAuthor(org: Organization): CFFAuthor {
 /**
  * Convert DANDI dandiset metadata to CFF format
  */
-export function dandisetToCFF(metadata: DandisetMetadata, doi?: string, versionModified?: string): CFF {
+export function dandisetToCFF(metadata: DandisetMetadata, doi?: string, isDraft?: boolean, draftModifiedDate?: string): CFF {
   const cff: CFF = {
     'cff-version': '1.2.0',
     message: 'If you use this dataset, please cite it as below.',
@@ -160,10 +160,10 @@ export function dandisetToCFF(metadata: DandisetMetadata, doi?: string, versionM
     cff.version = metadata.version;
   }
 
-  // Add release date (version modified date is most current, fall back to datePublished)
-  const releaseDate = (versionModified || metadata.datePublished) as string | undefined;
+  // Add release date
+  const releaseDate = isDraft ? draftModifiedDate : metadata.datePublished as string | undefined;
   if (releaseDate) {
-    cff['date-released'] = releaseDate.split('T')[0]; // Extract date part
+    cff['date-released'] = releaseDate.split('T')[0];
   }
 
   // Add related resources as references


### PR DESCRIPTION
## Summary
- Published dandiset versions have `datePublished` set but `dateModified` is null, causing the "How to Cite" citations to be missing the year field in all formats (APA, MLA, Chicago, etc.)
- Prefer `datePublished` over `dateModified` when generating the CFF `date-released` field

Fixes #2769

## Test plan
- [x] Navigate to a published dandiset (e.g. `/dandiset/000409`) and open the "How to Cite" tab
- [x] Verify the year appears in all citation formats (APA, MLA, Chicago, Harvard, Vancouver, IEEE, BibTeX, RIS)
- [x] Verify draft dandisets still show dates correctly (they use `dateModified`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)