### PR TITLE
Fix search within "My Dandisets" to include owned/embargoed dandisets

### DIFF
--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -108,14 +108,9 @@ function performSearch(evt: Event) {
     // nothing has changed, do nothing
     return;
   }
-  if (route.name !== 'searchDandisets') {
-    router.push({
-      name: 'searchDandisets',
-      query: {
-        search: currentSearch.value,
-      },
-    });
-  } else {
+  if (route.name === 'searchDandisets' || route.name === 'myDandisets') {
+    // Stay on the current page so the search keeps its context. On "My Dandisets"
+    // this scopes the search to the user's own dandisets (including embargoed).
     router.replace({
       ...route,
       query: {
@@ -123,6 +118,13 @@ function performSearch(evt: Event) {
         search: currentSearch.value,
       },
     } as RouteLocationRaw);
+  } else {
+    router.push({
+      name: 'searchDandisets',
+      query: {
+        search: currentSearch.value,
+      },
+    });
   }
 }
 </script>

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -142,7 +142,7 @@
       </v-btn>
     </v-toolbar>
     <v-alert
-      v-if="props.search && searchError"
+      v-if="searchActive && searchError"
       type="error"
       variant="tonal"
       class="mx-4 mx-md-8 mt-4"
@@ -151,7 +151,7 @@
       {{ searchError }}
     </v-alert>
     <div
-      v-else-if="props.search && djangoDandisetRequest"
+      v-else-if="searchActive && djangoDandisetRequest"
       class="mx-4 mx-md-8 mt-4 text-h6"
     >
       {{ djangoDandisetRequest.count }} {{ djangoDandisetRequest.count === 1 ? 'result' : 'results' }} found
@@ -232,6 +232,9 @@ const sortDir = ref(Number(route.query.sortDir || -1));
 const page = ref(Number(route.query.page) || 1);
 
 const pageTitle = computed(() => ((props.search) ? route.query.search as string : props.title));
+// A search is active either on the dedicated search page, or whenever a search
+// query is present on another listing page (e.g. "My Dandisets").
+const searchActive = computed(() => props.search || !!route.query.search);
 const sortField = computed(() => sortingOptions[sortOption.value].djangoField);
 
 // Django dandiset listing
@@ -246,7 +249,7 @@ watchEffect(async () => {
       page_size: DANDISETS_PER_PAGE,
       ordering,
       user: props.user ? 'me' : null,
-      search: props.search ? route.query.search : null,
+      search: searchActive.value ? route.query.search : null,
       starred: props.starred ? true : null,
       draft: props.user ? true : showDrafts.value,
       empty: props.user ? true : showEmpty.value,

--- a/web/src/views/MyDandisetsView/MyDandisetsView.vue
+++ b/web/src/views/MyDandisetsView/MyDandisetsView.vue
@@ -4,7 +4,10 @@
     user
   >
     <template #no-content>
-      <div>
+      <div v-if="route.query.search">
+        No results found in your dandisets.
+      </div>
+      <div v-else>
         You haven't created any dandisets yet
       </div>
     </template>
@@ -12,5 +15,8 @@
 </template>
 
 <script setup lang="ts">
+import { useRoute } from 'vue-router';
 import DandisetsPage from '@/components/DandisetsPage.vue';
+
+const route = useRoute();
 </script>


### PR DESCRIPTION
## Summary

Fixes #2834.

Searching from the **My Dandisets** page silently fell through to the public search route, so results only ever showed public dandisets — the user's embargoed dandisets were omitted, and there was no way to search across them.

The backend already supports `user=me` + `search` + `embargoed=true` together (the dandiset `list` action runs `get_queryset()`, honoring `user=me`/`embargoed`, then applies the search filter). The bug was entirely in the frontend.

## Changes

- **`DandisetSearchField.vue`** — `performSearch` now stays on the current route for the `myDandisets` page (previously only `searchDandisets`), instead of pushing to the public search route. This keeps the search scoped to the user's own dandisets.
- **`DandisetsPage.vue`** — added a `searchActive` computed (`props.search || !!route.query.search`). The `search` param is now sent whenever a search is active, not only on the dedicated public search view. Combined with the existing `user: 'me'` and `embargoed: true` params on this page, search now spans owned + embargoed dandisets. The "N results found" header and inline search-error alert use the same flag.
- **`MyDandisetsView.vue`** — empty state now shows "No results found in your dandisets." during a search, instead of the misleading "You haven't created any dandisets yet."

## Testing

`yarn lint` and `yarn type-check` pass for the changed files. Opening as a **draft** to test signed-in behavior on the deploy preview, since signing in locally is difficult.

To verify:
1. Sign in, go to **My Dandisets**.
2. Search for a term that matches an embargoed dandiset you own.
3. Confirm the URL stays on `/dandiset/my?search=...`, the embargoed dandiset appears, and the result count is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)