### PR TITLE
Fix instance store race condition, hardcoded URL, and minor issues

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -14,7 +14,11 @@ interface InstanceConfig {
 }
 
 async function fetchInstanceConfig(): Promise<InstanceConfig> {
-  const resp = await fetch(`${apiUrl}/info/`);
+  const url = `${apiUrl}/info/`;
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch instance config from ${url}: ${resp.status} ${resp.statusText}`);
+  }
   const data = await resp.json();
   return data.instance_config;
 }

--- a/scripts/check-no-hardcoded-dandi.sh
+++ b/scripts/check-no-hardcoded-dandi.sh
@@ -30,22 +30,22 @@ for file in "$@"; do
 
     # Check for DANDI: as identifier prefix in string/template literals
     # Match patterns like `DANDI:${...}`, "DANDI:", 'DANDI:'
-    if grep -nE '("|'\''|`)\s*DANDI:' "$file" >/dev/null 2>&1; then
+    if grep -nE '("|'\''|`)[[:space:]]*DANDI:' "$file" >/dev/null 2>&1; then
         echo "$file: found hardcoded 'DANDI:' identifier prefix — use instanceName from the instance store"
         ERRORS=$((ERRORS + 1))
     fi
 
     # Check for lowercase dandi: used as citation key prefix (followed by digits or ${)
     # Excludes schema URIs like dandi:OpenAccess, dandi:EmbargoedAccess
-    if grep -nE '("|'\''|`)\s*dandi:\$\{' "$file" >/dev/null 2>&1 || \
-       grep -nE '("|'\''|`)\s*dandi:[0-9]' "$file" >/dev/null 2>&1; then
+    if grep -nE '("|'\''|`)[[:space:]]*dandi:\$\{' "$file" >/dev/null 2>&1 || \
+       grep -nE '("|'\''|`)[[:space:]]*dandi:[0-9]' "$file" >/dev/null 2>&1; then
         echo "$file: found hardcoded 'dandi:' identifier prefix — use instanceName.toLowerCase() from the instance store"
         ERRORS=$((ERRORS + 1))
     fi
 
     # Check for "DANDI Archive" as publisher name in string literals
     # Exclude HTML comments (<!-- ... -->)
-    if grep -nE "(\"|\`|').*DANDI Archive" "$file" | grep -vE '^\s*<!--' >/dev/null 2>&1; then
+    if grep -nE "(\"|\`|').*DANDI Archive" "$file" | grep -vE '^[[:space:]]*<!--' >/dev/null 2>&1; then
         echo "$file: found hardcoded 'DANDI Archive' — use instanceName from the instance store"
         ERRORS=$((ERRORS + 1))
     fi

--- a/web/src/components/DLP/HowToCiteTab.vue
+++ b/web/src/components/DLP/HowToCiteTab.vue
@@ -346,18 +346,15 @@ const formattedCitations = computed<Record<CitationFormat, string>>(() => {
       cff: '',
     };
   }
-  const dandiset_version_identifier = dandisetVersionIdentifier.value;
-  const instance_name = instanceName.value;
-
   return {
-    apa: cffToAPA(cffObject.value, instance_name),
-    mla: cffToMLA(cffObject.value, instance_name),
-    chicago: cffToChicago(cffObject.value, instance_name),
-    harvard: cffToHarvard(cffObject.value, instance_name),
-    vancouver: cffToVancouver(cffObject.value, instance_name),
-    ieee: cffToIEEE(cffObject.value, instance_name),
-    bibtex: cffToBibTeX(cffObject.value, dandiset_version_identifier, instance_name),
-    ris: cffToRIS(cffObject.value, dandiset_version_identifier, instance_name),
+    apa: cffToAPA(cffObject.value, instanceName.value),
+    mla: cffToMLA(cffObject.value, instanceName.value),
+    chicago: cffToChicago(cffObject.value, instanceName.value),
+    harvard: cffToHarvard(cffObject.value, instanceName.value),
+    vancouver: cffToVancouver(cffObject.value, instanceName.value),
+    ieee: cffToIEEE(cffObject.value, instanceName.value),
+    bibtex: cffToBibTeX(cffObject.value, dandisetVersionIdentifier.value, instanceName.value),
+    ris: cffToRIS(cffObject.value, dandisetVersionIdentifier.value, instanceName.value),
     cff: cffToYAML(cffObject.value),
   };
 });
