### PR TITLE
Guard against empty `loc` in `_encode_pydantic_error`

### DIFF
--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -26,7 +26,11 @@ logger = get_task_logger(__name__)
 
 
 def _encode_pydantic_error(error) -> dict[str, str]:
-    return {'field': error['loc'][0], 'message': error['msg']}
+    # `loc` may be an empty tuple, e.g. for an error raised by a top-level
+    # `@model_validator`, which attaches the error to the model root. Mirror how
+    # `_encode_jsonschema_error` tolerates an empty path so we don't IndexError.
+    loc = error['loc']
+    return {'field': str(loc[0]) if loc else '', 'message': error['msg']}
 
 
 def _encode_jsonschema_error(error: jsonschema.exceptions.ValidationError) -> dict[str, str]:


### PR DESCRIPTION
Guards `_encode_pydantic_error` against an empty `loc` tuple (which a top-level `@model_validator` produces), mirroring how `_encode_jsonschema_error` already tolerates an empty path. Without this, `error['loc'][0]` raises `IndexError` inside the validation `except` handler and the validation task fails instead of recording a clean error.

This applies the fix proposed in #2851; see that issue for the full analysis, reproduction, and `ErrorDetails` background.

Closes #2851.

## Test plan

No new test ships here. The bug is unreachable under the pinned `dandischema==0.12.1` (no top-level model validators on `Dandiset`/`Asset`), so a unit test would have to hand-build the empty-`loc` error dict the encoder consumes, exercising no real Pydantic/dandischema behavior. The genuine coverage already exists in waiting: `test_validate_version_metadata_no_assets` and `test_validate_version_metadata_empty_zarr_asset` drive the zero-byte / no-file path and will exercise the real `loc == ()` error through this encoder once the dandischema consolidation lands. Updating their expected `field` at that point is the real regression test (tracked in #2854).

- [x] `pre-commit` hooks pass
- [x] CI: existing validation suite passes unchanged
