### PR TITLE
ci: pre-fetch Chromium with curl to fix E2E install stall (#2845)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -115,8 +115,32 @@ jobs:
       run: npm ci
       working-directory: e2e
 
+    - name: Pre-fetch Chromium with curl (workaround for #2845)
+      # `npx playwright install` chromium download from cdn.playwright.dev hangs
+      # after 100 % on ubuntu-24.04 runner image >= 20260525.161.1. curl does
+      # not exhibit the same socket-close-after-EOF bug, so we pre-seed
+      # playwright's cache and let `playwright install --with-deps` only run
+      # apt (it sees the browsers already there and skips the download).
+      run: |
+          set -eu
+          base=https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1161
+          cache=$HOME/.cache/ms-playwright
+          mkdir -p "$cache"
+          for pair in chromium-1161:chromium-linux.zip chromium_headless_shell-1161:chromium-headless-shell-linux.zip; do
+              dir=${pair%%:*}
+              zip=${pair##*:}
+              target=$cache/$dir
+              [ -e "$target/INSTALLATION_COMPLETE" ] && continue
+              mkdir -p "$target"
+              curl --retry 5 --retry-delay 5 --retry-connrefused -fSL \
+                  "$base/$zip" -o "/tmp/$zip"
+              unzip -q "/tmp/$zip" -d "$target"
+              touch "$target/INSTALLATION_COMPLETE"
+              rm "/tmp/$zip"
+          done
+
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      run: npx playwright install --with-deps chromium
       working-directory: e2e
 
     - name: Run Playwright tests


### PR DESCRIPTION
## Summary

Attempt 3 of 3 (see #2845) to unstick frontend E2E CI, which has been stalling at `npx playwright install --with-deps` ever since the GitHub-hosted `ubuntu-24.04` runner image moved from `20260518.149.1` to `20260525.161.1` on 2026-05-28/29.

`curl` from the same runner does **not** exhibit the socket-close-after-EOF hang. Pre-fetch the chromium and chromium-headless-shell zips (build v1161, matching the `@playwright/test` 1.51.1 pin) into `~/.cache/ms-playwright/` and write the `INSTALLATION_COMPLETE` marker so playwright sees them as already installed. The subsequent `playwright install --with-deps chromium` then runs apt only — no broken HTTP fetch.

> [!NOTE]
> The hardcoded `1161` build number is tied to `@playwright/test` 1.51.1. If/when playwright is bumped, this PR's build number will need to be bumped alongside it (or removed if the playwright-bump PR lands and resolves the underlying hang).

See #2845 for the full root-cause analysis (runner image bump from `20260518.149.1` -> `20260525.161.1` triggered the hang).

## Test plan

- [ ] CI on this PR: `E2E tests` job no longer hangs at `Install Playwright Browsers`.
- [ ] Logs show "Pre-fetch Chromium" succeeds in seconds and `playwright install` is apt-only.
- [ ] If the playwright-bump and/or container PR also fix the hang, prefer those — this PR's hardcoded `1161` is brittle.
