### PR TITLE
Fix native Celery instructions for RabbitMQ 4.3

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,7 +82,7 @@ but allows developers to run Python code on their native system.
 1. Run the Celery app
     1. Start a new terminal
     1. Run `export UV_ENV_FILE=./dev/.env.docker-compose-native`
-    1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip -Q celery,calculate_sha256,ingest_zarr_archive,manifest-worker -B`
+    1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip --queues celery,calculate_sha256,ingest_zarr_archive,manifest-worker --beat`
 1. When finished, run `docker compose stop`
 
 ## Testing

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,7 +82,7 @@ but allows developers to run Python code on their native system.
 1. Run the Celery app
     1. Start a new terminal
     1. Run `export UV_ENV_FILE=./dev/.env.docker-compose-native`
-    1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat -Q celery,calculate_sha256,ingest_zarr_archive,manifest-worker -B`
+    1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip -Q celery,calculate_sha256,ingest_zarr_archive,manifest-worker -B`
 1. When finished, run `docker compose stop`
 
 ## Testing


### PR DESCRIPTION
## Summary

- Commit c10a585c ("Fix incompatibility with RabbitMQ 4.3") updated the Celery worker invocation in the Dev Containers section of `DEVELOPMENT.md`, in `docker-compose.override.yml`, and in `Procfile`, but missed the matching command in the **Develop Natively (advanced)** section. As a result, following those instructions against RabbitMQ 4.3 produces a continuous restart loop with `amqp.exceptions.InternalError: Queue.declare: (541) INTERNAL_ERROR - Feature 'transient_nonexcl_queues' is deprecated.`, because mingle and gossip still try to declare non-exclusive, non-durable `pidbox` / `celeryev` queues.
- First commit adds the missing `--without-mingle` and `--without-gossip` flags so the native workflow works against RabbitMQ 4.3 again.
- Second commit (separate, for reviewability) aligns the option syntax with the Dev Containers section and `docker-compose.override.yml` — `--queues` instead of `-Q`, `--beat` instead of `-B` — so all three invocations read identically.

## Test plan

- [x] Reproduced the original failure by following the "Develop Natively" instructions verbatim against RabbitMQ 4.3.
- [x] Verified the updated command starts the worker successfully against the same RabbitMQ 4.3 container (worker logs `Connected to amqp://...` and `celery@<host> ready.` with no queue-declare rejection).
