### PR TITLE
Remove `standard:` search operator

### DIFF
--- a/dandiapi/api/services/search/filters.py
+++ b/dandiapi/api/services/search/filters.py
@@ -60,34 +60,29 @@ def _annotate_latest_published_created(queryset):
 
 
 # Each entry maps an operator to a Postgres jsonpath that selects the names
-# we want to match against, within an asset's metadata. `[*]` wildcards mean
-# we match if ANY element of the array satisfies the predicate — important for
-# assets that list multiple species, approaches, etc. Paths MUST be trusted
-# constants: they're interpolated into the SQL.
+# we want to match against. `[*]` wildcards mean we match if ANY element of
+# the array satisfies the predicate — important for assets that list
+# multiple species, approaches, etc. Paths MUST be trusted constants:
+# they're interpolated into the SQL.
 _NAME_PATH_OPS = {
     'species': '$.wasAttributedTo[*].species.name',
     'approach': '$.approach[*].name',
     'technique': '$.measurementTechnique[*].name',
 }
 
-# The data standard is reported on the Version's `assetsSummary`, not on
-# individual assets, so it's matched against the Version metadata column rather
-# than the asset_search view.
-_STANDARD_PATH = '$.assetsSummary.dataStandard[*].name'
 
-
-def _jsonpath_name_match(column: str, path: str, value: str) -> tuple[str, list[str]]:
+def _jsonpath_name_match(path: str, value: str) -> tuple[str, list[str]]:
     """Build a parameterized Postgres `jsonb_path_exists` predicate.
 
     Matches `value` case-insensitively as a substring against any node
-    selected by `path` within `column`. Both `column` and `path` MUST come
-    from a trusted allowlist; `value` is parameterized and regex-escaped.
+    selected by `path`. `path` MUST come from a trusted allowlist; `value`
+    is parameterized and regex-escaped.
     """
