### PR TITLE
Add in-browser zip download for small dandisets

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,7 @@
         "@resonant/oauth-client": "1.0.3",
         "@sentry/vue": "10.44.0",
         "axios": "1.8.1",
+        "client-zip": "^2.5.0",
         "core-js": "3.41.0",
         "dompurify": "3.2.4",
         "filesize": "11.0.14",
@@ -2882,6 +2883,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/client-zip": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.5.0.tgz",
+      "integrity": "sha512-ydG4nDZesbFurnNq0VVCp/yyomIBh+X/1fZPI/P24zbnG4dtC4tQAfI5uQsomigsUMeiRO2wiTPizLWQh+IAyQ==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "@resonant/oauth-client": "1.0.3",
     "@sentry/vue": "10.44.0",
     "axios": "1.8.1",
+    "client-zip": "^2.5.0",
     "core-js": "3.41.0",
     "dompurify": "3.2.4",
     "filesize": "11.0.14",

--- a/web/src/composables/useZipDownload.ts
+++ b/web/src/composables/useZipDownload.ts
@@ -1,0 +1,125 @@
+import { ref } from 'vue';
+import { downloadZip } from 'client-zip';
+
+export interface ZipEntry {
+  /** Path of the file inside the zip. */
+  name: string;
+  /** URL to fetch the file's bytes from. */
+  url: string;
+  /** Size in bytes, used for progress tracking. */
+  size: number;
+  lastModified?: Date;
+}
+
+// Wrap a byte stream so we can count bytes as they flow through to the zipper,
+// giving smooth progress even when the download is a few large files.
+function trackStream(
+  stream: ReadableStream<Uint8Array>,
+  onBytes: (n: number) => void,
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      onBytes(value.byteLength);
+      controller.enqueue(value);
+    },
+    cancel(reason) {
+      reader.cancel(reason);
+    },
+  });
+}
+
+/**
+ * Generic in-browser zip download: fetch a list of URLs sequentially, zip them
+ * client-side with client-zip, and save the result through the browser's normal
+ * download mechanism.
+ *
+ * The URLs are fetched with a plain (unauthenticated) `fetch`, so they must be
+ * publicly readable and CORS-accessible. The archive is buffered in memory
+ * before saving, so callers should gate usage on a reasonable total size.
+ */
+export function useZipDownload() {
+  const inProgress = ref(false);
+  const progress = ref(0); // 0–100
+  const canceled = ref(false);
+
+  let abortController: AbortController | null = null;
+
+  function cancel() {
+    abortController?.abort();
+  }
+
+  /**
+   * Fetch entries and save them as `zipName`. `getEntries` receives an
+   * AbortSignal so that entry listing is interrupted by `cancel()` along with
+   * any in-flight fetches. Throws on failure; after a `cancel()` the rejection
+   * is the abort reason and `canceled` is set.
+   */
+  async function download(
+    zipName: string,
+    getEntries: (signal: AbortSignal) => Promise<ZipEntry[]>,
+  ): Promise<void> {
+    if (inProgress.value) {
+      return;
+    }
+    inProgress.value = true;
+    progress.value = 0;
+    canceled.value = false;
+    abortController = new AbortController();
+    const { signal } = abortController;
+
+    try {
+      const entries = await getEntries(signal);
+      const totalBytes = entries.reduce((sum, entry) => sum + entry.size, 0);
+      let downloadedBytes = 0;
+
+      // Lazily fetch each entry so only one file is in flight at a time.
+      async function* zipEntries() {
+        for (const entry of entries) {
+          const response = await fetch(entry.url, { signal });
+          if (!response.ok) {
+            throw new Error(`Failed to download "${entry.name}" (HTTP ${response.status})`);
+          }
+          const body = response.body
+            ? trackStream(response.body, (n) => {
+              downloadedBytes += n;
+              progress.value = totalBytes ? (downloadedBytes / totalBytes) * 100 : 0;
+            })
+            : response;
+          yield {
+            name: entry.name,
+            input: body,
+            size: entry.size,
+            lastModified: entry.lastModified,
+          };
+        }
+      }
+
+      const blob = await downloadZip(zipEntries()).blob();
+
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = zipName;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (err) {
+      canceled.value = signal.aborted;
+      throw err;
+    } finally {
+      inProgress.value = false;
+      abortController = null;
+    }
+  }
+
+  return {
+    inProgress, progress, canceled, cancel, download,
+  };
+}

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -52,6 +52,59 @@
         </v-tooltip>
       </v-card-title>
       <v-list class="pa-0">
+        <!-- PROTOTYPE: in-browser zip download for small dandisets -->
+        <template v-if="browserZipEligible">
+          <v-list-item density="compact">
+            Download directly in your browser
+            ({{ filesize(currentDandiset?.size ?? 0, { round: 1, base: 10, standard: 'si' }) }})
+          </v-list-item>
+          <template v-if="zipInProgress">
+            <v-list-item density="compact">
+              <v-progress-linear
+                :model-value="zipProgress"
+                :indeterminate="zipProgress === 0"
+                color="primary"
+                height="20"
+                rounded
+              >
+                <span class="text-caption">{{ Math.round(zipProgress) }}%</span>
+              </v-progress-linear>
+            </v-list-item>
+            <v-list-item density="compact">
+              <v-btn
+                color="error"
+                variant="outlined"
+                block
+                prepend-icon="mdi-close"
+                @click="cancelZip"
+              >
+                Cancel
+              </v-btn>
+            </v-list-item>
+          </template>
+          <v-list-item
+            v-else
+            density="compact"
+          >
+            <v-btn
+              color="primary"
+              variant="flat"
+              block
+              prepend-icon="mdi-folder-zip"
+              @click="downloadAsZip"
+            >
+              Download .zip
+            </v-btn>
+          </v-list-item>
+          <v-list-item
+            v-if="zipError"
+            density="compact"
+            :class="zipCanceled ? 'text-medium-emphasis text-caption' : 'text-error text-caption'"
+          >
+            {{ zipError }}
+          </v-list-item>
+          <v-divider class="my-2" />
+        </template>
         <v-list-item density="compact">
           Use this command in your DANDI CLI
         </v-list-item>
@@ -131,10 +184,22 @@
 </template>
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
+import { downloadZip } from 'client-zip';
+import { filesize } from 'filesize';
 import { useDandisetStore } from '@/stores/dandiset';
 import CopyText from '@/components/CopyText.vue';
 import { dandiDocumentationUrl } from '@/utils/constants';
 import { dandiRest } from '@/rest';
+import type { Asset } from '@/types';
+
+// In-browser zip is gated to "small" dandisets: the whole archive is buffered in
+// memory (client-zip -> Blob) before the browser saves it, so keep both bytes and
+// file-count conservative. Bump these once a streaming-to-disk path is added.
+const BROWSER_ZIP_MAX_SIZE = 2 * (1024 ** 3); // 2 GiB
+const BROWSER_ZIP_MAX_FILES = 1000;
+
+// The assets list endpoint returns `zarr`/`blob` slugs that aren't on the TS Asset type.
+type AssetWithStorage = Asset & { zarr: string | null; blob: string | null };
 
 function downloadCommand(identifier: string, version: string): string {
   // Use the special 'DANDI:' url prefix if appropriate.
@@ -192,4 +257,153 @@ const customDownloadText = computed(() => {
   }
   return '';
 });
+
+// --- In-browser zip download (prototype) ---------------------------------
+
+const zipInProgress = ref(false);
+const zipProgress = ref(0); // 0–100
+const zipError = ref('');
+const zipCanceled = ref(false);
+
+let zipAbortController: AbortController | null = null;
+
+function cancelZip() {
+  zipAbortController?.abort();
+}
+
+// Wrap a byte stream so we can count bytes as they flow through to the zipper,
+// giving smooth progress even when a dandiset is a few large files.
+function trackStream(
+  stream: ReadableStream<Uint8Array>,
+  onBytes: (n: number) => void,
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      onBytes(value.byteLength);
+      controller.enqueue(value);
+    },
+    cancel(reason) {
+      reader.cancel(reason);
+    },
+  });
+}
+
+const browserZipEligible = computed(() => {
+  const version = currentDandiset.value;
+  return !!version
+    && !!identifier.value
+    && version.size > 0
+    && version.size <= BROWSER_ZIP_MAX_SIZE
+    && version.asset_count > 0
+    && version.asset_count <= BROWSER_ZIP_MAX_FILES;
+});
+
+// Fetch every asset in the version, following pagination.
+async function fetchAllAssets(
+  id: string,
+  version: string,
+  signal: AbortSignal,
+): Promise<AssetWithStorage[]> {
+  const assets: AssetWithStorage[] = [];
+  let page = 1;
+  for (;;) {
+    const data = await dandiRest.assets(id, version, { params: { page, page_size: 1000 }, signal });
+    if (!data) {
+      break;
+    }
+    assets.push(...(data.results as unknown as AssetWithStorage[]));
+    if (!data.next) {
+      break;
+    }
+    page += 1;
+  }
+  return assets;
+}
+
+async function downloadAsZip() {
+  const id = identifier.value;
+  const version = currentVersion.value;
+  if (!id || !version || zipInProgress.value) {
+    return;
+  }
+
+  zipInProgress.value = true;
+  zipProgress.value = 0;
+  zipError.value = '';
+  zipCanceled.value = false;
+  zipAbortController = new AbortController();
+  const { signal } = zipAbortController;
+
+  try {
+    const allAssets = await fetchAllAssets(id, version, signal);
+    // Zarr assets aren't single blobs and can't be fetched via the download endpoint.
+    const blobAssets = allAssets.filter((a) => !a.zarr);
+    const skipped = allAssets.length - blobAssets.length;
+    if (blobAssets.length === 0) {
+      zipError.value = 'No downloadable files in this dandiset (Zarr assets are not supported).';
+      return;
+    }
+
+    const totalBytes = blobAssets.reduce((sum, a) => sum + a.size, 0);
+    let downloadedBytes = 0;
+
+    // Nest everything under a single root folder matching the zip filename.
+    const rootFolder = `${id}-${version}`;
+
+    // Lazily fetch each asset so only one file is in flight at a time.
+    async function* zipEntries() {
+      for (const asset of blobAssets) {
+        const url = dandiRest.assetDownloadURI(id!, version!, asset.asset_id);
+        const response = await fetch(url, { signal });
+        if (!response.ok) {
+          throw new Error(`Failed to download "${asset.path}" (HTTP ${response.status})`);
+        }
+        const body = response.body
+          ? trackStream(response.body, (n) => {
+            downloadedBytes += n;
+            zipProgress.value = totalBytes ? (downloadedBytes / totalBytes) * 100 : 0;
+          })
+          : response;
+        yield {
+          name: `${rootFolder}/${asset.path}`,
+          input: body,
+          size: asset.size,
+          lastModified: new Date(asset.modified),
+        };
+      }
+    }
+
+    const zipResponse = downloadZip(zipEntries(), { length: blobAssets.length });
+    const blob = await zipResponse.blob();
+
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = objectUrl;
+    link.download = `${rootFolder}.zip`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(objectUrl);
+
+    if (skipped > 0) {
+      zipError.value = `Downloaded ${blobAssets.length} files. Skipped ${skipped} Zarr asset(s) — use the DANDI CLI for those.`;
+    }
+  } catch (err) {
+    if (signal.aborted) {
+      zipCanceled.value = true;
+      zipError.value = 'Download canceled.';
+    } else {
+      zipError.value = err instanceof Error ? err.message : 'Download failed.';
+    }
+  } finally {
+    zipInProgress.value = false;
+    zipAbortController = null;
+  }
+}
 </script>

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -184,9 +184,9 @@
 </template>
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
-import { downloadZip } from 'client-zip';
 import { filesize } from 'filesize';
 import { useDandisetStore } from '@/stores/dandiset';
