### PR TITLE
Fix incompatibility with RabbitMQ 4.3

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,7 +27,7 @@ This is the simplest configuration for developers to start with.
 ### Run Application
 1. Run the following commands in three separate VSCode built-in-terminals:
    1. `./manage.py runserver_plus 0.0.0.0:8000`
-   1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat -Q celery,calculate_sha256,ingest_zarr_archive,manifest-worker -B`
+   1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip --queues celery,calculate_sha256,ingest_zarr_archive,manifest-worker --beat`
    1. `cd web/ && npm install && npm run dev`
 1. Access the site, starting at http://localhost:8000/admin/
 1. When finished, use `Ctrl+C`

--- a/Procfile
+++ b/Procfile
@@ -6,6 +6,6 @@ web: gunicorn --config gunicorn.conf.py dandiapi.wsgi
 # This is OK for now because of how lightweight all high priority tasks currently are,
 # but we may need to switch back to a dedicated worker in the future.
 # The queue `celery` is the default queue.
-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B --without-gossip --without-mingle
+worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip --queues celery --beat
 # The checksum-worker calculates blob checksums and updates zarr checksum files
-checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256,ingest_zarr_archive --without-gossip --without-mingle
+checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip --queues calculate_sha256,ingest_zarr_archive

--- a/dandiapi/settings/base.py
+++ b/dandiapi/settings/base.py
@@ -187,6 +187,8 @@ SWAGGER_SETTINGS = {
 CELERY_BROKER_HEARTBEAT = 20
 # Allow this to be configurable, but keep the default as the number of CPU cores
 CELERY_WORKER_CONCURRENCY: int | None = env.int('DJANGO_CELERY_WORKER_CONCURRENCY', default=None)
+# Work around https://github.com/celery/kombu/issues/2237
+CELERY_WORKER_ENABLE_REMOTE_CONTROL = False
 
 _dandi_log_level: str = env.str('DJANGO_DANDI_LOG_LEVEL', default='INFO')
 # Configure the logging level on all DANDI loggers.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -44,9 +44,11 @@ services:
       "--app", "dandiapi.celery",
       "worker",
       "--loglevel", "INFO",
+      "--without-mingle",
       "--without-heartbeat",
-      "-Q", "celery,calculate_sha256,ingest_zarr_archive,manifest-worker",
-      "-B"
+      "--without-gossip",
+      "--queues", "celery,calculate_sha256,ingest_zarr_archive,manifest-worker",
+      "--beat"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
     tty: false


### PR DESCRIPTION
RabbitMQ 4.3 disallows a queue configuration (non-exclusive, non-durable) that Celery is still using by default. Celery creates such queues for:
* remote control (`pidbox`)
* events (`celeryev`)

To disable the (remote) control queue:
* `--without-mingle`
* `worker_enable_remote_control = False`

To disable the events queue:
* `--without-heartbeat`
* `--without-gossip`
* `worker_send_task_events = False` (already the default)

Note, gossip, mingle, and heartbeat features provide no value. They generate extra traffic and are only used for task revocation (which DANDI doesn't use) and worker monitoring.