### PR TITLE
fix: dedupe dandiset owners on PUT /users/ (closes #2831)

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -4,6 +4,7 @@ import datetime
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
+from allauth.socialaccount.models import SocialAccount
 from dandischema.conf import get_instance_config
 from dandischema.consts import DANDI_SCHEMA_VERSION
 from django.conf import settings
@@ -1267,6 +1268,109 @@ def test_dandiset_rest_add_owner_does_not_exist(api_client):
     resp = api_client.put(f'/api/dandisets/{dandiset.identifier}/users/', [{'username': fake_name}])
     assert resp.status_code == 400
     assert resp.data == [f'User {fake_name} not found']
+
+
+@pytest.mark.django_db
+def test_dandiset_rest_add_owner_username_collides_with_other_user_login(api_client):
+    """
+    Regression test for #2831.
+
+    Two distinct Django User rows can share a string `"yarikoptic"`: one as the social
+    account login (the canonical username clients see), the other as the Django
+    User.username (typically an email, but possibly a legacy account whose username
+    happens to be the same as another user's GitHub login). PUT /users/ must resolve
+    the requested username to exactly one User -- the one with the matching social
+    account.
+    """
+    shared_name = 'yarikoptic'
+    # The "real" GitHub-linked user that should win.
+    real_user = UserFactory.create(social_account__extra_data__login=shared_name)
+    # A legacy user whose Django username happens to equal `shared_name`.
+    UserFactory.create(username=shared_name, email=f'{shared_name}@example.com')
+
+    requesting_user = UserFactory.create()
+    dandiset = DandisetFactory.create(owners=[requesting_user])
+    api_client.force_authenticate(user=requesting_user)
+
+    resp = api_client.put(
+        f'/api/dandisets/{dandiset.identifier}/users/',
+        [
+            {'username': requesting_user.socialaccount_set.get().extra_data['login']},
+            {'username': shared_name},
+        ],
+    )
+
+    assert resp.status_code == 200
+    assert [o['username'] for o in resp.data] == [
+        requesting_user.socialaccount_set.get().extra_data['login'],
+        shared_name,
+    ]
+    assert list(get_dandiset_owners(dandiset)) == [requesting_user, real_user]
+
+
+@pytest.mark.django_db
+def test_dandiset_rest_add_owner_login_shared_by_two_social_accounts(api_client):
+    """
+    Regression test for #2831.
+
+    If two SocialAccount rows happen to share the same `extra_data['login']`
+    (e.g. someone renamed their GitHub username and the freed handle was taken
+    by another user), the PUT must still grant ownership to exactly one User.
+    """
+    shared_login = 'yarikoptic'
+    older_user = UserFactory.create(social_account__extra_data__login=shared_login)
+    newer_user = UserFactory.create()
+    # Force-rename newer_user's social-account login so we have two rows sharing it.
+    sa = newer_user.socialaccount_set.get()
+    sa.extra_data['login'] = shared_login
+    sa.save()
+    # Make `newer_user` the most recently active so it wins the deterministic ordering.
+    newer_user.last_login = timezone.now()
+    newer_user.save()
+
+    assert SocialAccount.objects.filter(extra_data__login=shared_login).count() == 2
+
+    requesting_user = UserFactory.create()
+    dandiset = DandisetFactory.create(owners=[requesting_user])
+    api_client.force_authenticate(user=requesting_user)
+
+    resp = api_client.put(
+        f'/api/dandisets/{dandiset.identifier}/users/',
+        [
+            {'username': requesting_user.socialaccount_set.get().extra_data['login']},
+            {'username': shared_login},
+        ],
+    )
+
+    assert resp.status_code == 200
+    assert [o['username'] for o in resp.data].count(shared_login) == 1
+    owners = list(get_dandiset_owners(dandiset))
+    assert len(owners) == 2
+    assert newer_user in owners
+    assert older_user not in owners
+
+
+@pytest.mark.django_db
+def test_dandiset_rest_add_owner_duplicate_usernames_in_payload(api_client):
+    """The same username repeated in the PUT body should yield one ownership, not two."""
+    user1 = UserFactory.create()
+    user2 = UserFactory.create()
+    dandiset = DandisetFactory.create(owners=[user1])
+    api_client.force_authenticate(user=user1)
+
+    login1 = user1.socialaccount_set.get().extra_data['login']
+    login2 = user2.socialaccount_set.get().extra_data['login']
+
+    resp = api_client.put(
+        f'/api/dandisets/{dandiset.identifier}/users/',
+        [{'username': login1}, {'username': login2}, {'username': login2}],
+    )
+
+    assert resp.status_code == 200
+    assert sorted(o['username'] for o in resp.data) == sorted([login1, login2])
+    assert sorted(get_dandiset_owners(dandiset), key=lambda u: u.pk) == sorted(
+        [user1, user2], key=lambda u: u.pk
+    )
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -1301,11 +1301,13 @@ def test_dandiset_rest_add_owner_username_collides_with_other_user_login(api_cli
     )
 
     assert resp.status_code == 200
-    assert [o['username'] for o in resp.data] == [
+    # Response order follows `get_dandiset_owners`' date_joined ordering, which is
+    # not the input order; compare as a set.
+    assert {o['username'] for o in resp.data} == {
         requesting_user.socialaccount_set.get().extra_data['login'],
         shared_name,
-    ]
-    assert list(get_dandiset_owners(dandiset)) == [requesting_user, real_user]
+    }
+    assert set(get_dandiset_owners(dandiset)) == {requesting_user, real_user}
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -1289,7 +1289,7 @@ def test_dandiset_rest_add_owner_username_collides_with_other_user_login(api_cli
     UserFactory.create(username=shared_name, email=f'{shared_name}@example.com')
 
     requesting_user = UserFactory.create()
-    dandiset = DandisetFactory.create(owners=[requesting_user])
+    dandiset = DraftVersionFactory.create(dandiset__owners=[requesting_user]).dandiset
     api_client.force_authenticate(user=requesting_user)
 
     resp = api_client.put(
@@ -1331,7 +1331,7 @@ def test_dandiset_rest_add_owner_login_shared_by_two_social_accounts(api_client)
     assert SocialAccount.objects.filter(extra_data__login=shared_login).count() == 2
 
     requesting_user = UserFactory.create()
-    dandiset = DandisetFactory.create(owners=[requesting_user])
+    dandiset = DraftVersionFactory.create(dandiset__owners=[requesting_user]).dandiset
     api_client.force_authenticate(user=requesting_user)
 
     resp = api_client.put(
@@ -1355,7 +1355,7 @@ def test_dandiset_rest_add_owner_duplicate_usernames_in_payload(api_client):
     """The same username repeated in the PUT body should yield one ownership, not two."""
     user1 = UserFactory.create()
     user2 = UserFactory.create()
-    dandiset = DandisetFactory.create(owners=[user1])
+    dandiset = DraftVersionFactory.create(dandiset__owners=[user1]).dandiset
     api_client.force_authenticate(user=user1)
 
     login1 = user1.socialaccount_set.get().extra_data['login']

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -531,7 +531,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
     )
     # TODO: move these into a viewset
     @action(methods=['GET', 'PUT'], detail=True)
-    def users(self, request, dandiset__pk):  # noqa: C901
+    def users(self, request, dandiset__pk):
         dandiset: Dandiset = self.get_object()
         if request.method == 'PUT':
             if dandiset.unembargo_in_progress:
@@ -548,29 +548,36 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             if not serializer.validated_data:
                 raise ValidationError('Cannot remove all draft owners')
 
-            # Get all owners that have the provided username in one of the two possible locations
+            # Resolve each requested username to at most one User. SocialAccount.extra_data['login']
+            # is the canonical identifier we expose to clients, so it wins over Django
+            # User.username (which is the user's email). Order_by makes the choice
+            # deterministic if multiple SocialAccount rows share a login (e.g. someone
+            # reused a freed GitHub username) -- pick the user with the most recent activity.
             usernames = [owner['username'] for owner in serializer.validated_data]
-            user_owners = list(User.objects.filter(username__in=usernames))
-            socialaccount_owners = list(
-                SocialAccount.objects.select_related('user').filter(extra_data__login__in=usernames)
-            )
+            social_by_login: dict[str, User] = {
+                acc.extra_data['login']: acc.user
+                for acc in SocialAccount.objects.select_related('user')
+                .filter(extra_data__login__in=usernames)
+                .order_by('-user__last_login', '-user__date_joined')
+            }
+            fallback_by_username: dict[str, User] = {
+                u.username: u for u in User.objects.filter(username__in=usernames)
+            }
 
-            # Check that all owners were found
-            if len(user_owners) + len(socialaccount_owners) < len(usernames):
-                username_set = {
-                    *(user.username for user in user_owners),
-                    *(owner.extra_data['login'] for owner in socialaccount_owners),
-                }
+            resolved: dict[str, User] = {}
+            for username in usernames:
+                user = social_by_login.get(username) or fallback_by_username.get(username)
+                if user is None:
+                    raise ValidationError(f'User {username} not found')
+                resolved[username] = user
 
-                # Raise exception on first username in list that's not found
-                for username in usernames:
-                    if username not in username_set:
-                        raise ValidationError(f'User {username} not found')
+            # Deduplicate by User.pk in case two distinct input usernames happen to resolve
+            # to the same Django user (e.g. one matched a SocialAccount, another matched
+            # the user's email-as-username fallback).
+            owners = list({u.pk: u for u in resolved.values()}.values())
 
-            # All owners found
             with transaction.atomic():
                 dandiset_locked = Dandiset.objects.select_for_update().get(pk=dandiset__pk)
-                owners = user_owners + [acc.user for acc in socialaccount_owners]
                 removed_owners, added_owners = replace_dandiset_owners(dandiset_locked, owners)
                 dandiset_locked.save()
 
@@ -586,8 +593,10 @@ class DandisetViewSet(ReadOnlyModelViewSet):
 
         owners = []
         for owner_user in get_dandiset_owners(dandiset):
-            try:
-                owner_account = SocialAccount.objects.get(user=owner_user)
+            # A user can in principle have more than one SocialAccount; use the first
+            # rather than .get() so we don't raise MultipleObjectsReturned here.
+            owner_account = SocialAccount.objects.filter(user=owner_user).first()
+            if owner_account is not None:
                 owner_dict = {'username': owner_account.extra_data['login']}
                 owner_dict['name'] = owner_account.extra_data.get('name', None)
                 owner_dict['email'] = (
@@ -597,8 +606,8 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                     else None
                 )
                 owners.append(owner_dict)
-            except SocialAccount.DoesNotExist:
-                # Just in case some users aren't using social accounts, have a fallback
+            else:
+                # Fallback for users without a social account
                 owners.append(
                     {
                         'username': owner_user.username,

--- a/web/src/components/DLP/DandisetOwnersDialog.vue
+++ b/web/src/components/DLP/DandisetOwnersDialog.vue
@@ -264,9 +264,19 @@ const throttledUpdate = debounce(async () => {
   _searchResults.value = users;
 }, 200);
 
-watch(() => store.owners, () => (
-  store.owners ? Object.assign(newOwners.value, store.owners) : null
-),
+// Re-sync `newOwners` from the store. Use a fresh copy (not Object.assign onto
+// the existing array) so that shrinking lists drop trailing entries and so
+// that duplicate-looking owners from the backend don't accumulate locally.
+watch(() => store.owners, () => {
+  if (store.owners) {
+    const seen = new Set<string>();
+    newOwners.value = (store.owners as User[]).filter((u) => {
+      if (seen.has(u.username)) return false;
+      seen.add(u.username);
+      return true;
+    });
+  }
+},
 { immediate: true });
 
 const isSelected = (user: User) => selectedUsers.value.map(
@@ -321,7 +331,13 @@ function checkBoxHandler(_user: User) {
 }
 
 function addSelected() {
-  newOwners.value = newOwners.value.concat(selectedUsers.value);
+  const existing = new Set(newOwners.value.map((u: User) => u.username));
+  for (const u of selectedUsers.value) {
+    if (!existing.has(u.username)) {
+      newOwners.value.push(u);
+      existing.add(u.username);
+    }
+  }
   selectedUsers.value = [];
 }
 


### PR DESCRIPTION
Closes #2831.

> [!IMPORTANT]
> After this lands, an admin still needs to remove the duplicate owner row on dandiset 001849 — the backend can't tell which Yaroslav `User` is the "real" one. A one-off `find_duplicate_owners` audit (see Test plan) would help find any other dandisets that hit the same bug before the fix.

## Summary

`PUT /api/dandisets/{id}/users/` was resolving each requested username through two parallel queries (`User.username` AND `SocialAccount.extra_data['login']`) and concatenating the results without deduplication. When a single input string matched both — or matched multiple `SocialAccount` rows sharing a login — multiple distinct `User` rows were granted the `owner` permission for what the user typed once. In #2831 this surfaced as the same GitHub user appearing twice in the owners list of dandiset 001849 right after a "Manage Owners" save.

The regression was introduced in #1737 (commit 7eff07bcc, 2023-11), which replaced a precedence-aware `get_user_or_400(username)` helper with bulk `User.objects.filter` + `SocialAccount.objects.filter` queries to cut N+1s — but lost the "exactly one user per username, SocialAccount wins" invariant.

This PR restores that invariant on the backend, hardens the GET path against multiple social accounts per user, and adds defensive dedup in the Manage Owners dialog so this kind of state can't compound client-side.

## Commits

- 8ff0f5045 `fix(api): resolve each PUT /users/ username to at most one User (#2831)`
- ae3809983 `fix(web): defensively dedup owners in Manage Owners dialog (#2831)`

<details><summary>Per-commit details</summary>

### 8ff0f5045 `fix(api): resolve each PUT /users/ username to at most one User (#2831)`

`dandiapi/api/views/dandiset.py`:

- PUT path: build `social_by_login` (ordered by `-user__last_login, -user__date_joined` so the choice is deterministic when two SocialAccount rows share a login — pick the user with the most recent activity) and `fallback_by_username` (Django `User.username`, which is the user's email in this app). For each requested username, prefer the SocialAccount match; fall back to Django username; raise `ValidationError("User X not found")` if neither matches. Finally dedup the resolved list by `User.pk` so two distinct input strings that resolve to the same `User` don't double-up.
- GET path: replaced `SocialAccount.objects.get(user=...)` with `.filter(...).first()` so a user with more than one social account doesn't 500 with `MultipleObjectsReturned`.

`dandiapi/api/tests/test_dandiset.py` — three regression tests:

- `test_dandiset_rest_add_owner_username_collides_with_other_user_login` — a legacy `User` whose `username` happens to equal another user's GitHub login does not double-grant.
- `test_dandiset_rest_add_owner_login_shared_by_two_social_accounts` — two `SocialAccount` rows sharing `extra_data['login']` resolve deterministically to the most-recently-active user, not both.
- `test_dandiset_rest_add_owner_duplicate_usernames_in_payload` — the same username repeated in the PUT body yields one ownership.

### ae3809983 `fix(web): defensively dedup owners in Manage Owners dialog (#2831)`

`web/src/components/DLP/DandisetOwnersDialog.vue`:

- Replace `Object.assign(newOwners.value, store.owners)` with a fresh, by-username-deduped copy. The previous form did not reset `length`, so a shrinking `store.owners` would leave stale trailing entries in `newOwners`, and duplicate-looking entries from the backend would render as separate cards.
- `addSelected()` now skips users already present in `newOwners` (the previous `.concat()` happily appended duplicates).

The backend fix already prevents the duplicate-owner scenario on writes; the frontend changes are defense-in-depth for pre-existing duplicate state and future regressions.

</details>

## Test plan

- [ ] Run `tox -e test -- dandiapi/api/tests/test_dandiset.py -k "owner"` in CI ~~/ locally~~(since requires manual startup/setup...) — the three new tests should pass and the existing owner tests should not regress. (The dev sandbox where this branch was prepared didn't have the docker-compose stack; only `ruff check` + `ruff format --check` were run.)
- [ ] Manually verify in the web UI on a dandiset where you're an owner: open "Manage Owners", add another user, Save, reopen — the dialog should show each owner exactly once.
- [ ] Manual data cleanup after merge: in Django admin, remove the extra Yaroslav grant on dandiset 001849 (the API fix prevents recurrence but can't tell which `User` row is the "real" one).
- [ ] (Optional follow-up) A small `find_duplicate_owners` management command listing `(dandiset_id, username, [user_pks])` would help find other dandisets affected before the fix.
