### PR TITLE
Display total data size on the homepage with one decimal place

### DIFF
--- a/web/src/views/HomeView/StatsBar.vue
+++ b/web/src/views/HomeView/StatsBar.vue
@@ -44,7 +44,7 @@ const stats = computed(() => [
     href: '/dandiset',
   },
   { name: 'users', value: users.value },
-  { name: 'total data size', value: filesize(size.value, { round: 0, base: 10, standard: 'si' }) },
+  { name: 'total data size', value: filesize(size.value, { round: 1, base: 10, standard: 'si' }) },
 ]);
 
 // equivalent of async created method in options API


### PR DESCRIPTION
Proposing this change because right now it shows 1 PB and we would only see this number change when it gets to 2 PB.