### PR TITLE
Update stats bar to show the total number of Dandisets that are not empty and unembargoed

### DIFF
--- a/web/src/views/HomeView/StatsBar.vue
+++ b/web/src/views/HomeView/StatsBar.vue
@@ -49,8 +49,11 @@ const stats = computed(() => [
 
 // equivalent of async created method in options API
 dandiRest.stats().then((data) => {
-  dandisets.value = data.dandiset_count;
   users.value = data.user_count;
   size.value = data.size;
+});
+
+dandiRest.dandisets({ page_size: 1, empty: false }).then((response) => {
+  dandisets.value = response.data.count;
 });
 </script>


### PR DESCRIPTION
Since the search bar is right above the stats bar, it implies that a user can search across that total number of Dandisets.

<img width="1725" height="203" alt="image" src="https://github.com/user-attachments/assets/edfbed95-5f1d-40c2-ad05-8c585c047e0b" />

So here I propose only showing the total number of non-empty, unembargoed Dandisets in the stats bar.