### PR TITLE
[codex] Fix citation author filtering

### DIFF
--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -264,6 +264,15 @@ export function cffToBibTeX(cff: CFF, identifier: string): string {
  * Convert CFF to APA format (7th edition)
  */
 export function cffToAPA(cff: CFF): string {
+  const year = cff['date-released'] ? ` (${cff['date-released'].split('-')[0]})` : '';
+  const version = cff.version ? ` (Version ${cff.version})` : '';
+  const doi = cff.doi ? ` https://doi.org/${cff.doi}` : '';
+
+  // APA 7: when there is no author, the title moves into the author position.
+  if (cff.authors.length === 0) {
+    return `${cff.title}${year}${version} [Data set]. DANDI Archive.${doi}`;
+  }
+
   const authors = cff.authors.map((author) => {
     if (author.name) {
       return author.name;
@@ -277,10 +286,8 @@ export function cffToAPA(cff: CFF): string {
     return `${author.family_names}, ${initials}`;
   });
 
-  let authorString = '';
-  if (authors.length === 0) {
-    authorString = cff.title;
-  } else if (authors.length === 1) {
+  let authorString: string;
+  if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length === 2) {
     authorString = `${authors[0]} & ${authors[1]}`;
@@ -288,19 +295,21 @@ export function cffToAPA(cff: CFF): string {
     authorString = authors.slice(0, -1).join(', ') + ', & ' + authors[authors.length - 1];
   }
 
-  const year = cff['date-released'] ? ` (${cff['date-released'].split('-')[0]})` : '';
-  const version = cff.version ? ` (Version ${cff.version})` : '';
-  const doi = cff.doi ? ` https://doi.org/${cff.doi}` : '';
-
-  const title = authors.length === 0 ? '' : ` ${cff.title}`;
-
-  return `${authorString}${year}.${title}${version} [Data set]. DANDI Archive.${doi}`;
+  return `${authorString}${year}. ${cff.title}${version} [Data set]. DANDI Archive.${doi}`;
 }
 
 /**
  * Convert CFF to MLA format (9th edition)
  */
 export function cffToMLA(cff: CFF): string {
+  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
+  const doi = cff.doi ? ` doi:${cff.doi}` : '';
+
+  // MLA 9: when there is no author, the entry begins with the title.
+  if (cff.authors.length === 0) {
+    return `"${cff.title}." DANDI Archive, ${year}.${doi}`;
+  }
+
   const authors = cff.authors.map((author, index) => {
     if (author.name) {
       return author.name;
@@ -314,10 +323,8 @@ export function cffToMLA(cff: CFF): string {
     return `${author.given_names} ${author.family_names}`;
   });
 
-  let authorString = '';
-  if (authors.length === 0) {
-    authorString = `"${cff.title}"`;
-  } else if (authors.length === 1) {
+  let authorString: string;
+  if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length === 2) {
     authorString = `${authors[0]}, and ${authors[1]}`;
@@ -327,18 +334,22 @@ export function cffToMLA(cff: CFF): string {
     authorString = `${authors[0]}, et al`;
   }
 
-  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
-  const doi = cff.doi ? ` doi:${cff.doi}` : '';
-
-  const title = authors.length === 0 ? '' : ` "${cff.title}."`;
-
-  return `${authorString}.${title} DANDI Archive, ${year}.${doi}`;
+  return `${authorString}. "${cff.title}." DANDI Archive, ${year}.${doi}`;
 }
 
 /**
  * Convert CFF to Chicago format (17th edition, Author-Date)
  */
 export function cffToChicago(cff: CFF): string {
+  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
+  const version = cff.version ? `, version ${cff.version}` : '';
+  const doi = cff.doi ? ` https://doi.org/${cff.doi}` : '';
+
+  // Chicago author-date: when there is no author, the title takes the author slot.
+  if (cff.authors.length === 0) {
+    return `"${cff.title}." ${year}. Data set${version}. DANDI Archive.${doi}`;
+  }
+
   const authors = cff.authors.map((author, index) => {
     if (author.name) {
       return author.name;
@@ -352,10 +363,8 @@ export function cffToChicago(cff: CFF): string {
     return `${author.given_names} ${author.family_names}`;
   });
 
-  let authorString = '';
-  if (authors.length === 0) {
-    authorString = cff.title;
-  } else if (authors.length === 1) {
+  let authorString: string;
+  if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length <= 3) {
     authorString = authors.slice(0, -1).join(', ') + ', and ' + authors[authors.length - 1];
@@ -363,19 +372,21 @@ export function cffToChicago(cff: CFF): string {
     authorString = `${authors[0]} et al.`;
   }
 
-  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
-  const version = cff.version ? `, version ${cff.version}` : '';
-  const doi = cff.doi ? ` https://doi.org/${cff.doi}` : '';
-
-  const title = authors.length === 0 ? '' : ` "${cff.title}."`;
-
-  return `${authorString}. ${year}.${title} Data set${version}. DANDI Archive.${doi}`;
+  return `${authorString}. ${year}. "${cff.title}." Data set${version}. DANDI Archive.${doi}`;
 }
 
 /**
  * Convert CFF to Harvard format
  */
 export function cffToHarvard(cff: CFF): string {
+  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
+  const doi = cff.doi ? ` Available at: https://doi.org/${cff.doi}` : '';
+
+  // Harvard: when there is no author, the title takes the author slot.
+  if (cff.authors.length === 0) {
+    return `'${cff.title}' (${year}) DANDI Archive. Data set.${doi}`;
+  }
+
   const authors = cff.authors.map((author) => {
     if (author.name) {
       return author.name;
@@ -389,10 +400,8 @@ export function cffToHarvard(cff: CFF): string {
     return `${author.family_names}, ${initials}`;
   });
 
-  let authorString = '';
-  if (authors.length === 0) {
-    authorString = cff.title;
-  } else if (authors.length === 1) {
+  let authorString: string;
+  if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length === 2) {
     authorString = `${authors[0]} and ${authors[1]}`;
@@ -402,18 +411,21 @@ export function cffToHarvard(cff: CFF): string {
     authorString = `${authors[0]} et al.`;
   }
 
-  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
-  const doi = cff.doi ? ` Available at: https://doi.org/${cff.doi}` : '';
-
-  const title = authors.length === 0 ? '' : ` '${cff.title}',`;
-
-  return `${authorString} (${year})${title} DANDI Archive. Data set.${doi}`;
+  return `${authorString} (${year}) '${cff.title}', DANDI Archive. Data set.${doi}`;
 }
 
 /**
  * Convert CFF to Vancouver format (used in biomedical sciences)
  */
 export function cffToVancouver(cff: CFF): string {
+  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : '';
+  const doi = cff.doi ? ` doi: ${cff.doi}` : '';
+
+  // Vancouver: when there is no author, the entry begins with the title.
+  if (cff.authors.length === 0) {
+    return `${cff.title} [Data set]. DANDI Archive; ${year}.${doi}`;
+  }
+
   const authors = cff.authors.map((author) => {
     if (author.name) {
       return author.name;
@@ -428,27 +440,28 @@ export function cffToVancouver(cff: CFF): string {
   });
 
   // Vancouver limits to 6 authors, then "et al."
-  let authorString = '';
-  if (authors.length === 0) {
-    authorString = cff.title;
-  } else if (authors.length <= 6) {
+  let authorString: string;
+  if (authors.length <= 6) {
     authorString = authors.join(', ');
   } else {
     authorString = authors.slice(0, 6).join(', ') + ', et al';
   }
 
-  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : '';
-  const doi = cff.doi ? ` doi: ${cff.doi}` : '';
-
-  const title = authors.length === 0 ? '' : ` ${cff.title}`;
-
-  return `${authorString}.${title} [Data set]. DANDI Archive; ${year}.${doi}`;
+  return `${authorString}. ${cff.title} [Data set]. DANDI Archive; ${year}.${doi}`;
 }
 
 /**
  * Convert CFF to IEEE format
  */
 export function cffToIEEE(cff: CFF): string {
+  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : '';
+  const doi = cff.doi ? ` doi: ${cff.doi}` : '';
+
+  // IEEE: when there is no author, the entry begins with the title.
+  if (cff.authors.length === 0) {
+    return `"${cff.title}," DANDI Archive, ${year}.${doi}`;
+  }
+
   const authors = cff.authors.map((author) => {
     if (author.name) {
       return author.name;
@@ -462,10 +475,8 @@ export function cffToIEEE(cff: CFF): string {
     return `${initials} ${author.family_names}`;
   });
 
-  let authorString = '';
-  if (authors.length === 0) {
-    authorString = `"${cff.title}"`;
-  } else if (authors.length === 1) {
+  let authorString: string;
+  if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length === 2) {
     authorString = `${authors[0]} and ${authors[1]}`;
@@ -473,12 +484,7 @@ export function cffToIEEE(cff: CFF): string {
     authorString = authors.slice(0, -1).join(', ') + ', and ' + authors[authors.length - 1];
   }
 
-  const year = cff['date-released'] ? cff['date-released'].split('-')[0] : '';
-  const doi = cff.doi ? ` doi: ${cff.doi}` : '';
-
-  const title = authors.length === 0 ? '' : `, "${cff.title},"`;
-
-  return `${authorString}${title} DANDI Archive, ${year}.${doi}`;
+  return `${authorString}, "${cff.title}," DANDI Archive, ${year}.${doi}`;
 }
 
 /**

--- a/web/src/utils/cff.ts
+++ b/web/src/utils/cff.ts
@@ -101,7 +101,7 @@ export function dandisetToCFF(metadata: DandisetMetadata, doi?: string): CFF {
 
   // Convert contributors who should be included in citation
   metadata.contributor.forEach(contributor => {
-    if (contributor.includeInCitation !== false) {
+    if (contributor.includeInCitation === true) {
       if (contributor.schemaKey === 'Person') {
         cff.authors.push(personToCFFAuthor(contributor as Person));
       } else if (contributor.schemaKey === 'Organization') {
@@ -224,7 +224,9 @@ export function cffToBibTeX(cff: CFF, identifier: string): string {
 
   let bibtex = `${type}{${key},\n`;
   bibtex += `  title = {${cff.title}},\n`;
-  bibtex += `  author = {${authors}},\n`;
+  if (authors) {
+    bibtex += `  author = {${authors}},\n`;
+  }
 
   if (cff.doi) {
     bibtex += `  doi = {${cff.doi}},\n`;
@@ -276,7 +278,9 @@ export function cffToAPA(cff: CFF): string {
   });
 
   let authorString = '';
-  if (authors.length === 1) {
+  if (authors.length === 0) {
+    authorString = cff.title;
+  } else if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length === 2) {
     authorString = `${authors[0]} & ${authors[1]}`;
@@ -288,7 +292,9 @@ export function cffToAPA(cff: CFF): string {
   const version = cff.version ? ` (Version ${cff.version})` : '';
   const doi = cff.doi ? ` https://doi.org/${cff.doi}` : '';
 
-  return `${authorString}${year}. ${cff.title}${version} [Data set]. DANDI Archive.${doi}`;
+  const title = authors.length === 0 ? '' : ` ${cff.title}`;
+
+  return `${authorString}${year}.${title}${version} [Data set]. DANDI Archive.${doi}`;
 }
 
 /**
@@ -309,7 +315,9 @@ export function cffToMLA(cff: CFF): string {
   });
 
   let authorString = '';
-  if (authors.length === 1) {
+  if (authors.length === 0) {
+    authorString = `"${cff.title}"`;
+  } else if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length === 2) {
     authorString = `${authors[0]}, and ${authors[1]}`;
@@ -322,7 +330,9 @@ export function cffToMLA(cff: CFF): string {
   const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
   const doi = cff.doi ? ` doi:${cff.doi}` : '';
 
-  return `${authorString}. "${cff.title}." DANDI Archive, ${year}.${doi}`;
+  const title = authors.length === 0 ? '' : ` "${cff.title}."`;
+
+  return `${authorString}.${title} DANDI Archive, ${year}.${doi}`;
 }
 
 /**
@@ -343,7 +353,9 @@ export function cffToChicago(cff: CFF): string {
   });
 
   let authorString = '';
-  if (authors.length === 1) {
+  if (authors.length === 0) {
+    authorString = cff.title;
+  } else if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length <= 3) {
     authorString = authors.slice(0, -1).join(', ') + ', and ' + authors[authors.length - 1];
@@ -355,7 +367,9 @@ export function cffToChicago(cff: CFF): string {
   const version = cff.version ? `, version ${cff.version}` : '';
   const doi = cff.doi ? ` https://doi.org/${cff.doi}` : '';
 
-  return `${authorString}. ${year}. "${cff.title}." Data set${version}. DANDI Archive.${doi}`;
+  const title = authors.length === 0 ? '' : ` "${cff.title}."`;
+
+  return `${authorString}. ${year}.${title} Data set${version}. DANDI Archive.${doi}`;
 }
 
 /**
@@ -376,7 +390,9 @@ export function cffToHarvard(cff: CFF): string {
   });
 
   let authorString = '';
-  if (authors.length === 1) {
+  if (authors.length === 0) {
+    authorString = cff.title;
+  } else if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length === 2) {
     authorString = `${authors[0]} and ${authors[1]}`;
@@ -389,7 +405,9 @@ export function cffToHarvard(cff: CFF): string {
   const year = cff['date-released'] ? cff['date-released'].split('-')[0] : 'n.d.';
   const doi = cff.doi ? ` Available at: https://doi.org/${cff.doi}` : '';
 
-  return `${authorString} (${year}) '${cff.title}', DANDI Archive. Data set.${doi}`;
+  const title = authors.length === 0 ? '' : ` '${cff.title}',`;
+
+  return `${authorString} (${year})${title} DANDI Archive. Data set.${doi}`;
 }
 
 /**
@@ -411,7 +429,9 @@ export function cffToVancouver(cff: CFF): string {
 
   // Vancouver limits to 6 authors, then "et al."
   let authorString = '';
-  if (authors.length <= 6) {
+  if (authors.length === 0) {
+    authorString = cff.title;
+  } else if (authors.length <= 6) {
     authorString = authors.join(', ');
   } else {
     authorString = authors.slice(0, 6).join(', ') + ', et al';
@@ -420,7 +440,9 @@ export function cffToVancouver(cff: CFF): string {
   const year = cff['date-released'] ? cff['date-released'].split('-')[0] : '';
   const doi = cff.doi ? ` doi: ${cff.doi}` : '';
 
-  return `${authorString}. ${cff.title} [Data set]. DANDI Archive; ${year}.${doi}`;
+  const title = authors.length === 0 ? '' : ` ${cff.title}`;
+
+  return `${authorString}.${title} [Data set]. DANDI Archive; ${year}.${doi}`;
 }
 
 /**
@@ -441,7 +463,9 @@ export function cffToIEEE(cff: CFF): string {
   });
 
   let authorString = '';
-  if (authors.length === 1) {
+  if (authors.length === 0) {
+    authorString = `"${cff.title}"`;
+  } else if (authors.length === 1) {
     authorString = authors[0];
   } else if (authors.length === 2) {
     authorString = `${authors[0]} and ${authors[1]}`;
@@ -452,7 +476,9 @@ export function cffToIEEE(cff: CFF): string {
   const year = cff['date-released'] ? cff['date-released'].split('-')[0] : '';
   const doi = cff.doi ? ` doi: ${cff.doi}` : '';
 
-  return `${authorString}, "${cff.title}," DANDI Archive, ${year}.${doi}`;
+  const title = authors.length === 0 ? '' : `, "${cff.title},"`;
+
+  return `${authorString}${title} DANDI Archive, ${year}.${doi}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #2793 by making the frontend CFF/citation conversion include only contributors explicitly marked with `includeInCitation: true`.

The backend citation path and the landing-page overview already use that stricter behavior, but the frontend citation formatter treated missing `includeInCitation` values as included. That allowed non-author contributors such as funders to appear in formatted citations.

This also handles no-author citation formatting more gracefully across exported citation formats so empty author lists do not produce malformed punctuation or empty BibTeX author fields.

## Checks

- `npm run type-check`
- `npx eslint src/utils/cff.ts --max-warnings=0`
- One-off formatter check against the reported Dandiset metadata shape confirmed `National Institutes of Health (NIH)` is excluded

`npm run build` was attempted, but local Vite startup hit `EMFILE: too many open files, watch` before code compilation.