### PR TITLE
ci: run E2E tests inside Playwright container (#2845)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -126,7 +126,11 @@ jobs:
           # with browsers preinstalled. This bypasses `npx playwright install`,
           # whose chromium download from cdn.playwright.dev hangs after 100 %
           # on the ubuntu-24.04 runner image >= 20260525.161.1 (see #2845).
+          # PW_TEST_HTML_REPORT_OPEN=never stops the HTML reporter from auto-
+          # serving the report on test failure (which would otherwise hang the
+          # job at "Serving HTML report at http://localhost:9323").
           docker run --rm --network host \
+              -e CI=1 -e PW_TEST_HTML_REPORT_OPEN=never -e PLAYWRIGHT_HTML_OPEN=never \
               -v "$PWD/e2e:/work" -w /work \
               mcr.microsoft.com/playwright:v1.51.1-noble \
               sh -c "npm ci && npx playwright test"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -111,14 +111,6 @@ jobs:
     - name: Install test data
       run: ./manage.py loaddata playwright
 
-    - name: Install dependencies
-      run: npm ci
-      working-directory: e2e
-
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
-      working-directory: e2e
-
     - name: Run Playwright tests
       run: |
           # start vue dev server
@@ -130,8 +122,14 @@ jobs:
           # start the dandi-api server
           ./manage.py runserver &
 
-          # run the tests
-          cd e2e && npx playwright test
+          # Run e2e tests inside the official Playwright container, which ships
+          # with browsers preinstalled. This bypasses `npx playwright install`,
+          # whose chromium download from cdn.playwright.dev hangs after 100 %
+          # on the ubuntu-24.04 runner image >= 20260525.161.1 (see #2845).
+          docker run --rm --network host \
+              -v "$PWD/e2e:/work" -w /work \
+              mcr.microsoft.com/playwright:v1.51.1-noble \
+              sh -c "npm ci && npx playwright test"
 
     - uses: actions/upload-artifact@v7
       if: always()


### PR DESCRIPTION
## Summary

Attempt 2 of 3 (see #2845) to unstick frontend E2E CI, which has been stalling at `npx playwright install --with-deps` ever since the GitHub-hosted `ubuntu-24.04` runner image moved from `20260518.149.1` to `20260525.161.1` on 2026-05-28/29.

Run the Playwright tests inside `mcr.microsoft.com/playwright:v1.51.1-noble`, which ships with the matching browser binaries pre-installed. The `npx playwright install` step (and the hanging chromium download) is gone entirely:

- "Install dependencies" + "Install Playwright Browsers" steps are dropped.
- The "Run Playwright tests" step now `docker run`s the container with `--network host` so it can reach the Vue dev server / Django API on `localhost`. `npm ci && npx playwright test` happens inside the container.
- `@playwright/test` stays pinned to 1.51.1 (matches the container tag); no code or dependency change.

See #2845 for the full root-cause analysis (runner image bump from `20260518.149.1` -> `20260525.161.1` triggered the hang).

## Test plan

- [ ] CI on this PR: `E2E tests` job no longer hangs and tests still pass.
- [ ] First-run image pull (~1.4 GB) doesn't push job over time limit.
- [ ] If green and the playwright-bump PR is also green, prefer the simpler bump; keep this as the documented escape hatch.
