### PR TITLE
Wider, responsive advanced-search help popover (closes #2818)

### DIFF
--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -35,8 +35,7 @@
             </v-icon>
           </template>
           <v-card
-            max-width="420"
-            class="pa-3"
+            class="pa-3 advanced-search-help"
           >
             <div class="text-subtitle-2 mb-2">
               Advanced search operators
@@ -51,7 +50,9 @@
                   v-for="op in operatorHelp"
                   :key="op.example"
                 >
-                  <td><code>{{ op.example }}</code></td>
+                  <td class="example-cell">
+                    <code>{{ op.example }}</code>
+                  </td>
                   <td class="text-caption">
                     {{ op.description }}
                   </td>
@@ -125,3 +126,16 @@ function performSearch(evt: Event) {
   }
 }
 </script>
+
+<style scoped>
+.advanced-search-help {
+  /* Sized responsively: wide enough for the longest example without wrapping,
+   * but capped so it doesn't fill very wide monitors. */
+  min-width: 420px;
+  max-width: min(80vw, 720px);
+}
+.advanced-search-help .example-cell {
+  /* Keep operator examples on a single line so they read like code. */
+  white-space: nowrap;
+}
+</style>


### PR DESCRIPTION
Closes #2818. Stacked on top of #2814 — until that merges, this PR's diff includes the parent's changes; afterward GitHub will rebase and show only the popover diff.

> **Prior conversation:** this PR was originally opened against the parent branch on the fork at [bendichter/dandi-archive#2](https://github.com/bendichter/dandi-archive/pull/2) (now closed) — see that thread for context.

The popover was hard-capped at `max-width: 420px`, which forced the description column to wrap awkwardly even when there was plenty of viewport room (per yarikoptic's screenshot in #2818).

## Change

Replace the fixed cap with responsive sizing:

```css
min-width: 420px;
max-width: min(80vw, 720px);
```

- `min-width: 420px` keeps the popover from collapsing on a single short example.
- `max-width: 80vw` lets it grow with the window — up to 80% of viewport, as requested in #2818.
- `max-width: 720px` caps the absolute width on very wide monitors so the popover doesn't sprawl.

Also pinned the operator-example column with `white-space: nowrap` so strings like `created_after:2024-01-01` and `technique:"patch clamp"` stay readable as code instead of wrapping mid-token.

## Test plan

- [x] `npm run lint -- src/components/DandisetSearchField.vue` passes
- [x] Manually opened the popover at narrow (~500px) and wide (~2000px) viewports — fits content cleanly at both, no horizontal scroll, examples don't wrap.
