### PR TITLE
Make `Related resource` titles clickable links on Dandiset landing page

### DIFF
--- a/web/src/components/DLP/MetadataCard.vue
+++ b/web/src/components/DLP/MetadataCard.vue
@@ -35,10 +35,15 @@
                 cols="9"
                 class="text-grey-darken-3"
               >
-                <span v-if="item.name || item.identifier || item.id">
-                  {{ item.name || item.identifier || item.id }}
-                  <br>
-                </span>
+                <slot
+                  name="itemTitle"
+                  :item="item"
+                >
+                  <span v-if="item.name || item.identifier || item.id">
+                    {{ item.name || item.identifier || item.id }}
+                    <br>
+                  </span>
+                </slot>
                 <slot
                   name="content"
                   :item="item"

--- a/web/src/components/DLP/OverviewTab.vue
+++ b/web/src/components/DLP/OverviewTab.vue
@@ -92,6 +92,7 @@
         <span v-if="slotProps.item.name || slotProps.item.identifier || slotProps.item.id">
           <a
             v-if="slotProps.item.url"
+            class="related-resource-link"
             :href="slotProps.item.url"
             target="_blank"
             rel="noopener"
@@ -366,3 +367,19 @@ onUnmounted(() => {
 });
 
 </script>
+
+<style scoped>
+/* Match the link styling used in https://docs.dandiarchive.org/ (Material for
+ * MkDocs): colored, no underline, with a smooth transition to a lighter blue on
+ * hover/focus — rather than the default underlined browser link. */
+.related-resource-link {
+  color: #4051b5;
+  text-decoration: none;
+  transition: color 125ms;
+}
+
+.related-resource-link:hover,
+.related-resource-link:focus {
+  color: #0091eb;
+}
+</style>

--- a/web/src/components/DLP/OverviewTab.vue
+++ b/web/src/components/DLP/OverviewTab.vue
@@ -88,6 +88,22 @@
       name="Related resources"
       icon="mdi-book"
     >
+      <template #itemTitle="slotProps">
+        <span v-if="slotProps.item.name || slotProps.item.identifier || slotProps.item.id">
+          <a
+            v-if="slotProps.item.url"
+            :href="slotProps.item.url"
+            target="_blank"
+            rel="noopener"
+          >
+            {{ slotProps.item.name || slotProps.item.identifier || slotProps.item.id }}
+          </a>
+          <template v-else>
+            {{ slotProps.item.name || slotProps.item.identifier || slotProps.item.id }}
+          </template>
+          <br>
+        </span>
+      </template>
       <template #content="slotProps">
         <span
           v-if="slotProps.item.identifier"
@@ -116,18 +132,6 @@
         >
           <strong>Relation: </strong>{{ slotProps.item.relation }}
         </span>
-      </template>
-      <template #links="slotProps">
-        <v-btn
-          v-if="slotProps.item.url"
-          icon
-          variant="text"
-          :href="slotProps.item.url"
-          target="_blank"
-          rel="noopener"
-        >
-          <v-icon>mdi-link</v-icon>
-        </v-btn>
       </template>
     </MetadataCard>
 


### PR DESCRIPTION
## Context

I have been on calls where users who were navigating the DLP didn't see the link icon that is off to the right of the resource.

<img width="1544" height="235" alt="image" src="https://github.com/user-attachments/assets/4d06d3c5-bbdf-418a-8091-4178386b5329" />

## Changes

Here I propose making the related resource titles clickable links that open in a new tab and removing the link icon.

cc @satra @ayendiki