### PR TITLE
ci: bump @playwright/test 1.51.1 -> 1.60.0 to fix E2E stall (#2845)

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,7 +7,7 @@
       "name": "dandi-playwright-test",
       "devDependencies": {
         "@faker-js/faker": "9.6.0",
-        "@playwright/test": "1.51.1",
+        "@playwright/test": "1.60.0",
         "@types/node": "24.12.0",
         "axios": "1.8.4",
         "lodash": "4.17.21",
@@ -32,13 +32,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
-      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.51.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -214,21 +214,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -384,13 +369,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
-      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.51.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -403,9 +388,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
-      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -214,6 +214,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
   "scripts": {},
   "devDependencies": {
     "@faker-js/faker": "9.6.0",
-    "@playwright/test": "1.51.1",
+    "@playwright/test": "1.60.0",
     "@types/node": "24.12.0",
     "axios": "1.8.4",
     "lodash": "4.17.21",


### PR DESCRIPTION
## Summary

- Closes #2845 

Attempt 1 of 3 (see #2845) to unstick frontend E2E CI, which has been stalling at `npx playwright install --with-deps` ever since the GitHub-hosted `ubuntu-24.04` runner image moved from `20260518.149.1` to `20260525.161.1` on 2026-05-28/29.

This PR is the **smallest blast-radius** attempt: bump `@playwright/test` from 1.51.1 (Mar 2025) to 1.60.0 (current latest 1.x). Several 1.5x / 1.6x releases include fixes in the browser-download pathway. If 1.60.0 still stalls we'll fall back to the parallel container-based or curl-prefetch PRs.

See #2845 for the full root-cause analysis (runner image bump from `20260518.149.1` -> `20260525.161.1` triggered the hang).

## Test plan

- [x] CI on this PR: `E2E tests` job no longer hangs at `Install Playwright Browsers`
- [x] If green, this is the preferred fix (smallest diff). If red, close in favor of the container-based or curl-prefetch PR.
