### PR TITLE
Display embargoedUntil date on the dandiset landing page

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -166,6 +166,9 @@
               :key="i"
             >
               <strong>{{ item.status }}</strong>
+              <span v-if="item.embargoedUntil">
+                (embargoed until <strong>{{ formatDate(item.embargoedUntil) }}</strong>)
+              </span>
               <span v-text="accessInformation && i === accessInformation.length - 1 ? '' : ', '" />
             </span>
           </span>


### PR DESCRIPTION
## Summary

Embargoed dandisets carry an `embargoedUntil` date in their metadata, but it was not surfaced anywhere on the landing page — a viewer (including the dandiset's own owners) could only find it by querying the API directly.

This adds the embargo end date to the **Access Information** section of the landing page, alongside the existing access status:

> Access Information: **dandi:EmbargoedAccess** (embargoed until **January 9, 2028**)

## Changes

- `web/src/views/DandisetLandingView/DandisetMain.vue` — render `embargoedUntil` next to each access requirement's status.

## Notes

- **Permission-gated automatically** — `accessInformation` is derived from `meta.access`, and dandiset metadata only loads for viewers permitted to see an embargoed dandiset, so no extra gating is needed.
- **Missing/null `embargoedUntil`** — the new markup is wrapped in `v-if="item.embargoedUntil"`, so it falls back cleanly to just the status label.
- **Formatting/localization** — reuses the existing `formatDate()` helper (`moment(date).format('LL')`), producing a locale-aware human-readable date, consistent with the "Created" / "Last update" dates on the same page.

Closes #2832

🤖 Generated with [Claude Code](https://claude.com/claude-code)