### PR TITLE
Fix "This Version" header style on DLP

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetUnembargo.vue
+++ b/web/src/views/DandisetLandingView/DandisetUnembargo.vue
@@ -168,11 +168,9 @@
       :is-owner="true"
     />
 
-    <v-row>
-      <v-list-subheader class="mb-2 text-black text-h5">
-        This Version
-      </v-list-subheader>
-    </v-row>
+    <v-card-title class="px-0">
+      This Version
+    </v-card-title>
     <v-row
       class="pa-2 mb-5 text-body-2 align-center"
       style="border-top: thin solid rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
## Summary
- The "This Version" header in the Unembargo card on the Dandiset Landing Page was using a `v-list-subheader` wrapped in a `v-row`, which produced the wrong font/size and misaligned spacing relative to the neighboring "Owners" and "Dandiset Actions" cards.
- Replaced it with a `v-card-title` (with `px-0` to respect the parent card's existing horizontal padding) so it matches the heading style used elsewhere in the sidebar.

## Test plan
- [x] On an embargoed dandiset's landing page, confirm the "This Version" heading visually matches "Owners" and "Dandiset Actions" (font, size, alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)