-    # No table prefix on the column: Django may alias the table (e.g. inside a
-    # subquery), and qualifying the column would break those queries. The
-    # unqualified column is unambiguous in our usage.
+    # No table prefix on `asset_metadata`: Django may alias the AssetSearch
+    # table (e.g. inside a subquery), and qualifying the column would break
+    # those queries. The unqualified column is unambiguous in our usage.
     where = (
-        f'jsonb_path_exists({column}, '
+        'jsonb_path_exists(asset_metadata, '
         f"('{path} ? (@ like_regex ' "
         '|| to_jsonb(%s::text)::text || '
         '\' flag "i")\')::jsonpath)'
@@ -98,7 +93,7 @@ def _jsonpath_name_match(column: str, path: str, value: str) -> tuple[str, list[
 def _apply_asset_filter(queryset, operator: str, value: str):
     """Apply one parsed asset operator to an AssetSearch queryset."""
     if operator in _NAME_PATH_OPS:
-        where, params = _jsonpath_name_match('asset_metadata', _NAME_PATH_OPS[operator], value)
+        where, params = _jsonpath_name_match(_NAME_PATH_OPS[operator], value)
         # `where` interpolates only an allowlisted jsonpath; the user value
         # is bound via params (and re-escaped against regex injection).
         return queryset.extra(where=[where], params=params)  # noqa: S610
@@ -106,22 +101,6 @@ def _apply_asset_filter(queryset, operator: str, value: str):
         mime_prefix = _FILE_TYPE_ALIASES.get(value.lower(), value)
         return queryset.filter(asset_metadata__encodingFormat__istartswith=mime_prefix)
     raise ValueError(f'unknown asset operator: {operator}')  # pragma: no cover
-
-
-def _apply_standard_filter(queryset, value: str):
-    """Filter dandisets whose version assetsSummary lists a matching data standard.
-
-    Unlike the asset operators, `dataStandard` lives on the Version metadata
-    (`assetsSummary.dataStandard`), so we match against Versions and restrict the
-    dandiset queryset to those that have at least one matching version.
-    """
-    where, params = _jsonpath_name_match('metadata', _STANDARD_PATH, value)
-    matching_dandiset_ids = (
-        Version.objects.extra(where=[where], params=params)  # noqa: S610
-        .values_list('dandiset_id', flat=True)
-        .distinct()
-    )
-    return queryset.filter(id__in=matching_dandiset_ids)
 
 
 _MODIFIED_ALIAS = '_search_latest_version_modified'
@@ -190,8 +169,6 @@ def apply_search_filters(
                     f'Invalid date for "{key}": {value!r}. Use YYYY-MM-DD.'
                 ) from exc
             queryset = _apply_date_filter(queryset, key, ts, annotated)
-        elif key == 'standard':
-            queryset = _apply_standard_filter(queryset, value)
         elif key in _ASSET_OPS:
             if asset_qs is None:
                 asset_qs = AssetSearch.objects.visible_to(user)

--- a/dandiapi/api/services/search/filters.py
+++ b/dandiapi/api/services/search/filters.py
@@ -38,7 +38,7 @@ _DATE_OPS = frozenset(
         'published_after',
     }
 )
-_ASSET_OPS = frozenset({'species', 'approach', 'technique', 'standard', 'file_type'})
+_ASSET_OPS = frozenset({'species', 'approach', 'technique', 'file_type'})
 
 
 def _annotate_latest_version_modified(queryset):
@@ -60,30 +60,34 @@ def _annotate_latest_published_created(queryset):
 
 
 # Each entry maps an operator to a Postgres jsonpath that selects the names
-# we want to match against. `[*]` wildcards mean we match if ANY element of
-# the array satisfies the predicate — important for assets that list
-# multiple species, approaches, etc. Paths MUST be trusted constants:
-# they're interpolated into the SQL.
+# we want to match against, within an asset's metadata. `[*]` wildcards mean
+# we match if ANY element of the array satisfies the predicate — important for
+# assets that list multiple species, approaches, etc. Paths MUST be trusted
+# constants: they're interpolated into the SQL.
 _NAME_PATH_OPS = {
     'species': '$.wasAttributedTo[*].species.name',
     'approach': '$.approach[*].name',
     'technique': '$.measurementTechnique[*].name',
-    'standard': '$.dataStandard[*].name',
 }
 
+# The data standard is reported on the Version's `assetsSummary`, not on
+# individual assets, so it's matched against the Version metadata column rather
+# than the asset_search view.
+_STANDARD_PATH = '$.assetsSummary.dataStandard[*].name'
 
-def _jsonpath_name_match(path: str, value: str) -> tuple[str, list[str]]:
+
+def _jsonpath_name_match(column: str, path: str, value: str) -> tuple[str, list[str]]:
     """Build a parameterized Postgres `jsonb_path_exists` predicate.
 
     Matches `value` case-insensitively as a substring against any node
-    selected by `path`. `path` MUST come from a trusted allowlist; `value`
-    is parameterized and regex-escaped.
+    selected by `path` within `column`. Both `column` and `path` MUST come
+    from a trusted allowlist; `value` is parameterized and regex-escaped.
     """
-    # No table prefix on `asset_metadata`: Django may alias the AssetSearch
-    # table (e.g. inside a subquery), and qualifying the column would break
-    # those queries. The unqualified column is unambiguous in our usage.
+    # No table prefix on the column: Django may alias the table (e.g. inside a
+    # subquery), and qualifying the column would break those queries. The
+    # unqualified column is unambiguous in our usage.
     where = (
-        'jsonb_path_exists(asset_metadata, '
+        f'jsonb_path_exists({column}, '
         f"('{path} ? (@ like_regex ' "
         '|| to_jsonb(%s::text)::text || '
         '\' flag "i")\')::jsonpath)'
@@ -94,7 +98,7 @@ def _jsonpath_name_match(path: str, value: str) -> tuple[str, list[str]]:
 def _apply_asset_filter(queryset, operator: str, value: str):
     """Apply one parsed asset operator to an AssetSearch queryset."""
     if operator in _NAME_PATH_OPS:
-        where, params = _jsonpath_name_match(_NAME_PATH_OPS[operator], value)
+        where, params = _jsonpath_name_match('asset_metadata', _NAME_PATH_OPS[operator], value)
         # `where` interpolates only an allowlisted jsonpath; the user value
         # is bound via params (and re-escaped against regex injection).
         return queryset.extra(where=[where], params=params)  # noqa: S610
@@ -102,6 +106,22 @@ def _apply_asset_filter(queryset, operator: str, value: str):
         mime_prefix = _FILE_TYPE_ALIASES.get(value.lower(), value)
         return queryset.filter(asset_metadata__encodingFormat__istartswith=mime_prefix)
     raise ValueError(f'unknown asset operator: {operator}')  # pragma: no cover
+
+
+def _apply_standard_filter(queryset, value: str):
+    """Filter dandisets whose version assetsSummary lists a matching data standard.
+
+    Unlike the asset operators, `dataStandard` lives on the Version metadata
+    (`assetsSummary.dataStandard`), so we match against Versions and restrict the
+    dandiset queryset to those that have at least one matching version.
+    """
+    where, params = _jsonpath_name_match('metadata', _STANDARD_PATH, value)
+    matching_dandiset_ids = (
+        Version.objects.extra(where=[where], params=params)  # noqa: S610
+        .values_list('dandiset_id', flat=True)
+        .distinct()
+    )
+    return queryset.filter(id__in=matching_dandiset_ids)
 
 
 _MODIFIED_ALIAS = '_search_latest_version_modified'
@@ -170,6 +190,8 @@ def apply_search_filters(
                     f'Invalid date for "{key}": {value!r}. Use YYYY-MM-DD.'
                 ) from exc
             queryset = _apply_date_filter(queryset, key, ts, annotated)
+        elif key == 'standard':
+            queryset = _apply_standard_filter(queryset, value)
         elif key in _ASSET_OPS:
             if asset_qs is None:
                 asset_qs = AssetSearch.objects.visible_to(user)
@@ -178,7 +200,7 @@ def apply_search_filters(
     if asset_qs is not None:
         # NOTE perf: jsonb_path_exists with a runtime-built jsonpath cannot
         # use the existing per-field GIN indexes; the path-scan operators
-        # (species/approach/technique/standard) currently sequential-scan the
+        # (species/approach/technique) currently sequential-scan the
         # asset_search materialized view. The view is small enough today
         # (~one row per asset) that this is acceptable, but if it becomes a
         # hot path the fix is expression GIN indexes on each path or

--- a/dandiapi/api/services/search/parser.py
+++ b/dandiapi/api/services/search/parser.py
@@ -29,7 +29,6 @@ OPERATOR_KEYS: frozenset[str] = frozenset(
         'species',
         'approach',
         'technique',
-        'standard',
         'file_type',
     }
 )

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -1594,8 +1594,14 @@ def _refresh_asset_search():
         cursor.execute('REFRESH MATERIALIZED VIEW asset_search;')
 
 
-def _seed_dandiset_with_asset(*, asset_metadata: dict, embargoed: bool = False) -> Dandiset:
+def _seed_dandiset_with_asset(
+    *, asset_metadata: dict, version_metadata: dict | None = None, embargoed: bool = False
+) -> Dandiset:
     """Create a draft dandiset + version + single asset with the given metadata.
+
+    ``version_metadata`` is merged into the version's metadata (e.g. to set
+    ``assetsSummary``, which is reported at the version level rather than on
+    individual assets).
 
     Caller is responsible for `_refresh_asset_search()` after seeding all
     fixtures so the materialized view sees them.
@@ -1603,6 +1609,9 @@ def _seed_dandiset_with_asset(*, asset_metadata: dict, embargoed: bool = False) 
     embargo_status = Dandiset.EmbargoStatus.EMBARGOED if embargoed else Dandiset.EmbargoStatus.OPEN
     dandiset = DandisetFactory.create(embargo_status=embargo_status)
     version = DraftVersionFactory.create(dandiset=dandiset)
+    if version_metadata:
+        version.metadata = {**version.metadata, **version_metadata}
+        version.save()
     base_metadata = {
         'schemaVersion': DANDI_SCHEMA_VERSION,
         'schemaKey': 'Asset',
@@ -1972,11 +1981,19 @@ def test_advanced_search_technique_with_quoted_phrase(api_client):
 @pytest.mark.ai_generated
 @pytest.mark.django_db
 def test_advanced_search_standard_matches(api_client):
+    # `dataStandard` is reported on the version's assetsSummary, not on
+    # individual assets, so it must be matched against the version metadata.
     nwb = _seed_dandiset_with_asset(
-        asset_metadata={'dataStandard': [{'name': 'Neurodata Without Borders (NWB)'}]},
+        asset_metadata={},
+        version_metadata={
+            'assetsSummary': {'dataStandard': [{'name': 'Neurodata Without Borders (NWB)'}]}
+        },
     )
     bids = _seed_dandiset_with_asset(
-        asset_metadata={'dataStandard': [{'name': 'Brain Imaging Data Structure (BIDS)'}]},
+        asset_metadata={},
+        version_metadata={
+            'assetsSummary': {'dataStandard': [{'name': 'Brain Imaging Data Structure (BIDS)'}]}
+        },
     )
     _refresh_asset_search()
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -1594,14 +1594,8 @@ def _refresh_asset_search():
         cursor.execute('REFRESH MATERIALIZED VIEW asset_search;')
 
 
-def _seed_dandiset_with_asset(
-    *, asset_metadata: dict, version_metadata: dict | None = None, embargoed: bool = False
-) -> Dandiset:
+def _seed_dandiset_with_asset(*, asset_metadata: dict, embargoed: bool = False) -> Dandiset:
     """Create a draft dandiset + version + single asset with the given metadata.
-
-    ``version_metadata`` is merged into the version's metadata (e.g. to set
-    ``assetsSummary``, which is reported at the version level rather than on
-    individual assets).
 
     Caller is responsible for `_refresh_asset_search()` after seeding all
     fixtures so the materialized view sees them.
@@ -1609,9 +1603,6 @@ def _seed_dandiset_with_asset(
     embargo_status = Dandiset.EmbargoStatus.EMBARGOED if embargoed else Dandiset.EmbargoStatus.OPEN
     dandiset = DandisetFactory.create(embargo_status=embargo_status)
     version = DraftVersionFactory.create(dandiset=dandiset)
-    if version_metadata:
-        version.metadata = {**version.metadata, **version_metadata}
-        version.save()
     base_metadata = {
         'schemaVersion': DANDI_SCHEMA_VERSION,
         'schemaKey': 'Asset',
@@ -1976,29 +1967,6 @@ def test_advanced_search_technique_with_quoted_phrase(api_client):
 
     assert _search_ids(api_client, 'technique:"spike sorting"') == {spike.identifier}
     assert _search_ids(api_client, 'technique:surgical') == {surg.identifier}
-
-
-@pytest.mark.ai_generated
-@pytest.mark.django_db
-def test_advanced_search_standard_matches(api_client):
-    # `dataStandard` is reported on the version's assetsSummary, not on
-    # individual assets, so it must be matched against the version metadata.
-    nwb = _seed_dandiset_with_asset(
-        asset_metadata={},
-        version_metadata={
-            'assetsSummary': {'dataStandard': [{'name': 'Neurodata Without Borders (NWB)'}]}
-        },
-    )
-    bids = _seed_dandiset_with_asset(
-        asset_metadata={},
-        version_metadata={
-            'assetsSummary': {'dataStandard': [{'name': 'Brain Imaging Data Structure (BIDS)'}]}
-        },
-    )
-    _refresh_asset_search()
-
-    assert _search_ids(api_client, 'standard:NWB') == {nwb.identifier}
-    assert _search_ids(api_client, 'standard:BIDS') == {bids.identifier}
 
 
 @pytest.mark.ai_generated

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -309,7 +309,7 @@ class DandisetQueryParameterSerializer(serializers.Serializer):
             'Available operators: '
             'created_before, created_after, modified_before, modified_after, '
             'published_before, published_after (all take YYYY-MM-DD); '
-            'species, approach, technique, standard (case-insensitive '
+            'species, approach, technique (case-insensitive '
             'substring against the corresponding asset_metadata array); '
             'file_type (nwb, image, text, video — or any MIME prefix). '
             'Invalid syntax returns HTTP 400 with the offending token; '

--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -93,7 +93,6 @@ const operatorHelp = [
   { example: 'species:mouse', description: 'Has assets attributed to a species' },
   { example: 'approach:electrophysiology', description: 'Has assets using an approach' },
   { example: 'technique:"patch clamp"', description: 'Has assets using a measurement technique' },
-  { example: 'standard:nwb', description: 'Has assets in a data standard' },
   { example: 'file_type:nwb', description: 'Has assets of a file type (nwb, image, text, video)' },
 ];
 


### PR DESCRIPTION
## Summary

The `standard:` search operator (e.g. `standard:NWB`) never returned results against real data, and it isn't providing enough value to justify keeping a half-working operator around. **This PR removes `standard:` entirely.** It can be re-added later, wired to the correct metadata source.

### Why it was broken

`standard:` matched `$.dataStandard[*].name` against **asset** metadata, but assets don't carry a `dataStandard` field — the data standard is reported on the **Version's** `assetsSummary.dataStandard`, so the jsonpath never matched.

Verified against the sandbox API:
- `standard:nwb` / `standard:NWB` → **0 results**
- (sibling operators that *do* live on assets work, e.g. `species:mouse` → 134, `technique:two-photon` → 12)

Rather than relocate it to match the version metadata, we're dropping it for now since it's low-value, and re-introducing it cleanly later is straightforward.

## Changes

- `parser.py` — removed `standard` from `OPERATOR_KEYS`; an unknown `standard:` token now falls through to the standard 400 + "did you mean?" handling.
- `filters.py` — removed `standard` from `_ASSET_OPS`/`_NAME_PATH_OPS`, and reverted `_jsonpath_name_match` to its single-column form (the column generalization existed only to serve `standard`).
- `serializers.py` — dropped `standard` from the API search help text.
- `DandisetSearchField.vue` — removed the `standard:nwb` example from the frontend operator hints.
- `test_dandiset.py` — removed `test_advanced_search_standard_matches` and the now-unused `version_metadata` param on the `_seed_dandiset_with_asset` helper.

## Testing

`ruff check` passes on the changed files. The remaining search operator tests (`species`/`approach`/`technique`/`file_type` + the unknown-operator suggestion path) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