@@ -413,7 +410,8 @@ const dandiUrl = computed(() => {
   }
 
   const { identifier } = currentDandiset.value.dandiset;
-  return `https://dandiarchive.org/dandiset/${identifier}`;
+  const baseUrl = instanceStore.instanceUrl || window.location.origin;
+  return `${baseUrl}/dandiset/${identifier}`;
 });
 
 const methodsText = computed(() => {

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -16,9 +16,14 @@ import App from './App.vue'
 // Composables
 import { createApp } from 'vue'
 
+import { useInstanceStore } from '@/stores/instance'
+
 const app = createApp(App)
 
 registerPlugins(app)
 registerDirectives(app)
+
+// Fetch instance config early so page titles and identifiers are available
+useInstanceStore().fetchInstanceInfo();
 
 app.mount('#app')

--- a/web/src/stores/instance.ts
+++ b/web/src/stores/instance.ts
@@ -7,6 +7,7 @@ interface InstanceState {
   instanceIdentifier: string | null;
   instanceUrl: string | null;
   loaded: boolean;
+  _fetchPromise: Promise<void> | null;
 }
 
 export const useInstanceStore = defineStore('instance', {
@@ -15,12 +16,20 @@ export const useInstanceStore = defineStore('instance', {
     instanceIdentifier: null,
     instanceUrl: null,
     loaded: false,
+    _fetchPromise: null,
   }),
   actions: {
     async fetchInstanceInfo() {
       if (this.loaded) {
         return;
       }
+      if (this._fetchPromise) {
+        return this._fetchPromise;
+      }
+      this._fetchPromise = this._doFetch();
+      return this._fetchPromise;
+    },
+    async _doFetch() {
       const info = await dandiRest.info();
       this.instanceName = info.instance_config.instance_name;
       this.instanceIdentifier = info.instance_config.instance_identifier;

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -161,10 +161,10 @@ const currentVersion = computed(() => store.version);
 const cliMinimalVersion = ref<string>();
 const cliRequiresPython = ref<string>();
 onMounted(async () => {
+  await instanceStore.fetchInstanceInfo();
   const info = await dandiRest.info();
   cliMinimalVersion.value = info['cli-minimal-version'];
   cliRequiresPython.value = info['cli-requires-python'];
-  await instanceStore.fetchInstanceInfo();
 });
 
 const selectedDownloadOption = ref('draft');


### PR DESCRIPTION
## Summary

Follow-up fixes for #2765:

- **Race condition in instance store**: Concurrent `fetchInstanceInfo()` calls from multiple components now share a single in-flight promise instead of firing duplicate `/api/info/` requests
- **Hardcoded URL in HowToCiteTab**: `dandiUrl` computed property was still falling back to `https://dandiarchive.org` — now uses `instanceStore.instanceUrl`
- **App-level store initialization**: Instance store is now fetched at startup in `main.ts` so page titles work on all routes (not just those mounting components that call `fetchInstanceInfo()`)
- **Double API call in DownloadDialog**: Reordered to use cached instance store fetch before the separate `dandiRest.info()` call for CLI version info
- **snake_case → camelCase**: Fixed local variable naming in HowToCiteTab to match project conventions
- **POSIX-portable grep**: Replaced `\s` with `[[:space:]]` in lint script for BSD grep compatibility
- **E2E error handling**: Added `resp.ok` check in `fetchInstanceConfig()`

## Test plan

- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] Hardcoded identifier lint check passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)