+import { useZipDownload, type ZipEntry } from '@/composables/useZipDownload';
 import CopyText from '@/components/CopyText.vue';
 import { dandiDocumentationUrl } from '@/utils/constants';
 import { dandiRest } from '@/rest';
@@ -260,44 +260,23 @@ const customDownloadText = computed(() => {
 
 // --- In-browser zip download (prototype) ---------------------------------
 
-const zipInProgress = ref(false);
-const zipProgress = ref(0); // 0–100
+const {
+  inProgress: zipInProgress,
+  progress: zipProgress,
+  canceled: zipCanceled,
+  cancel: cancelZip,
+  download: downloadEntriesAsZip,
+} = useZipDownload();
+
 const zipError = ref('');
-const zipCanceled = ref(false);
-
-let zipAbortController: AbortController | null = null;
-
-function cancelZip() {
-  zipAbortController?.abort();
-}
-
-// Wrap a byte stream so we can count bytes as they flow through to the zipper,
-// giving smooth progress even when a dandiset is a few large files.
-function trackStream(
-  stream: ReadableStream<Uint8Array>,
-  onBytes: (n: number) => void,
-): ReadableStream<Uint8Array> {
-  const reader = stream.getReader();
-  return new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      const { done, value } = await reader.read();
-      if (done) {
-        controller.close();
-        return;
-      }
-      onBytes(value.byteLength);
-      controller.enqueue(value);
-    },
-    cancel(reason) {
-      reader.cancel(reason);
-    },
-  });
-}
 
 const browserZipEligible = computed(() => {
   const version = currentDandiset.value;
+  // The composable fetches assets without auth headers, so embargoed
+  // dandisets (which require an authenticated download) are excluded.
   return !!version
     && !!identifier.value
+    && version.dandiset.embargo_status === 'OPEN'
     && version.size > 0
     && version.size <= BROWSER_ZIP_MAX_SIZE
     && version.asset_count > 0
@@ -333,77 +312,40 @@ async function downloadAsZip() {
     return;
   }
 
-  zipInProgress.value = true;
-  zipProgress.value = 0;
   zipError.value = '';
-  zipCanceled.value = false;
-  zipAbortController = new AbortController();
-  const { signal } = zipAbortController;
+
+  // Nest everything under a single root folder matching the zip filename.
+  const rootFolder = `${id}-${version}`;
+  let included = 0;
+  let skipped = 0;
 
   try {
-    const allAssets = await fetchAllAssets(id, version, signal);
-    // Zarr assets aren't single blobs and can't be fetched via the download endpoint.
-    const blobAssets = allAssets.filter((a) => !a.zarr);
-    const skipped = allAssets.length - blobAssets.length;
-    if (blobAssets.length === 0) {
-      zipError.value = 'No downloadable files in this dandiset (Zarr assets are not supported).';
-      return;
-    }
-
-    const totalBytes = blobAssets.reduce((sum, a) => sum + a.size, 0);
-    let downloadedBytes = 0;
-
-    // Nest everything under a single root folder matching the zip filename.
-    const rootFolder = `${id}-${version}`;
-
-    // Lazily fetch each asset so only one file is in flight at a time.
-    async function* zipEntries() {
-      for (const asset of blobAssets) {
-        const url = dandiRest.assetDownloadURI(id!, version!, asset.asset_id);
-        const response = await fetch(url, { signal });
-        if (!response.ok) {
-          throw new Error(`Failed to download "${asset.path}" (HTTP ${response.status})`);
-        }
-        const body = response.body
-          ? trackStream(response.body, (n) => {
-            downloadedBytes += n;
-            zipProgress.value = totalBytes ? (downloadedBytes / totalBytes) * 100 : 0;
-          })
-          : response;
-        yield {
-          name: `${rootFolder}/${asset.path}`,
-          input: body,
-          size: asset.size,
-          lastModified: new Date(asset.modified),
-        };
+    await downloadEntriesAsZip(`${rootFolder}.zip`, async (signal): Promise<ZipEntry[]> => {
+      const allAssets = await fetchAllAssets(id, version, signal);
+      // Zarr assets aren't single blobs and can't be fetched via the download endpoint.
+      const blobAssets = allAssets.filter((a) => !a.zarr);
+      included = blobAssets.length;
+      skipped = allAssets.length - blobAssets.length;
+      if (blobAssets.length === 0) {
+        throw new Error('No downloadable files in this dandiset (Zarr assets are not supported).');
       }
-    }
-
-    const zipResponse = downloadZip(zipEntries(), { length: blobAssets.length });
-    const blob = await zipResponse.blob();
-
-    const objectUrl = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = objectUrl;
-    link.download = `${rootFolder}.zip`;
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    URL.revokeObjectURL(objectUrl);
+      return blobAssets.map((asset) => ({
+        name: `${rootFolder}/${asset.path}`,
+        url: dandiRest.assetDownloadURI(id, version, asset.asset_id),
+        size: asset.size,
+        lastModified: new Date(asset.modified),
+      }));
+    });
 
     if (skipped > 0) {
-      zipError.value = `Downloaded ${blobAssets.length} files. Skipped ${skipped} Zarr asset(s) — use the DANDI CLI for those.`;
+      zipError.value = `Downloaded ${included} files. Skipped ${skipped} Zarr asset(s); use the DANDI CLI for those.`;
     }
   } catch (err) {
-    if (signal.aborted) {
-      zipCanceled.value = true;
+    if (zipCanceled.value) {
       zipError.value = 'Download canceled.';
     } else {
       zipError.value = err instanceof Error ? err.message : 'Download failed.';
     }
-  } finally {
-    zipInProgress.value = false;
-    zipAbortController = null;
   }
 }
 </script>


### PR DESCRIPTION
## Motivation

Requiring the DANDI CLI to download a dandiset is **overkill for small datasets**. The current Download menu only hands the user a `dandi download ...` command — there's no way to grab a small dandiset straight from the browser.

This adds a **Download .zip** button to the dandiset Download menu that bundles the dataset client-side and saves it through the normal browser download mechanism.

## How it works

- Fetches each asset's blob **directly from S3** (the bucket already serves `Access-Control-Allow-Origin: *`, so browser `fetch` works) and zips them client-side with [`client-zip`](https://github.com/Touffy/client-zip) (~5 KB).
- **No backend changes and no server bandwidth cost** — bytes go S3 → browser, preserving the existing S3-direct model. The button is purely additive; the CLI flow is untouched.
- Files nest under a single root folder matching the zip filename (e.g. `000123-draft/sub-01/...`).
- **Byte-level progress bar** and a **Cancel** button (backed by an `AbortController` that interrupts both the asset listing and in-flight fetches).
- **Zarr assets are skipped** (they're not single blobs) with a user-facing note pointing to the CLI.

## Gating

Shown only for "small" versions: **≤ 2 GiB** and **≤ 1000 files** (constants at the top of the component). The archive is buffered in memory (`client-zip` → `Blob`) before saving, which is why the cap exists.

Video of sandbox testing below

## Status / open questions
- **Memory cap**: the in-memory buffer is the reason for the 2 GiB limit. A follow-up could stream to disk via the File System Access API (`createWritable()`) to lift the cap.
- **Thresholds** (2 GiB / 1000 files) are guesses — feedback welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)