### PR TITLE
Reconcile S3 manifests with DB + fix publish-time DOI race

### DIFF
--- a/dandiapi/api/doi.py
+++ b/dandiapi/api/doi.py
@@ -25,16 +25,27 @@ def doi_configured() -> bool:
     return all(setting is not None for setting, _ in DANDI_DOI_SETTINGS)
 
 
-def _generate_doi_data(version: Version):
-    from dandischema.datacite import to_datacite
+def doi_for_version(version: Version) -> str:
+    """Compute the DOI a Version has (or would have) at DataCite.
 
-    publish = settings.DANDI_DOI_PUBLISH
+    Purely deterministic -- no API call, no side effects. Because it is
+    deterministic, a Version whose ``doi`` column is NULL may nonetheless
+    already have this DOI registered at DataCite (minted at publish time,
+    then not persisted); see ``get_doi``.
+    """
     # Use the DANDI test datacite instance as a placeholder if PREFIX isn't set
     prefix = settings.DANDI_DOI_API_PREFIX
     instance_name: str = get_instance_config().instance_name
     dandiset_id = version.dandiset.identifier
     version_id = version.version
-    doi = f'{prefix}/{instance_name.lower()}.{dandiset_id}/{version_id}'
+    return f'{prefix}/{instance_name.lower()}.{dandiset_id}/{version_id}'
+
+
+def _generate_doi_data(version: Version):
+    from dandischema.datacite import to_datacite
+
+    publish = settings.DANDI_DOI_PUBLISH
+    doi = doi_for_version(version)
     metadata = version.metadata
     metadata['doi'] = doi
     return (doi, to_datacite(metadata, publish=publish))
@@ -61,6 +72,35 @@ def create_doi(version: Version) -> str:
                 logger.exception(e.response.text)
             raise
     return doi
+
+
+def get_doi(doi: str) -> dict | None:
+    """Fetch a DOI's ``attributes`` from DataCite; None if it isn't registered.
+
+    Returns None (without an API call) when DOI minting isn't configured.
+    """
+    if not doi_configured():
+        logger.debug('Skipping DOI lookup for %s since not configured', doi)
+        return None
+
+    doi_url = settings.DANDI_DOI_API_URL.rstrip('/') + '/' + doi
+    try:
+        r = requests.get(
+            doi_url,
+            auth=requests.auth.HTTPBasicAuth(
+                settings.DANDI_DOI_API_USER,
+                settings.DANDI_DOI_API_PASSWORD,
+            ),
+            headers={'Accept': 'application/vnd.api+json'},
+            timeout=30,
+        )
+        r.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == requests.codes.not_found:
+            return None
+        logger.exception('Failed to fetch data for DOI %s', doi)
+        raise
+    return r.json()['data']['attributes']
 
 
 def delete_doi(doi: str) -> None:

--- a/dandiapi/api/management/commands/sync_manifest_files.py
+++ b/dandiapi/api/management/commands/sync_manifest_files.py
@@ -1,0 +1,382 @@
+"""
+Management command to reconcile manifest files on S3 against the database.
+
+For each selected Version, compare what `dandiset.jsonld` and/or `assets.jsonld`
+would be generated now from `version.metadata` / `version.assets` to what's
+currently stored on S3. If they differ (or if the S3 object is missing),
+trigger `write_manifest_files` to rewrite all manifest files for that version.
+
+Optionally also re-mint DOIs for published versions whose `version.doi` is
+NULL or equals the placeholder ``.../123456/0.123456.1234`` (symptom of a
+failed DOI creation at publish time).
+
+Context: https://github.com/dandi/dandi-archive/issues/2759
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+
+from django.core.files.storage import default_storage
+import djclick as click
+from rest_framework.renderers import JSONRenderer
+from tqdm import tqdm
+
+from dandiapi.api import doi as doi_module
+from dandiapi.api.manifests import _assets_jsonld_path, _dandiset_jsonld_path
+from dandiapi.api.models import Version
+from dandiapi.api.tasks import write_manifest_files
+
+# Matches the placeholder DOI that the publish code injects purely for schema
+# validation (see dandiapi/api/services/publish/__init__.py and
+# dandiapi/api/services/metadata/__init__.py).
+_DUMMY_DOI_RE = re.compile(r'\.123456/0\.123456\.1234$')
+
+VERSION_CHOICES = ('draft', 'published', 'all')
+TARGET_CHOICES = ('dandiset', 'assets', 'both')
+
+
+def _is_dummy_doi(doi: str | None) -> bool:
+    return bool(doi) and bool(_DUMMY_DOI_RE.search(doi))
+
+
+def _read_s3_bytes(path: str) -> bytes | None:
+    """Return the bytes at ``path`` in the default storage, or None if missing."""
+    if not default_storage.exists(path):
+        return None
+    with default_storage.open(path) as f:
+        return f.read()
+
+
+def _iter_asset_full_metadata(version: Version) -> list[dict]:
+    return [
+        asset.full_metadata
+        for asset in version.assets.select_related('blob', 'zarr', 'zarr__dandiset').iterator()
+    ]
+
+
+def _renormalize(obj: object) -> object:
+    """Round-trip ``obj`` through ``JSONRenderer`` and ``json.loads``.
+
+    Ensures comparisons with parsed-from-S3 data are not tripped by
+    ``Decimal``/``UUID``/``datetime`` or other DRF-specific coercions that
+    ``json.loads`` would otherwise see only on one side.
+    """
+    return json.loads(JSONRenderer().render(obj))
+
+
+def _diff(expected: object, actual: object, label: str) -> str:
+    expected_s = json.dumps(expected, indent=2, sort_keys=True).splitlines(keepends=True)
+    actual_s = json.dumps(actual, indent=2, sort_keys=True).splitlines(keepends=True)
+    return ''.join(
+        difflib.unified_diff(
+            actual_s,
+            expected_s,
+            fromfile=f'{label} (S3)',
+            tofile=f'{label} (expected from DB)',
+            n=3,
+        )
+    )
+
+
+def _dandiset_jsonld_matches(version: Version, *, show_diff: bool) -> tuple[bool, str]:
+    path = _dandiset_jsonld_path(version)
+    s3_bytes = _read_s3_bytes(path)
+    if s3_bytes is None:
+        return False, f'  {path}: MISSING on S3'
+
+    try:
+        s3_obj = json.loads(s3_bytes)
+    except json.JSONDecodeError as e:
+        return False, f'  {path}: unparsable on S3 ({e})'
+
+    expected_obj = _renormalize(version.metadata)
+    if s3_obj == expected_obj:
+        return True, ''
+
+    msg = f'  {path}: differs'
+    if show_diff:
+        msg += '\n' + _diff(expected_obj, s3_obj, 'dandiset.jsonld')
+    return False, msg
+
+
+def _assets_jsonld_matches(version: Version, *, show_diff: bool) -> tuple[bool, str]:
+    path = _assets_jsonld_path(version)
+    s3_bytes = _read_s3_bytes(path)
+    if s3_bytes is None:
+        return False, f'  {path}: MISSING on S3'
+
+    try:
+        s3_obj = json.loads(s3_bytes)
+    except json.JSONDecodeError as e:
+        return False, f'  {path}: unparsable on S3 ({e})'
+
+    expected_obj = _renormalize(_iter_asset_full_metadata(version))
+    if s3_obj == expected_obj:
+        return True, ''
+
+    msg = f'  {path}: differs ({len(s3_obj)} assets on S3, {len(expected_obj)} expected)'
+    if show_diff:
+        msg += '\n' + _diff(expected_obj, s3_obj, 'assets.jsonld')
+    return False, msg
+
+
+def _fix_missing_doi(version: Version, *, dry_run: bool) -> tuple[bool, str]:
+    """Re-mint the DOI for a published Version whose DOI is missing/placeholder.
+
+    Returns (changed, message).
+    """
+    if version.version == 'draft':
+        return False, ''
+    if version.doi and not _is_dummy_doi(version.doi):
+        return False, ''
+
+    reason = 'NULL' if not version.doi else 'placeholder'
+    if dry_run:
+        return True, f'  DOI would be re-minted ({reason})'
+
+    try:
+        new_doi = doi_module.create_doi(version)
+    except Exception as e:  # noqa: BLE001
+        # ``doi.create_doi`` (via ``_generate_doi_data``) mutates
+        # ``version.metadata['doi']`` as a side effect *before* the HTTP call.
+        # On failure that mutation is left behind on the in-memory instance,
+        # which would then make the immediately-following compare-to-S3 step
+        # report a spurious mismatch. Re-load from the DB to discard it.
+        version.refresh_from_db()
+        return False, f'  DOI remint FAILED ({reason}): {e}'
+
+    # Save doi column; Version.save() re-populates metadata with the real DOI
+    # and a DOI-based citation.
+    version.doi = new_doi
+    version.save()
+    return True, f'  DOI re-minted ({reason}) -> {new_doi}'
+
+
+def _select_versions(
+    dandisets: tuple[int, ...],
+    *,
+    include_all: bool,
+    version_filter: str,
+    specific_version: str | None,
+):
+    qs = Version.objects.select_related('dandiset')
+
+    if dandisets:
+        qs = qs.filter(dandiset_id__in=dandisets)
+    # else: --all was specified (mutual-exclusion is enforced by the caller),
+    # so the queryset stays unfiltered by dandiset.
+
+    if specific_version:
+        qs = qs.filter(version=specific_version)
+    elif version_filter == 'draft':
+        qs = qs.filter(version='draft')
+    elif version_filter == 'published':
+        qs = qs.exclude(version='draft')
+    elif version_filter == 'all':
+        pass
+    else:  # pragma: no cover - click.Choice enforces this
+        raise click.ClickException(f'Unknown --version filter {version_filter!r}')
+
+    return qs.order_by('dandiset_id', 'version')
+
+
+@click.command()
+@click.argument('dandisets', type=click.INT, nargs=-1)
+@click.option(
+    '-a',
+    '--all',
+    'include_all',
+    is_flag=True,
+    help='Run on all dandisets (mutually exclusive with positional dandiset IDs).',
+)
+@click.option(
+    '--version',
+    'version_filter',
+    type=click.Choice(VERSION_CHOICES),
+    default='all',
+    show_default=True,
+    help='Which versions to consider.',
+)
+@click.option(
+    '--specific-version',
+    'specific_version',
+    default=None,
+    help='Limit to a single version string (e.g. "draft" or "0.250917.2023"). Overrides --version.',
+)
+@click.option(
+    '--targets',
+    type=click.Choice(TARGET_CHOICES),
+    default='dandiset',
+    show_default=True,
+    help='Which manifest files to compare: "dandiset" (dandiset.jsonld only, '
+    'cheap), "assets" (assets.jsonld only, expensive), or "both".',
+)
+@click.option(
+    '--dry-run',
+    '--check',
+    'dry_run',
+    is_flag=True,
+    default=False,
+    help="Don't write anything; just report versions that would be updated.",
+)
+@click.option(
+    '--sync/--async',
+    'run_sync',
+    default=False,
+    show_default=True,
+    help='Run write_manifest_files inline (--sync) or enqueue via celery (--async, default).',
+)
+@click.option(
+    '--fix-doi/--no-fix-doi',
+    'fix_doi',
+    default=True,
+    show_default=True,
+    help='Also re-mint DOIs for published versions whose version.doi is NULL or a placeholder.',
+)
+@click.option(
+    '--show-diff',
+    is_flag=True,
+    default=False,
+    help='Show a unified diff when a manifest differs (implies verbose output).',
+)
+def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    dandisets: tuple[int, ...],
+    *,
+    include_all: bool,
+    version_filter: str,
+    specific_version: str | None,
+    targets: str,
+    dry_run: bool,
+    run_sync: bool,
+    fix_doi: bool,
+    show_diff: bool,
+):
+    """
+    Reconcile S3 manifests with the database.
+
+    For each selected Version, compares the on-S3 dandiset.jsonld and/or
+    assets.jsonld to what would be generated from the current database state.
+    If they differ (or the S3 object is missing), the full set of manifest
+    files for that version is regenerated via ``write_manifest_files``. By
+    default the regeneration is enqueued via Celery (use ``--sync`` to run
+    inline).
+
+    Optionally (on by default) re-mint DOIs for published versions whose
+    ``version.doi`` column is NULL or is the publishing-time placeholder
+    (...`.123456/0.123456.1234`).
+
+    Motivated by https://github.com/dandi/dandi-archive/issues/2759.
+    """
+    if bool(dandisets) == include_all:
+        raise click.ClickException("Must specify exactly one of 'dandisets' or --all")
+
+    if specific_version and version_filter != 'all':
+        click.echo('Note: --specific-version overrides --version', err=True)
+
+    compare_dandiset = targets in ('dandiset', 'both')
+    compare_assets = targets in ('assets', 'both')
+
+    versions_qs = _select_versions(
+        dandisets,
+        include_all=include_all,
+        version_filter=version_filter,
+        specific_version=specific_version,
+    )
+
+    total = versions_qs.count()
+    if total == 0:
+        click.echo('No matching versions.')
+        return
+
+    click.echo(
+        f'Checking {total} version(s) '
+        f'(targets={targets}, dry_run={dry_run}, '
+        f'async={not run_sync}, fix_doi={fix_doi}).'
+    )
+
+    n_doi_fixed = 0
+    n_doi_would_fix = 0
+    n_manifest_mismatch = 0
+    n_manifest_regen = 0
+    n_regen_failed = 0
+
+    for version in tqdm(versions_qs.iterator(), total=total):
+        label = f'{version.dandiset.identifier}/{version.version}'
+        messages: list[str] = []
+        need_regen = False
+
+        # 1) DOI fix (only for published versions; draft versions have no DOI,
+        # and skip if doi already looks OK).
+        if (
+            fix_doi
+            and version.version != 'draft'
+            and (not version.doi or _is_dummy_doi(version.doi))
+        ):
+            changed, msg = _fix_missing_doi(version, dry_run=dry_run)
+            if msg:
+                messages.append(msg)
+            if changed:
+                if dry_run:
+                    n_doi_would_fix += 1
+                else:
+                    n_doi_fixed += 1
+                # DOI fix updates metadata -> manifest definitely needs rewrite
+                need_regen = True
+
+        # 2) Compare manifests
+        if compare_dandiset:
+            matches, msg = _dandiset_jsonld_matches(version, show_diff=show_diff)
+            if not matches:
+                need_regen = True
+                n_manifest_mismatch += 1
+                messages.append(msg)
+
+        if compare_assets:
+            matches, msg = _assets_jsonld_matches(version, show_diff=show_diff)
+            if not matches:
+                need_regen = True
+                n_manifest_mismatch += 1
+                messages.append(msg)
+
+        if not need_regen:
+            continue
+
+        if dry_run:
+            messages.append('  -> would regenerate all manifest files')
+        else:
+            try:
+                if run_sync:
+                    write_manifest_files(version.id)
+                else:
+                    write_manifest_files.delay(version.id)
+                n_manifest_regen += 1
+                messages.append(
+                    '  -> regenerated all manifest files'
+                    if run_sync
+                    else '  -> enqueued manifest regeneration'
+                )
+            except Exception as e:  # noqa: BLE001
+                n_regen_failed += 1
+                messages.append(f'  -> regeneration FAILED: {e}')
+
+        click.echo(f'{label}:')
+        for m in messages:
+            click.echo(m)
+
+    click.echo('')
+    click.echo('Summary:')
+    click.echo(f'  versions checked:       {total}')
+    click.echo(f'  manifest mismatches:    {n_manifest_mismatch}')
+    if dry_run:
+        click.echo(f'  DOIs to re-mint:        {n_doi_would_fix}')
+        click.echo('  (dry run: no changes made)')
+    else:
+        click.echo(f'  DOIs re-minted:         {n_doi_fixed}')
+        click.echo(
+            f'  manifest regenerations: {n_manifest_regen} ({"sync" if run_sync else "enqueued"})'
+        )
+        if n_regen_failed:
+            click.echo(f'  regeneration failures:  {n_regen_failed}')

--- a/dandiapi/api/management/commands/sync_manifest_files.py
+++ b/dandiapi/api/management/commands/sync_manifest_files.py
@@ -37,6 +37,12 @@ _DUMMY_DOI_RE = re.compile(r'\.123456/0\.123456\.1234$')
 VERSION_CHOICES = ('draft', 'published', 'all')
 TARGET_CHOICES = ('dandiset', 'assets', 'both')
 
+# Outcomes of the per-version DOI repair step.
+DOI_SKIPPED = 'skipped'
+DOI_WOULD_FIX = 'would-fix'
+DOI_FIXED = 'fixed'
+DOI_FAILED = 'failed'
+
 
 def _is_dummy_doi(doi: str | None) -> bool:
     return bool(doi) and bool(_DUMMY_DOI_RE.search(doi))
@@ -123,19 +129,20 @@ def _assets_jsonld_matches(version: Version, *, show_diff: bool) -> tuple[bool, 
     return False, msg
 
 
-def _fix_missing_doi(version: Version, *, dry_run: bool) -> tuple[bool, str]:
+def _fix_missing_doi(version: Version, *, dry_run: bool) -> tuple[str, str]:
     """Re-mint the DOI for a published Version whose DOI is missing/placeholder.
 
-    Returns (changed, message).
+    Returns ``(status, message)``, where status is one of ``DOI_SKIPPED``,
+    ``DOI_WOULD_FIX``, ``DOI_FIXED`` or ``DOI_FAILED``.
     """
     if version.version == 'draft':
-        return False, ''
+        return DOI_SKIPPED, ''
     if version.doi and not _is_dummy_doi(version.doi):
-        return False, ''
+        return DOI_SKIPPED, ''
 
     reason = 'NULL' if not version.doi else 'placeholder'
     if dry_run:
-        return True, f'  DOI would be re-minted ({reason})'
+        return DOI_WOULD_FIX, f'  DOI would be re-minted ({reason})'
 
     try:
         new_doi = doi_module.create_doi(version)
@@ -146,13 +153,13 @@ def _fix_missing_doi(version: Version, *, dry_run: bool) -> tuple[bool, str]:
         # which would then make the immediately-following compare-to-S3 step
         # report a spurious mismatch. Re-load from the DB to discard it.
         version.refresh_from_db()
-        return False, f'  DOI remint FAILED ({reason}): {e}'
+        return DOI_FAILED, f'  DOI remint FAILED ({reason}): {e}'
 
     # Save doi column; Version.save() re-populates metadata with the real DOI
     # and a DOI-based citation.
     version.doi = new_doi
     version.save()
-    return True, f'  DOI re-minted ({reason}) -> {new_doi}'
+    return DOI_FIXED, f'  DOI re-minted ({reason}) -> {new_doi}'
 
 
 def _select_versions(
@@ -279,6 +286,21 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
     compare_dandiset = targets in ('dandiset', 'both')
     compare_assets = targets in ('assets', 'both')
 
+    # ``doi.create_doi`` computes the DOI string deterministically and only
+    # *registers* it with DataCite when all DANDI_DOI_API_* settings are set.
+    # Without them it would still return a well-formed DOI, which we would then
+    # persist and publish in the manifests -- advertising a DOI that resolves
+    # nowhere. That is worse than the NULL we are trying to repair, so refuse
+    # to touch DOIs at all in that case.
+    doi_unconfigured = fix_doi and not doi_module.doi_configured()
+    if doi_unconfigured:
+        fix_doi = False
+        click.echo(
+            'WARNING: DOI minting is not configured (DANDI_DOI_API_URL/USER/PASSWORD/PREFIX); '
+            'skipping DOI repair. Manifests are still reconciled.',
+            err=True,
+        )
+
     versions_qs = _select_versions(
         dandisets,
         include_all=include_all,
@@ -299,6 +321,7 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     n_doi_fixed = 0
     n_doi_would_fix = 0
+    n_doi_failed = 0
     n_manifest_mismatch = 0
     n_manifest_regen = 0
     n_regen_failed = 0
@@ -308,23 +331,21 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
         messages: list[str] = []
         need_regen = False
 
-        # 1) DOI fix (only for published versions; draft versions have no DOI,
-        # and skip if doi already looks OK).
-        if (
-            fix_doi
-            and version.version != 'draft'
-            and (not version.doi or _is_dummy_doi(version.doi))
-        ):
-            changed, msg = _fix_missing_doi(version, dry_run=dry_run)
+        # 1) DOI fix. ``_fix_missing_doi`` itself skips draft versions and
+        # versions whose DOI already looks fine.
+        if fix_doi:
+            status, msg = _fix_missing_doi(version, dry_run=dry_run)
             if msg:
                 messages.append(msg)
-            if changed:
-                if dry_run:
-                    n_doi_would_fix += 1
-                else:
-                    n_doi_fixed += 1
+            if status == DOI_WOULD_FIX:
+                n_doi_would_fix += 1
                 # DOI fix updates metadata -> manifest definitely needs rewrite
                 need_regen = True
+            elif status == DOI_FIXED:
+                n_doi_fixed += 1
+                need_regen = True
+            elif status == DOI_FAILED:
+                n_doi_failed += 1
 
         # 2) Compare manifests
         if compare_dandiset:
@@ -341,26 +362,29 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 n_manifest_mismatch += 1
                 messages.append(msg)
 
-        if not need_regen:
-            continue
+        if need_regen:
+            if dry_run:
+                messages.append('  -> would regenerate all manifest files')
+            else:
+                try:
+                    if run_sync:
+                        write_manifest_files(version.id)
+                    else:
+                        write_manifest_files.delay(version.id)
+                    n_manifest_regen += 1
+                    messages.append(
+                        '  -> regenerated all manifest files'
+                        if run_sync
+                        else '  -> enqueued manifest regeneration'
+                    )
+                except Exception as e:  # noqa: BLE001
+                    n_regen_failed += 1
+                    messages.append(f'  -> regeneration FAILED: {e}')
 
-        if dry_run:
-            messages.append('  -> would regenerate all manifest files')
-        else:
-            try:
-                if run_sync:
-                    write_manifest_files(version.id)
-                else:
-                    write_manifest_files.delay(version.id)
-                n_manifest_regen += 1
-                messages.append(
-                    '  -> regenerated all manifest files'
-                    if run_sync
-                    else '  -> enqueued manifest regeneration'
-                )
-            except Exception as e:  # noqa: BLE001
-                n_regen_failed += 1
-                messages.append(f'  -> regeneration FAILED: {e}')
+        # Report anything worth reporting -- in particular a failed DOI remint
+        # on a version whose manifests are otherwise in sync.
+        if not messages:
+            continue
 
         click.echo(f'{label}:')
         for m in messages:
@@ -375,8 +399,12 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
         click.echo('  (dry run: no changes made)')
     else:
         click.echo(f'  DOIs re-minted:         {n_doi_fixed}')
+        if n_doi_failed:
+            click.echo(f'  DOI remint failures:    {n_doi_failed}')
         click.echo(
             f'  manifest regenerations: {n_manifest_regen} ({"sync" if run_sync else "enqueued"})'
         )
         if n_regen_failed:
             click.echo(f'  regeneration failures:  {n_regen_failed}')
+    if doi_unconfigured:
+        click.echo('  (DOI repair skipped: DOI minting is not configured)')

--- a/dandiapi/api/management/commands/sync_manifest_files.py
+++ b/dandiapi/api/management/commands/sync_manifest_files.py
@@ -6,9 +6,10 @@ would be generated now from `version.metadata` / `version.assets` to what's
 currently stored on S3. If they differ (or if the S3 object is missing),
 trigger `write_manifest_files` to rewrite all manifest files for that version.
 
-Optionally also re-mint DOIs for published versions whose `version.doi` is
+Optionally also repair DOIs for published versions whose `version.doi` is
 NULL or equals the placeholder ``.../123456/0.123456.1234`` (symptom of a
-failed DOI creation at publish time).
+failed DOI creation at publish time): adopt the DOI if it turns out to be
+registered at DataCite already, otherwise mint it.
 
 Context: https://github.com/dandi/dandi-archive/issues/2759
 """
@@ -39,8 +40,10 @@ TARGET_CHOICES = ('dandiset', 'assets', 'both')
 
 # Outcomes of the per-version DOI repair step.
 DOI_SKIPPED = 'skipped'
-DOI_WOULD_FIX = 'would-fix'
-DOI_FIXED = 'fixed'
+DOI_WOULD_MINT = 'would-mint'
+DOI_WOULD_ADOPT = 'would-adopt'
+DOI_MINTED = 'minted'
+DOI_ADOPTED = 'adopted'
 DOI_FAILED = 'failed'
 
 
@@ -129,11 +132,44 @@ def _assets_jsonld_matches(version: Version, *, show_diff: bool) -> tuple[bool, 
     return False, msg
 
 
-def _fix_missing_doi(version: Version, *, dry_run: bool) -> tuple[str, str]:
-    """Re-mint the DOI for a published Version whose DOI is missing/placeholder.
+def _unadoptable_reason(version: Version, attributes: dict) -> str | None:
+    """Say why an existing DataCite record must not be adopted, or None if it can be.
+
+    Two ways a registered DOI is not the DOI we want to advertise:
+
+    * it describes something else -- a misconfigured prefix or instance name
+      would otherwise silently attach an unrelated DOI to this version. (A
+      version published before ``DANDI_WEB_APP_URL`` last changed also lands
+      here; that is a report-and-let-a-human-look case, not an auto-fix.)
+    * it is still a DataCite ``draft``, which does not resolve. Publishing a
+      dead doi.org link in the manifest is what we are trying to fix, not
+      something to introduce. Promoting it would mean writing to DataCite,
+      which this command deliberately never does.
+    """
+    expected_url = version.metadata.get('url')
+    actual_url = attributes.get('url')
+    if expected_url and actual_url and actual_url != expected_url:
+        return f'it points at {actual_url} rather than {expected_url}'
+
+    state = attributes.get('state')
+    if state == 'draft':
+        return 'it is still in DataCite "draft" state and would not resolve'
+
+    return None
+
+
+def _fix_missing_doi(version: Version, *, dry_run: bool) -> tuple[str, str]:  # noqa: PLR0911
+    """Repair the DOI of a published Version whose DOI is missing/placeholder.
+
+    The DOI string is deterministic, so a NULL ``version.doi`` does not mean
+    there is no DOI: publish may have minted one and then failed to persist it
+    (``services/publish`` logs exactly that). DataCite rejects a POST for an
+    already-registered DOI, so look the DOI up first and adopt what is already
+    there; only mint when nothing is registered.
 
     Returns ``(status, message)``, where status is one of ``DOI_SKIPPED``,
-    ``DOI_WOULD_FIX``, ``DOI_FIXED`` or ``DOI_FAILED``.
+    ``DOI_WOULD_MINT``, ``DOI_WOULD_ADOPT``, ``DOI_MINTED``, ``DOI_ADOPTED``
+    or ``DOI_FAILED``.
     """
     if version.version == 'draft':
         return DOI_SKIPPED, ''
@@ -141,8 +177,31 @@ def _fix_missing_doi(version: Version, *, dry_run: bool) -> tuple[str, str]:
         return DOI_SKIPPED, ''
 
     reason = 'NULL' if not version.doi else 'placeholder'
+    expected_doi = doi_module.doi_for_version(version)
+
+    # Read-only, so it runs under --dry-run too: that is what tells an operator
+    # how many versions need a mint vs. only a DB write.
+    try:
+        existing = doi_module.get_doi(expected_doi)
+    except Exception as e:  # noqa: BLE001
+        return DOI_FAILED, f'  DOI lookup FAILED ({reason}) for {expected_doi}: {e}'
+
+    if existing is not None:
+        unadoptable = _unadoptable_reason(version, existing)
+        if unadoptable:
+            return DOI_FAILED, (
+                f'  DOI {expected_doi} is registered at DataCite but {unadoptable}; not adopting'
+            )
+        if dry_run:
+            return DOI_WOULD_ADOPT, f'  DOI would be adopted ({reason}) -> {expected_doi}'
+        # Registered already: no DataCite write, just record it and let the
+        # manifest be rewritten with the DOI and a doi.org citation.
+        version.doi = expected_doi
+        version.save()
+        return DOI_ADOPTED, f'  DOI adopted from DataCite ({reason}) -> {expected_doi}'
+
     if dry_run:
-        return DOI_WOULD_FIX, f'  DOI would be re-minted ({reason})'
+        return DOI_WOULD_MINT, f'  DOI would be minted ({reason}) -> {expected_doi}'
 
     try:
         new_doi = doi_module.create_doi(version)
@@ -153,13 +212,13 @@ def _fix_missing_doi(version: Version, *, dry_run: bool) -> tuple[str, str]:
         # which would then make the immediately-following compare-to-S3 step
         # report a spurious mismatch. Re-load from the DB to discard it.
         version.refresh_from_db()
-        return DOI_FAILED, f'  DOI remint FAILED ({reason}): {e}'
+        return DOI_FAILED, f'  DOI mint FAILED ({reason}): {e}'
 
     # Save doi column; Version.save() re-populates metadata with the real DOI
     # and a DOI-based citation.
     version.doi = new_doi
     version.save()
-    return DOI_FIXED, f'  DOI re-minted ({reason}) -> {new_doi}'
+    return DOI_MINTED, f'  DOI minted ({reason}) -> {new_doi}'
 
 
 def _select_versions(
@@ -241,7 +300,8 @@ def _select_versions(
     'fix_doi',
     default=True,
     show_default=True,
-    help='Also re-mint DOIs for published versions whose version.doi is NULL or a placeholder.',
+    help='Also repair DOIs for published versions whose version.doi is NULL or a placeholder '
+    '(adopting an already-registered DataCite DOI in preference to minting a new one).',
 )
 @click.option(
     '--show-diff',
@@ -271,9 +331,11 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
     default the regeneration is enqueued via Celery (use ``--sync`` to run
     inline).
 
-    Optionally (on by default) re-mint DOIs for published versions whose
+    Optionally (on by default) repair DOIs for published versions whose
     ``version.doi`` column is NULL or is the publishing-time placeholder
-    (...`.123456/0.123456.1234`).
+    (...`.123456/0.123456.1234`). Because the DOI string is deterministic,
+    such a version may already have its DOI registered at DataCite; that one
+    is adopted (no DataCite write) and only a genuinely absent DOI is minted.
 
     Motivated by https://github.com/dandi/dandi-archive/issues/2759.
     """
@@ -319,8 +381,10 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
         f'async={not run_sync}, fix_doi={fix_doi}).'
     )
 
-    n_doi_fixed = 0
-    n_doi_would_fix = 0
+    n_doi_minted = 0
+    n_doi_adopted = 0
+    n_doi_would_mint = 0
+    n_doi_would_adopt = 0
     n_doi_failed = 0
     n_manifest_mismatch = 0
     n_manifest_regen = 0
@@ -337,12 +401,18 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
             status, msg = _fix_missing_doi(version, dry_run=dry_run)
             if msg:
                 messages.append(msg)
-            if status == DOI_WOULD_FIX:
-                n_doi_would_fix += 1
+            if status == DOI_WOULD_MINT:
+                n_doi_would_mint += 1
                 # DOI fix updates metadata -> manifest definitely needs rewrite
                 need_regen = True
-            elif status == DOI_FIXED:
-                n_doi_fixed += 1
+            elif status == DOI_WOULD_ADOPT:
+                n_doi_would_adopt += 1
+                need_regen = True
+            elif status == DOI_MINTED:
+                n_doi_minted += 1
+                need_regen = True
+            elif status == DOI_ADOPTED:
+                n_doi_adopted += 1
                 need_regen = True
             elif status == DOI_FAILED:
                 n_doi_failed += 1
@@ -381,7 +451,7 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     n_regen_failed += 1
                     messages.append(f'  -> regeneration FAILED: {e}')
 
-        # Report anything worth reporting -- in particular a failed DOI remint
+        # Report anything worth reporting -- in particular a failed DOI repair
         # on a version whose manifests are otherwise in sync.
         if not messages:
             continue
@@ -395,12 +465,16 @@ def sync_manifest_files(  # noqa: C901, PLR0912, PLR0913, PLR0915
     click.echo(f'  versions checked:       {total}')
     click.echo(f'  manifest mismatches:    {n_manifest_mismatch}')
     if dry_run:
-        click.echo(f'  DOIs to re-mint:        {n_doi_would_fix}')
+        click.echo(f'  DOIs to mint:           {n_doi_would_mint}')
+        click.echo(f'  DOIs to adopt:          {n_doi_would_adopt}')
+        if n_doi_failed:
+            click.echo(f'  DOI repair problems:    {n_doi_failed}')
         click.echo('  (dry run: no changes made)')
     else:
-        click.echo(f'  DOIs re-minted:         {n_doi_fixed}')
+        click.echo(f'  DOIs minted:            {n_doi_minted}')
+        click.echo(f'  DOIs adopted:           {n_doi_adopted}')
         if n_doi_failed:
-            click.echo(f'  DOI remint failures:    {n_doi_failed}')
+            click.echo(f'  DOI repair failures:    {n_doi_failed}')
         click.echo(
             f'  manifest regenerations: {n_manifest_regen} ({"sync" if run_sync else "enqueued"})'
         )

--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import logging
 from typing import TYPE_CHECKING
 
 from dandischema.conf import get_instance_config
@@ -28,6 +29,8 @@ from dandiapi.api.tasks import write_manifest_files
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
+
+logger = logging.getLogger(__name__)
 
 
 def publish_asset(*, asset: Asset) -> None:
@@ -190,16 +193,38 @@ def _publish_dandiset(dandiset_id: int, user_id: int) -> None:
 
         validate(new_version.metadata, schema_key='PublishedDandiset', json_validation=True)
 
-        # Write updated manifest files and create DOI after
-        # published version has been committed to DB.
-        transaction.on_commit(lambda: write_manifest_files.delay(new_version.id))
-
-        def _create_doi(version_id: int):
+        # After the published version is committed, mint the DOI first and
+        # only then write the manifest files. Doing these as two independent
+        # ``on_commit`` callbacks raced — the manifest task could run before
+        # the DOI was saved, leaving ``dandiset.jsonld`` on S3 without
+        # ``doi`` (and with a non-DOI ``citation``) and never rewritten. See
+        # https://github.com/dandi/dandi-archive/issues/2759.
+        #
+        # Failures at either substep are logged distinctly but do not abort
+        # the manifest write: even a DOI-less published version is better
+        # represented by an on-S3 manifest than by nothing.
+        # ``sync_manifest_files --fix-doi`` can later remint the DOI and
+        # rewrite the manifest if either substep below was skipped or failed.
+        def _create_doi_and_write_manifests(version_id: int):
             version = Version.objects.get(id=version_id)
-            version.doi = doi.create_doi(version)
-            version.save()
+            new_doi: str | None = None
+            try:
+                new_doi = doi.create_doi(version)
+            except Exception:
+                logger.exception('Failed to mint DOI for version %s', version_id)
+            if new_doi is not None:
+                try:
+                    version.doi = new_doi
+                    version.save()
+                except Exception:
+                    logger.exception(
+                        'Minted DOI %s but failed to persist it on version %s',
+                        new_doi,
+                        version_id,
+                    )
+            write_manifest_files.delay(version_id)
 
-        transaction.on_commit(lambda: _create_doi(new_version.id))
+        transaction.on_commit(lambda: _create_doi_and_write_manifests(new_version.id))
 
         user = User.objects.get(id=user_id)
         audit.publish_dandiset(

--- a/dandiapi/api/tests/test_sync_manifest_files.py
+++ b/dandiapi/api/tests/test_sync_manifest_files.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import json
+
+import click
+from django.core.files.storage import default_storage
+import pytest
+
+from dandiapi.api import doi as doi_module
+from dandiapi.api.management.commands.sync_manifest_files import (
+    _is_dummy_doi,
+    sync_manifest_files,
+)
+from dandiapi.api.manifests import _assets_jsonld_path, _dandiset_jsonld_path
+from dandiapi.api.models import Version
+from dandiapi.api.models.dandiset import Dandiset
+from dandiapi.api.tasks import write_manifest_files
+from dandiapi.api.tests.factories import (
+    DandisetFactory,
+    DraftVersionFactory,
+    PublishedAssetFactory,
+    PublishedVersionFactory,
+)
+
+# A deterministic synthetic DOI used for tests that exercise the DOI-remint
+# code path. The real ``doi.create_doi`` runs ``to_datacite()`` which performs
+# full ``PublishedDandiset`` pydantic validation; faker-generated metadata
+# does not satisfy that schema, so we monkeypatch ``create_doi`` rather than
+# relying on the offline-mode shortcut to short-circuit it.
+_FAKE_DOI = '10.80507/dandi.000001/0.250506.1234'
+
+
+def _read_jsonld(path: str):
+    with default_storage.open(path) as f:
+        return json.loads(f.read())
+
+
+def _seed(version: Version) -> None:
+    """Render and upload the full set of manifest files for ``version``."""
+    write_manifest_files(version.id)
+
+
+def _install_fake_create_doi(monkeypatch, value: str = _FAKE_DOI) -> None:
+    """Replace ``doi.create_doi`` with a deterministic, no-op shim.
+
+    Mirrors the side effect the real function has on ``version.metadata``
+    via ``_generate_doi_data`` so subsequent ``Version.save()`` calls see
+    the same in-memory state they would in production.
+    """
+
+    def _shim(version):
+        version.metadata['doi'] = value
+        return value
+
+    monkeypatch.setattr(doi_module, 'create_doi', _shim)
+
+
+# ---------------------------------------------------------------------------
+# Pure-unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        (None, False),
+        ('', False),
+        ('10.48324/dandi.000027/0.210831.2033', False),
+        ('10.80507/dandi.123456/0.123456.1234', True),
+        ('10.48324/dandi.123456/0.123456.1234', True),
+        # The suffix anchor (``\.1234$``) means an additional trailing digit
+        # disqualifies it.
+        ('10.80507/dandi.123456/0.123456.12345', False),
+    ],
+)
+def test_is_dummy_doi(value, expected):
+    assert _is_dummy_doi(value) is expected
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: MinIO + Django DB + eager Celery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_no_change_when_in_sync(draft_asset_factory, capsys):
+    """When S3 matches the DB, the command must not rewrite anything."""
+    version = DraftVersionFactory.create()
+    version.assets.add(draft_asset_factory())
+    _seed(version)
+
+    path = _dandiset_jsonld_path(version)
+    before = _read_jsonld(path)
+
+    sync_manifest_files(str(version.dandiset_id), '--targets', 'dandiset')
+
+    assert _read_jsonld(path) == before
+    out = capsys.readouterr().out
+    assert 'manifest mismatches:    0' in out
+
+
+@pytest.mark.django_db
+def test_detects_and_repairs_drift_in_dandiset_jsonld(draft_asset_factory):
+    """If the on-S3 manifest is stale, the command must regenerate it."""
+    version = DraftVersionFactory.create()
+    version.assets.add(draft_asset_factory())
+    _seed(version)
+
+    path = _dandiset_jsonld_path(version)
+    assert 'NEW DESCRIPTION' not in (_read_jsonld(path).get('description') or '')
+
+    version.metadata['description'] = 'NEW DESCRIPTION'
+    version.save()
+    version.refresh_from_db()
+
+    sync_manifest_files(str(version.dandiset_id), '--targets', 'dandiset')
+
+    after = _read_jsonld(path)
+    assert after['description'] == 'NEW DESCRIPTION'
+    assert after == version.metadata
+
+
+@pytest.mark.django_db
+def test_dry_run_does_not_write(draft_asset_factory, capsys):
+    version = DraftVersionFactory.create()
+    version.assets.add(draft_asset_factory())
+    _seed(version)
+
+    path = _dandiset_jsonld_path(version)
+    snapshot = _read_jsonld(path)
+
+    version.metadata['description'] = 'WOULD BE WRITTEN'
+    version.save()
+
+    sync_manifest_files(
+        str(version.dandiset_id),
+        '--targets',
+        'dandiset',
+        '--dry-run',
+    )
+
+    # S3 is untouched
+    assert _read_jsonld(path) == snapshot
+    # ... but the command reported what it would have done
+    out = capsys.readouterr().out
+    assert 'would regenerate' in out
+
+
+@pytest.mark.django_db
+def test_missing_s3_object_treated_as_mismatch(draft_asset_factory):
+    version = DraftVersionFactory.create()
+    version.assets.add(draft_asset_factory())
+    _seed(version)
+
+    path = _dandiset_jsonld_path(version)
+    default_storage.delete(path)
+    assert not default_storage.exists(path)
+
+    sync_manifest_files(str(version.dandiset_id), '--targets', 'dandiset')
+
+    assert default_storage.exists(path)
+    assert _read_jsonld(path) == version.metadata
+
+
+@pytest.mark.django_db
+def test_targets_assets_compares_assets_jsonld():
+    version = DraftVersionFactory.create()
+    version.assets.add(PublishedAssetFactory.create())
+    _seed(version)
+
+    assets_path = _assets_jsonld_path(version)
+    assert _read_jsonld(assets_path) == [a.full_metadata for a in version.assets.all()]
+
+    # Add a new asset so DB and S3 diverge for assets.jsonld.
+    version.assets.add(PublishedAssetFactory.create())
+
+    sync_manifest_files(str(version.dandiset_id), '--targets', 'assets')
+
+    assert _read_jsonld(assets_path) == [a.full_metadata for a in version.assets.all()]
+
+
+@pytest.mark.django_db
+def test_targets_both_regenerates_when_either_differs():
+    """``--targets=both`` must regenerate if either of the two manifests is stale."""
+    version = DraftVersionFactory.create()
+    version.assets.add(PublishedAssetFactory.create())
+    _seed(version)
+
+    dandiset_path = _dandiset_jsonld_path(version)
+    assets_path = _assets_jsonld_path(version)
+    dandiset_before = _read_jsonld(dandiset_path)
+
+    # Drift only on the dandiset side; assets.jsonld is still in sync.
+    version.metadata['description'] = 'BOTH-MODE DRIFT'
+    version.save()
+
+    sync_manifest_files(str(version.dandiset_id), '--targets', 'both')
+
+    # dandiset.jsonld got the update
+    after = _read_jsonld(dandiset_path)
+    assert after != dandiset_before
+    assert after['description'] == 'BOTH-MODE DRIFT'
+    # assets.jsonld is still consistent with the DB (write_manifest_files
+    # rewrites all five anyway, so this exercises that path too).
+    assert _read_jsonld(assets_path) == [a.full_metadata for a in version.assets.all()]
+
+
+@pytest.mark.django_db
+def test_doi_remint_fills_null_doi_on_published_version(monkeypatch):
+    """A published version with a NULL doi should be re-minted by default."""
+    _install_fake_create_doi(monkeypatch)
+
+    version = PublishedVersionFactory.create(doi=None)
+    version.metadata.pop('doi', None)
+    Version.objects.filter(id=version.id).update(metadata=version.metadata)
+    _seed(version)
+    version.refresh_from_db()
+    assert version.doi is None
+
+    sync_manifest_files(str(version.dandiset_id), '--version', 'published')
+
+    version.refresh_from_db()
+    assert version.doi == _FAKE_DOI
+    s3 = _read_jsonld(_dandiset_jsonld_path(version))
+    assert s3.get('doi') == _FAKE_DOI
+    assert _FAKE_DOI in s3.get('citation', '')
+
+
+@pytest.mark.django_db
+def test_doi_remint_replaces_placeholder_doi(monkeypatch):
+    _install_fake_create_doi(monkeypatch)
+
+    placeholder = '10.80507/dandi.123456/0.123456.1234'
+    version = PublishedVersionFactory.create(doi=placeholder)
+    version.metadata['doi'] = placeholder
+    Version.objects.filter(id=version.id).update(metadata=version.metadata)
+    _seed(version)
+
+    sync_manifest_files(str(version.dandiset_id), '--version', 'published')
+
+    version.refresh_from_db()
+    assert version.doi == _FAKE_DOI
+    assert not _is_dummy_doi(version.doi)
+
+
+@pytest.mark.django_db
+def test_no_fix_doi_skips_doi_repair():
+    """``--no-fix-doi`` must leave a NULL DOI untouched even on a published version."""
+    version = PublishedVersionFactory.create(doi=None)
+    version.metadata.pop('doi', None)
+    Version.objects.filter(id=version.id).update(metadata=version.metadata)
+    _seed(version)
+
+    sync_manifest_files(
+        str(version.dandiset_id),
+        '--version',
+        'published',
+        '--no-fix-doi',
+    )
+
+    version.refresh_from_db()
+    assert version.doi is None
+
+
+@pytest.mark.django_db
+def test_doi_remint_failure_is_reported_not_fatal(monkeypatch, capsys):
+    version = PublishedVersionFactory.create(doi=None)
+    version.metadata.pop('doi', None)
+    Version.objects.filter(id=version.id).update(metadata=version.metadata)
+    _seed(version)
+
+    def _boom(_v):
+        raise RuntimeError('datacite is on fire')
+
+    monkeypatch.setattr(doi_module, 'create_doi', _boom)
+
+    # Must not raise.
+    sync_manifest_files(str(version.dandiset_id), '--version', 'published')
+
+    out = capsys.readouterr().out
+    assert 'DOI remint FAILED' in out
+
+    version.refresh_from_db()
+    assert version.doi is None
+
+
+@pytest.mark.django_db
+def test_version_filter_published_skips_drafts(draft_asset_factory):
+    """``--version=published`` must not touch draft versions."""
+    dandiset = DandisetFactory.create()
+    draft = DraftVersionFactory.create(dandiset=dandiset)
+    draft.assets.add(draft_asset_factory())
+    published = PublishedVersionFactory.create(dandiset=dandiset)
+    _seed(draft)
+    _seed(published)
+
+    draft_path = _dandiset_jsonld_path(draft)
+    pub_path = _dandiset_jsonld_path(published)
+    draft_before = _read_jsonld(draft_path)
+
+    draft.metadata['description'] = 'STALE DRAFT'
+    draft.save()
+    published.metadata['description'] = 'STALE PUB'
+    published.save()
+
+    sync_manifest_files(
+        str(dandiset.id),
+        '--version',
+        'published',
+        '--no-fix-doi',
+        '--targets',
+        'dandiset',
+    )
+
+    assert _read_jsonld(draft_path) == draft_before
+    assert _read_jsonld(pub_path)['description'] == 'STALE PUB'
+
+
+@pytest.mark.django_db
+def test_version_filter_draft_skips_published(draft_asset_factory):
+    """``--version=draft`` must not touch published versions."""
+    dandiset = DandisetFactory.create()
+    draft = DraftVersionFactory.create(dandiset=dandiset)
+    draft.assets.add(draft_asset_factory())
+    published = PublishedVersionFactory.create(dandiset=dandiset)
+    _seed(draft)
+    _seed(published)
+
+    draft_path = _dandiset_jsonld_path(draft)
+    pub_path = _dandiset_jsonld_path(published)
+    pub_before = _read_jsonld(pub_path)
+
+    draft.metadata['description'] = 'STALE DRAFT'
+    draft.save()
+    published.metadata['description'] = 'STALE PUB'
+    published.save()
+
+    sync_manifest_files(
+        str(dandiset.id),
+        '--version',
+        'draft',
+        '--targets',
+        'dandiset',
+    )
+
+    assert _read_jsonld(pub_path) == pub_before
+    assert _read_jsonld(draft_path)['description'] == 'STALE DRAFT'
+
+
+@pytest.mark.django_db
+def test_specific_version_overrides_version_filter(draft_asset_factory):
+    """``--specific-version=<ver>`` selects exactly that version, overriding --version."""
+    dandiset = DandisetFactory.create()
+    v1 = PublishedVersionFactory.create(dandiset=dandiset)
+    v2 = PublishedVersionFactory.create(dandiset=dandiset)
+    _seed(v1)
+    _seed(v2)
+
+    v1_path = _dandiset_jsonld_path(v1)
+    v2_path = _dandiset_jsonld_path(v2)
+    v2_before = _read_jsonld(v2_path)
+
+    v1.metadata['description'] = 'V1 NEW'
+    v1.save()
+    v2.metadata['description'] = 'V2 NEW'
+    v2.save()
+
+    sync_manifest_files(
+        str(dandiset.id),
+        '--specific-version',
+        v1.version,
+        '--no-fix-doi',
+        '--targets',
+        'dandiset',
+    )
+
+    assert _read_jsonld(v1_path)['description'] == 'V1 NEW'
+    # v2 is still the pre-update content on S3 (untouched by this run).
+    assert _read_jsonld(v2_path) == v2_before
+
+
+@pytest.mark.django_db
+def test_dandiset_arg_filter_only_touches_named_dandiset(draft_asset_factory):
+    a = DraftVersionFactory.create()
+    b = DraftVersionFactory.create()
+    a.assets.add(draft_asset_factory())
+    b.assets.add(draft_asset_factory())
+    _seed(a)
+    _seed(b)
+
+    a_path = _dandiset_jsonld_path(a)
+    b_path = _dandiset_jsonld_path(b)
+    b_before = _read_jsonld(b_path)
+
+    a.metadata['description'] = 'A NEW'
+    a.save()
+    b.metadata['description'] = 'B NEW'
+    b.save()
+
+    sync_manifest_files(str(a.dandiset_id), '--targets', 'dandiset')
+
+    assert _read_jsonld(a_path)['description'] == 'A NEW'
+    assert _read_jsonld(b_path) == b_before
+
+
+@pytest.mark.django_db
+def test_all_flag_processes_every_dandiset(draft_asset_factory, capsys):
+    """``--all`` with one stale and one in-sync dandiset: only the stale one regenerates."""
+    stale = DraftVersionFactory.create()
+    fresh = DraftVersionFactory.create()
+    stale.assets.add(draft_asset_factory())
+    fresh.assets.add(draft_asset_factory())
+    _seed(stale)
+    _seed(fresh)
+
+    fresh_path = _dandiset_jsonld_path(fresh)
+    fresh_snapshot = _read_jsonld(fresh_path)
+
+    stale.metadata['description'] = 'STALE'
+    stale.save()
+
+    sync_manifest_files('--all', '--targets', 'dandiset', '--no-fix-doi')
+
+    assert _read_jsonld(_dandiset_jsonld_path(stale))['description'] == 'STALE'
+    assert _read_jsonld(fresh_path) == fresh_snapshot
+    out = capsys.readouterr().out
+    assert 'manifest mismatches:    1' in out
+
+
+@pytest.mark.django_db
+def test_show_diff_prints_unified_diff(draft_asset_factory, capsys):
+    version = DraftVersionFactory.create()
+    version.assets.add(draft_asset_factory())
+    _seed(version)
+
+    version.metadata['description'] = 'DIFF SHOULD APPEAR'
+    version.save()
+
+    sync_manifest_files(
+        str(version.dandiset_id),
+        '--targets',
+        'dandiset',
+        '--dry-run',
+        '--show-diff',
+    )
+
+    out = capsys.readouterr().out
+    assert 'dandiset.jsonld (S3)' in out
+    assert 'dandiset.jsonld (expected from DB)' in out
+    # Sanity: the diff body itself references the changed value
+    assert 'DIFF SHOULD APPEAR' in out
+
+
+@pytest.mark.django_db
+def test_mutually_exclusive_args():
+    """Either --all or dandiset IDs must be specified, not both, not neither."""
+    with pytest.raises(click.ClickException):
+        sync_manifest_files()  # neither
+
+    with pytest.raises(click.ClickException):
+        sync_manifest_files('--all', '1')  # both
+
+
+@pytest.mark.django_db
+def test_embargoed_manifest_is_re_tagged_on_regeneration(draft_asset_factory):
+    version = DraftVersionFactory.create(
+        dandiset__embargo_status=Dandiset.EmbargoStatus.EMBARGOED,
+    )
+    version.assets.add(draft_asset_factory())
+    _seed(version)
+    path = _dandiset_jsonld_path(version)
+    assert default_storage.get_tags(path) == {'embargoed': 'true'}
+
+    version.metadata['description'] = 'CHANGED'
+    version.save()
+
+    sync_manifest_files(str(version.dandiset_id), '--targets', 'dandiset')
+
+    assert default_storage.get_tags(path) == {'embargoed': 'true'}
+    assert _read_jsonld(path)['description'] == 'CHANGED'

--- a/dandiapi/api/tests/test_sync_manifest_files.py
+++ b/dandiapi/api/tests/test_sync_manifest_files.py
@@ -40,6 +40,16 @@ def _seed(version: Version) -> None:
     write_manifest_files(version.id)
 
 
+def _pretend_doi_configured(monkeypatch) -> None:
+    """Make the command believe DataCite credentials are present.
+
+    They are not under test settings, and the command refuses to touch DOIs
+    without them (an unregistered DOI in a published manifest is worse than
+    the NULL it would replace).
+    """
+    monkeypatch.setattr(doi_module, 'doi_configured', lambda: True)
+
+
 def _install_fake_create_doi(monkeypatch, value: str = _FAKE_DOI) -> None:
     """Replace ``doi.create_doi`` with a deterministic, no-op shim.
 
@@ -52,6 +62,7 @@ def _install_fake_create_doi(monkeypatch, value: str = _FAKE_DOI) -> None:
         version.metadata['doi'] = value
         return value
 
+    _pretend_doi_configured(monkeypatch)
     monkeypatch.setattr(doi_module, 'create_doi', _shim)
 
 
@@ -272,16 +283,39 @@ def test_doi_remint_failure_is_reported_not_fatal(monkeypatch, capsys):
     def _boom(_v):
         raise RuntimeError('datacite is on fire')
 
+    _pretend_doi_configured(monkeypatch)
     monkeypatch.setattr(doi_module, 'create_doi', _boom)
 
     # Must not raise.
     sync_manifest_files(str(version.dandiset_id), '--version', 'published')
 
     out = capsys.readouterr().out
+    # Reported even though the manifests themselves are in sync and nothing
+    # needed to be regenerated for this version.
     assert 'DOI remint FAILED' in out
+    assert 'DOI remint failures:    1' in out
 
     version.refresh_from_db()
     assert version.doi is None
+
+
+@pytest.mark.django_db
+def test_doi_repair_skipped_when_doi_not_configured(capsys):
+    """Without DataCite credentials the command must not invent DOIs."""
+    version = PublishedVersionFactory.create(doi=None)
+    version.metadata.pop('doi', None)
+    Version.objects.filter(id=version.id).update(metadata=version.metadata)
+    _seed(version)
+
+    # Test settings leave DANDI_DOI_API_URL/USER/PASSWORD unset, so
+    # ``doi.doi_configured()`` is False here without any patching.
+    sync_manifest_files(str(version.dandiset_id), '--version', 'published')
+
+    version.refresh_from_db()
+    assert version.doi is None
+    captured = capsys.readouterr()
+    assert 'DOI minting is not configured' in captured.err
+    assert 'DOI repair skipped' in captured.out
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_sync_manifest_files.py
+++ b/dandiapi/api/tests/test_sync_manifest_files.py
@@ -40,6 +40,10 @@ def _seed(version: Version) -> None:
     write_manifest_files(version.id)
 
 
+def _never_mint(_version):
+    raise AssertionError('create_doi must not be called in this scenario')
+
+
 def _pretend_doi_configured(monkeypatch) -> None:
     """Make the command believe DataCite credentials are present.
 
@@ -63,6 +67,8 @@ def _install_fake_create_doi(monkeypatch, value: str = _FAKE_DOI) -> None:
         return value
 
     _pretend_doi_configured(monkeypatch)
+    # Nothing registered at DataCite yet, so the command mints rather than adopts.
+    monkeypatch.setattr(doi_module, 'get_doi', lambda _doi: None)
     monkeypatch.setattr(doi_module, 'create_doi', _shim)
 
 
@@ -284,6 +290,7 @@ def test_doi_remint_failure_is_reported_not_fatal(monkeypatch, capsys):
         raise RuntimeError('datacite is on fire')
 
     _pretend_doi_configured(monkeypatch)
+    monkeypatch.setattr(doi_module, 'get_doi', lambda _doi: None)
     monkeypatch.setattr(doi_module, 'create_doi', _boom)
 
     # Must not raise.
@@ -292,8 +299,8 @@ def test_doi_remint_failure_is_reported_not_fatal(monkeypatch, capsys):
     out = capsys.readouterr().out
     # Reported even though the manifests themselves are in sync and nothing
     # needed to be regenerated for this version.
-    assert 'DOI remint FAILED' in out
-    assert 'DOI remint failures:    1' in out
+    assert 'DOI mint FAILED' in out
+    assert 'DOI repair failures:    1' in out
 
     version.refresh_from_db()
     assert version.doi is None
@@ -316,6 +323,118 @@ def test_doi_repair_skipped_when_doi_not_configured(capsys):
     captured = capsys.readouterr()
     assert 'DOI minting is not configured' in captured.err
     assert 'DOI repair skipped' in captured.out
+
+
+def _published_version_without_doi() -> Version:
+    version = PublishedVersionFactory.create(doi=None)
+    version.metadata.pop('doi', None)
+    Version.objects.filter(id=version.id).update(metadata=version.metadata)
+    _seed(version)
+    version.refresh_from_db()
+    return version
+
+
+@pytest.mark.django_db
+def test_doi_already_registered_is_adopted_not_reminted(monkeypatch):
+    """A DOI minted at publish time but never persisted must be adopted, not re-POSTed.
+
+    DataCite rejects a POST for an existing DOI, so minting again would fail
+    and leave the version NULL forever.
+    """
+    version = _published_version_without_doi()
+    expected_doi = doi_module.doi_for_version(version)
+
+    _pretend_doi_configured(monkeypatch)
+    monkeypatch.setattr(
+        doi_module,
+        'get_doi',
+        lambda doi: (
+            {'url': version.metadata['url'], 'state': 'findable'} if doi == expected_doi else None
+        ),
+    )
+
+    def _must_not_be_called(_v):
+        raise AssertionError('create_doi must not be called for an already-registered DOI')
+
+    monkeypatch.setattr(doi_module, 'create_doi', _must_not_be_called)
+
+    sync_manifest_files(str(version.dandiset_id), '--version', 'published')
+
+    version.refresh_from_db()
+    assert version.doi == expected_doi
+    # ... and the manifest was rewritten with it.
+    s3 = _read_jsonld(_dandiset_jsonld_path(version))
+    assert s3['doi'] == expected_doi
+    assert expected_doi in s3['citation']
+
+
+@pytest.mark.django_db
+def test_registered_doi_pointing_elsewhere_is_not_adopted(monkeypatch, capsys):
+    """A DataCite record describing something else must never be attached."""
+    version = _published_version_without_doi()
+
+    _pretend_doi_configured(monkeypatch)
+    monkeypatch.setattr(
+        doi_module,
+        'get_doi',
+        lambda _doi: {'url': 'https://example.org/somebody/elses/thing', 'state': 'findable'},
+    )
+    monkeypatch.setattr(doi_module, 'create_doi', _never_mint)
+
+    sync_manifest_files(str(version.dandiset_id), '--version', 'published')
+
+    version.refresh_from_db()
+    assert version.doi is None
+    out = capsys.readouterr().out
+    assert 'not adopting' in out
+    assert 'DOI repair failures:    1' in out
+
+
+@pytest.mark.django_db
+def test_draft_state_doi_is_not_adopted(monkeypatch, capsys):
+    """A DataCite ``draft`` DOI does not resolve, so it must not reach the manifest."""
+    version = _published_version_without_doi()
+
+    _pretend_doi_configured(monkeypatch)
+    monkeypatch.setattr(
+        doi_module,
+        'get_doi',
+        lambda _doi: {'url': version.metadata['url'], 'state': 'draft'},
+    )
+    monkeypatch.setattr(doi_module, 'create_doi', _never_mint)
+
+    sync_manifest_files(str(version.dandiset_id), '--version', 'published')
+
+    version.refresh_from_db()
+    assert version.doi is None
+    assert 'draft' in capsys.readouterr().out
+
+
+@pytest.mark.django_db
+def test_dry_run_distinguishes_mint_from_adopt(monkeypatch, capsys):
+    """``--dry-run`` is the measurement tool: how many need DataCite, how many just the DB."""
+    to_adopt = _published_version_without_doi()
+    to_mint = _published_version_without_doi()
+    adoptable_doi = doi_module.doi_for_version(to_adopt)
+
+    _pretend_doi_configured(monkeypatch)
+    monkeypatch.setattr(
+        doi_module,
+        'get_doi',
+        lambda doi: (
+            {'url': to_adopt.metadata['url'], 'state': 'findable'} if doi == adoptable_doi else None
+        ),
+    )
+    monkeypatch.setattr(doi_module, 'create_doi', _never_mint)
+
+    sync_manifest_files('--all', '--version', 'published', '--dry-run')
+
+    for version in (to_adopt, to_mint):
+        version.refresh_from_db()
+        assert version.doi is None
+    out = capsys.readouterr().out
+    assert 'DOIs to mint:           1' in out
+    assert 'DOIs to adopt:          1' in out
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import hashlib
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,7 @@ from zarr_checksum.checksum import EMPTY_CHECKSUM
 from zarr_checksum.generators import ZarrArchiveFile
 
 from dandiapi.api import tasks
+from dandiapi.api.manifests import _dandiset_jsonld_path
 from dandiapi.api.models import Asset, Version
 from dandiapi.api.tests.factories import DraftVersionFactory, UserFactory
 from dandiapi.zarr.models import ZarrArchiveStatus
@@ -448,3 +450,38 @@ def test_publish_task(
     assert new_published_asset.path == old_published_asset.path
     assert new_published_asset.blob == old_published_asset.blob
     assert new_published_asset.metadata == old_published_asset.metadata
+
+
+@pytest.mark.django_db
+def test_publish_task_writes_doi_into_manifest(
+    draft_asset_factory,
+    published_asset_factory,
+    django_capture_on_commit_callbacks,
+):
+    """The published dandiset.jsonld must carry the DOI minted at publish time.
+
+    Regression test for dandi/dandi-archive#2759: the manifest write used to be
+    enqueued from an ``on_commit`` callback independent of the one minting the
+    DOI, so it could run before ``version.doi`` was saved -- leaving ``doi:
+    null`` and a non-DOI ``citation`` in the on-S3 manifest forever.
+    """
+    user = UserFactory.create()
+    draft_version: Version = DraftVersionFactory.create(
+        status=Version.Status.PUBLISHING, dandiset__owners=[user]
+    )
+    draft_version.assets.set(
+        [draft_asset_factory(status=Asset.Status.VALID), published_asset_factory()]
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        tasks.publish_dandiset_task(draft_version.dandiset.id, user.id)
+
+    published_version: Version = draft_version.dandiset.versions.exclude(version='draft').get()
+    assert published_version.doi
+
+    with default_storage.open(_dandiset_jsonld_path(published_version)) as f:
+        manifest = json.loads(f.read())
+
+    assert manifest['doi'] == published_version.doi
+    assert published_version.doi in manifest['citation']
+    assert manifest == published_version.metadata

--- a/doc/design/manifests-consistency.md
+++ b/doc/design/manifests-consistency.md
@@ -1,0 +1,297 @@
+# Manifest consistency on S3
+
+Author: Yaroslav O. Halchenko (with Claude Code assistance)
+
+Tracking issue: [dandi/dandi-archive#2759](https://github.com/dandi/dandi-archive/issues/2759)
+
+## Overview
+
+For every Dandiset version the archive writes five manifest files under
+`dandisets/<dandiset_id>/<version>/` on S3:
+
+- `dandiset.jsonld`
+- `assets.jsonld`
+- `dandiset.yaml`
+- `assets.yaml`
+- `collection.jsonld`
+
+These are intended to be a faithful, dereferenceable, on-S3 representation of
+the metadata that the Django archive holds for that version. Several
+deployments and downstream consumers (e.g. `linkml`-ification efforts, mirrors,
+the `dandiset-manifests` clone at `drogon`) treat the S3 copy as authoritative.
+
+Issue #2759 documented two failure modes:
+
+1. **Missing or placeholder DOIs** in published `dandiset.jsonld` files — for
+   most recently published versions the `doi` field is `null` or, in a small
+   number of older publications, the publish-time placeholder
+   `10.80507/dandi.123456/0.123456.1234`.
+2. **Drift between S3 and the database** — older manifests can disagree with
+   the current DB state in fields that are recomputed (`assetsSummary`,
+   `citation`, `manifestLocation`, etc.) or were corrected post-publish (e.g.
+   the affiliation-corruption migration handled by
+   `correct_metadata`).
+
+A reproducer script attached to the issue compares
+`https://dandiarchive.s3.amazonaws.com/dandisets/<id>/<ver>/dandiset.jsonld`
+against `https://api.dandiarchive.org/api/dandisets/<id>/versions/<ver>/`.
+
+## Root cause analysis
+
+### Missing DOIs — race in `_publish_dandiset`
+
+In `dandiapi/api/services/publish/__init__.py` the publish path schedules two
+*independent* `transaction.on_commit` callbacks:
+
+```python
+transaction.on_commit(lambda: write_manifest_files.delay(new_version.id))
+
+def _create_doi(version_id: int):
+    version = Version.objects.get(id=version_id)
+    version.doi = doi.create_doi(version)
+    version.save()
+
+transaction.on_commit(lambda: _create_doi(new_version.id))
+```
+
+Sequence at runtime, after the publish transaction commits:
+
+1. `write_manifest_files.delay(new_version.id)` is **enqueued** to the celery
+   broker (returns immediately).
+2. `_create_doi(new_version.id)` runs **synchronously** in the publish task,
+   issuing an HTTP request to DataCite and then `version.save()`-ing the
+   result. `Version.save()` calls `_populate_metadata`, which copies
+   `self.doi` into `metadata['doi']` and rebuilds `citation`.
+
+There is no ordering between (1) and (2). A celery worker that picks up the
+manifest task can read `Version` from the DB before the DOI commit lands. The
+result is a published `dandiset.jsonld` written from a version whose
+`metadata` does not yet contain `doi`, and consequently has the
+non-DOI form of `citation`. **Nothing re-runs `write_manifest_files` after
+`_create_doi` saves the DOI**, so the stale manifest persists indefinitely.
+
+Notes:
+
+- The "dummy DOI" injected at lines ~187 of `_publish_dandiset` is set on the
+  in-memory `new_version.metadata` purely to make the `validate(...)` call
+  pass. The publish path does not `save()` the new version after that
+  injection (the last preceding `save()` had `self.doi=None`, so
+  `_populate_metadata` did not propagate the dummy into the persisted
+  metadata), so it does not normally end up in the manifest. The handful
+  of older manifests that do contain it are an artifact of an earlier
+  publish code path that *did* persist the placeholder.
+- If `_create_doi` itself fails (DataCite outage, network), `version.doi`
+  stays `NULL` in the DB and is never retried; the manifest is then
+  permanently DOI-less even from the DB's point of view.
+
+### Drift on older manifests
+
+Independently of DOIs, any change to `Version.metadata` that does not
+trigger `write_manifest_files` (schema migrations, `correct_metadata`,
+`migrate_published_version_metadata`, manual fixups, recomputations of
+`assetsSummary`) will leave the on-S3 manifest stale. Issue #2759 shows
+000004's draft as an example: the S3 `assetsSummary` is `{numberOfBytes:0,
+numberOfFiles:0}` while the API has the populated summary.
+
+## Plan
+
+The work splits into three deliverables. Only #1 is in scope for the
+present change.
+
+### 1. New management command: `sync_manifest_files`
+
+Path: `dandiapi/api/management/commands/sync_manifest_files.py`
+
+Purpose: reconcile S3 manifests against the database. For each selected
+Version, parse the on-S3 `dandiset.jsonld` and/or `assets.jsonld`, compare
+to what the current `Version.metadata` / `Version.assets` would render, and
+if they differ (or if the S3 object is missing), invoke
+`write_manifest_files(version.id)` to rewrite all five manifest files.
+Optionally re-mint DOIs for published versions whose `Version.doi` is `NULL`
+or matches the placeholder.
+
+Surface (current):
+
+```
+./manage.py sync_manifest_files [DANDISET_ID …] [-a/--all]
+    [--version draft|published|all]      # default: all
+    [--specific-version VER]              # overrides --version
+    [--targets dandiset|assets|both]      # default: dandiset
+    [--dry-run / --check]
+    [--sync / --async]                    # default: --async
+    [--fix-doi / --no-fix-doi]            # default: --fix-doi
+    [--show-diff]
+```
+
+Defaults follow operational ergonomics for the live deployment:
+
+- `--targets=dandiset` is the cheap default; comparing every
+  `assets.jsonld` for every version is expensive (large dandisets).
+- `--async` enqueues regenerations via celery, so a single invocation can
+  fan out across workers.
+- `--fix-doi` is on so that a single sweep restores both DOIs and manifests
+  "once and for all"; opt-out with `--no-fix-doi` for a manifest-only run.
+
+Comparison is **semantic**: both sides are parsed as JSON and compared as
+Python objects, so whitespace/key-ordering differences do not produce false
+mismatches. With `--show-diff` a `difflib.unified_diff` of the
+sort-keyed pretty-printed forms is emitted.
+
+DOI re-minting calls `dandiapi.api.doi.create_doi(version)` synchronously
+(so failures surface in the operator's terminal). When DataCite is not
+configured the HTTP call itself is skipped, but `_generate_doi_data` still
+runs full `PublishedDandiset` schema validation via
+`dandischema.datacite.to_datacite`; the function only returns the
+deterministically computed DOI when validation succeeds. If validation
+fails the in-memory `version.metadata['doi']` is rolled back via
+`version.refresh_from_db()` so the immediately following S3 comparison
+is not corrupted.
+
+### 2. Fix the publish race
+
+Replace the two parallel `on_commit` callbacks in `_publish_dandiset` with
+a single chained one so manifest writing is enqueued **after** the DOI is
+committed. Failures at either substep are logged distinctly (so it's clear
+whether the DOI was minted-but-not-saved or never minted at all) and do
+not abort the manifest write — even a DOI-less published version is better
+represented by a manifest on S3 than by nothing. `sync_manifest_files
+--fix-doi` later reconciles whatever was missed.
+
+```python
+def _create_doi_and_write_manifests(version_id: int):
+    version = Version.objects.get(id=version_id)
+    new_doi: str | None = None
+    try:
+        new_doi = doi.create_doi(version)
+    except Exception:
+        logger.exception('Failed to mint DOI for version %s', version_id)
+    if new_doi is not None:
+        try:
+            version.doi = new_doi
+            version.save()
+        except Exception:
+            logger.exception(
+                'Minted DOI %s but failed to persist it on version %s',
+                new_doi, version_id,
+            )
+    write_manifest_files.delay(version_id)
+
+transaction.on_commit(lambda: _create_doi_and_write_manifests(new_version.id))
+```
+
+Future hardening (not included here): turn `_create_doi_and_write_manifests`
+into a real celery `shared_task` with `autoretry_for=(requests.RequestException,)`
+so transient DataCite failures auto-recover rather than relying on an
+operator-driven `sync_manifest_files --fix-doi` sweep.
+
+### 3. One-off operational sweep
+
+After #1 lands and #2 is deployed, run, in order:
+
+```
+./manage.py sync_manifest_files --all --version published --dry-run --show-diff
+./manage.py sync_manifest_files --all --version published
+./manage.py sync_manifest_files --all --version draft --dry-run
+./manage.py sync_manifest_files --all --version draft
+```
+
+Optionally with `--targets=both` if drift in `assets.jsonld` is suspected
+beyond the `dandiset.jsonld` audit.
+
+## Testing plan
+
+The repository already has the test infrastructure needed for this work;
+no new harness is required.
+
+### What is already in place
+
+- **MinIO is the test storage backend.**
+  `dandiapi/settings/testing.py` wires `STORAGES['default']` to
+  `dandiapi.storage.MinioDandiS3Storage` pointed at
+  `DJANGO_MINIO_STORAGE_URL`. Tests that touch `default_storage` exercise a
+  real MinIO instance (the `minio` service in `docker-compose.yml`). This
+  *is* the integration harness.
+- **Eager celery.** `CELERY_TASK_ALWAYS_EAGER = True` and
+  `CELERY_TASK_EAGER_PROPAGATES = True` mean
+  `write_manifest_files.delay(...)` runs inline in tests, so both `--sync`
+  and `--async` exercise the same code path.
+- **DOI minting skips the network in tests.** `doi.create_doi` skips the
+  HTTP call when any `DANDI_DOI_*` setting is `None` (which is the case
+  under test settings). It is **not** pure compute, though: it still runs
+  `to_datacite()`, which performs full `PublishedDandiset` pydantic
+  validation on the version metadata, and faker-generated factory
+  metadata does not satisfy that schema. DOI-fix tests therefore
+  monkeypatch `doi.create_doi` directly rather than relying on the
+  no-HTTP-call shortcut to short-circuit it (see `_install_fake_create_doi`
+  in `test_sync_manifest_files.py`).
+- **djclick command invocation.** Existing tests
+  (`test_create_dev_dandiset.py`, `test_correct_metadata.py`) call the
+  `@click.command()` function directly with argv-style positional args;
+  djclick's `CommandAdapter.__call__` dispatches via `execute` with
+  `standalone_mode=False`, so there is no `SystemExit` and no
+  `CliRunner.invoke` boilerplate.
+- **Factories.** `DraftVersionFactory`, `PublishedVersionFactory` (already
+  populates `doi`), `DraftAssetFactory`, `PublishedAssetFactory`. The
+  parametrized `version` fixture in `dandiapi/conftest.py` covers
+  draft/published.
+
+### Test file
+
+`dandiapi/api/tests/test_sync_manifest_files.py`, marked `@pytest.mark.django_db`.
+
+### Coverage matrix
+
+| #   | Scenario                                              | Setup → Action → Assertion                                                                                                                                                                |
+| --- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| U1  | `_is_dummy_doi` truth table                           | parametrized real DOI / placeholder / None                                                                                                                                                |
+| U2  | `_diff` shape                                         | unequal dicts → non-empty unified diff with expected headers                                                                                                                              |
+| A1  | Happy path: nothing to do                             | seed draft + manifests → run `--all --dry-run` → S3 unchanged, summary 0 mismatches                                                                                                       |
+| A2  | Drafted out-of-sync `dandiset.jsonld`                 | seed → mutate `version.metadata` and save → run `--all` → S3 `dandiset.jsonld` parsed equals `version.metadata`                                                                           |
+| A3  | `--dry-run` does not write                            | as A2 with `--dry-run` → S3 still has the old content                                                                                                                                     |
+| A4  | Missing S3 object treated as mismatch                 | seed → `default_storage.delete(...)` → run → file recreated                                                                                                                                |
+| A5  | `--targets=assets`                                    | seed published version → mutate one asset's metadata → run with `--targets=assets` → S3 `assets.jsonld` matches expected list                                                              |
+| A6  | `--targets=both`                                      | mutate both → run `--targets=both` → both files updated                                                                                                                                   |
+| A7  | DOI remint: NULL doi on published version             | published version with `doi=None` → run with default `--fix-doi` → `version.doi` populated; S3 `dandiset.jsonld['doi']` matches; citation uses doi.org URL                                |
+| A8  | DOI remint: placeholder doi                           | published version with `doi='…/123456/0.123456.1234'` → run → real doi minted, manifest updated                                                                                          |
+| A9  | `--no-fix-doi` skips DOI fix                          | as A7 with `--no-fix-doi` → `version.doi` still NULL                                                                                                                                       |
+| A10 | DOI remint failure is reported, not fatal             | monkeypatch `doi_module.create_doi` to raise → run with `--fix-doi` → command completes; output shows "DOI remint FAILED"; `version.doi` unchanged                                         |
+| A11 | `--version=draft` filter                              | one draft + one published, both stale → run `--version=draft` → only draft regenerated                                                                                                    |
+| A12 | `--version=published` filter                          | symmetric to A11                                                                                                                                                                          |
+| A13 | `--specific-version=<ver>`                            | published v1 + v2 stale → only v1 regenerated                                                                                                                                              |
+| A14 | Positional dandiset filter                            | two dandisets stale → run with one ID → only that one regenerated                                                                                                                         |
+| A15 | Mutually-exclusive arg validation                     | `--all` + positional, or neither → `ClickException`                                                                                                                                       |
+| A16 | Embargoed manifest re-tagged on regeneration          | embargoed dandiset, mutate metadata → run → `default_storage.get_tags(path)` includes `embargoed: 'true'`                                                                                  |
+| A17 | `--show-diff` produces diff output                    | mutate metadata → run with `--show-diff` → captured stdout contains the unified-diff headers                                                                                              |
+
+### Notes / caveats
+
+- `_dandiset_jsonld_matches` runs the DB-side metadata through
+  `json.loads(JSONRenderer().render(...))` (via the `_renormalize` helper)
+  before comparing to `json.loads(s3_bytes)`, so a future field that
+  involves DRF-specific coercion (`Decimal`, `UUID`, `datetime`) does not
+  produce a one-sided mismatch.
+- `default_storage.open(...).read()` returning `bytes` for S3-backed storage
+  is assumed (existing `test_manifests.py` does the same).
+- "Mock S3" is intentionally **not** introduced. The existing MinIO-based
+  setup is more faithful and is already what CI runs.
+
+### Running
+
+- Local: `docker compose up -d minio postgres rabbitmq`
+  then `tox -e test -- dandiapi/api/tests/test_sync_manifest_files.py`.
+- CI: covered by the existing `[testenv:test]` env; no workflow changes.
+
+## Open questions
+
+- Should `sync_manifest_files` also reconcile `assets.yaml` /
+  `dandiset.yaml` / `collection.jsonld` independently, or is regenerating
+  all five from a `dandiset.jsonld` mismatch sufficient? (Current design:
+  any mismatch triggers full regeneration via `write_manifest_files`,
+  which rewrites all five.)
+- Should DOI re-minting attempt to *recover* an existing DataCite DOI
+  (e.g. via `GET` before `POST`) so it does not fail-loud on duplicate
+  creation when `version.doi` is NULL but the DOI was actually minted in
+  a prior partially-failed run?
+- Do we want a periodic/scheduled invocation (celery beat) of a
+  manifest-consistency audit, or is on-demand operator invocation
+  sufficient?

--- a/doc/design/manifests-consistency.md
+++ b/doc/design/manifests-consistency.md
@@ -131,6 +131,12 @@ Defaults follow operational ergonomics for the live deployment:
   fan out across workers.
 - `--fix-doi` is on so that a single sweep restores both DOIs and manifests
   "once and for all"; opt-out with `--no-fix-doi` for a manifest-only run.
+  It is a no-op (with a warning on stderr and a note in the summary) when
+  `doi.doi_configured()` is False: `create_doi` derives the DOI string
+  deterministically and only *registers* it with DataCite when the
+  `DANDI_DOI_API_*` settings are present, so without them the command would
+  persist -- and publish in the manifests -- a well-formed DOI that resolves
+  nowhere. That is worse than the `null` it would replace.
 
 Comparison is **semantic**: both sides are parsed as JSON and compared as
 Python objects, so whitespace/key-ordering differences do not produce false
@@ -262,6 +268,8 @@ no new harness is required.
 | A15 | Mutually-exclusive arg validation                     | `--all` + positional, or neither → `ClickException`                                                                                                                                       |
 | A16 | Embargoed manifest re-tagged on regeneration          | embargoed dandiset, mutate metadata → run → `default_storage.get_tags(path)` includes `embargoed: 'true'`                                                                                  |
 | A17 | `--show-diff` produces diff output                    | mutate metadata → run with `--show-diff` → captured stdout contains the unified-diff headers                                                                                              |
+| A18 | DOI repair is skipped when DataCite is unconfigured    | published version with `doi=None`, no `DANDI_DOI_API_*` settings → run with default `--fix-doi` → `version.doi` still NULL, warning on stderr                                              |
+| P1  | Publish writes the DOI into the manifest              | publish a draft with `django_capture_on_commit_callbacks` → S3 `dandiset.jsonld` has `doi` == `version.doi` and a doi.org citation (regression test for the race fixed in #2)              |
 
 ### Notes / caveats
 
@@ -291,7 +299,11 @@ no new harness is required.
 - Should DOI re-minting attempt to *recover* an existing DataCite DOI
   (e.g. via `GET` before `POST`) so it does not fail-loud on duplicate
   creation when `version.doi` is NULL but the DOI was actually minted in
-  a prior partially-failed run?
+  a prior partially-failed run? This needs deciding *before* the sweep:
+  "minted at DataCite but not persisted in the DB" is one of the failure
+  modes #2759 covers, the DOI string is deterministic, and a `POST` for an
+  already-registered DOI is rejected by DataCite -- so those versions would
+  all report `DOI remint FAILED` and stay NULL.
 - Do we want a periodic/scheduled invocation (celery beat) of a
   manifest-consistency audit, or is on-demand operator invocation
   sufficient?

--- a/doc/design/manifests-consistency.md
+++ b/doc/design/manifests-consistency.md
@@ -143,8 +143,38 @@ Python objects, so whitespace/key-ordering differences do not produce false
 mismatches. With `--show-diff` a `difflib.unified_diff` of the
 sort-keyed pretty-printed forms is emitted.
 
-DOI re-minting calls `dandiapi.api.doi.create_doi(version)` synchronously
-(so failures surface in the operator's terminal). When DataCite is not
+#### DOI repair
+
+`version.doi` being NULL does not mean no DOI exists. `create_doi` derives
+the DOI deterministically (`{prefix}/{instance}.{dandiset_id}/{version}`)
+and only then POSTs it, so publish can (and does) mint a DOI at DataCite and
+then fail to persist it -- `_create_doi_and_write_manifests` logs exactly
+that case. DataCite rejects a POST for an already-registered DOI, so a
+mint-only repair would report a failure and leave NULL precisely those
+versions that already have a working DOI.
+
+The command therefore looks first (`doi.get_doi`, a `GET` mirroring the one
+already in `delete_doi`) and:
+
+- **registered and consistent** -> adopt it: write `version.doi`, let
+  `Version.save()` rebuild `metadata['doi']` and the doi.org citation, and
+  regenerate the manifests. No write to DataCite.
+- **registered but inconsistent** -> report, do not adopt. Two cases: the
+  record's `url` disagrees with the version's (a misconfigured prefix or
+  instance name must not silently attach an unrelated DOI; a version
+  published before `DANDI_WEB_APP_URL` last changed lands here too), or the
+  record is still in DataCite `draft` state, which does not resolve --
+  publishing a dead doi.org link is the bug being fixed, not one to add.
+  Promoting a draft would mean writing to DataCite, which this command
+  deliberately never does.
+- **not registered** -> mint it, as before.
+
+The lookup is read-only and so also runs under `--dry-run`, which makes the
+dry run the measurement tool: its summary separates "DOIs to mint" (DataCite
+was never told) from "DOIs to adopt" (DataCite knows, the DB does not).
+
+Everything happens synchronously, so failures surface in the operator's
+terminal. When DataCite is not
 configured the HTTP call itself is skipped, but `_generate_doi_data` still
 runs full `PublishedDandiset` schema validation via
 `dandischema.datacite.to_datacite`; the function only returns the
@@ -268,6 +298,10 @@ no new harness is required.
 | A15 | Mutually-exclusive arg validation                     | `--all` + positional, or neither → `ClickException`                                                                                                                                       |
 | A16 | Embargoed manifest re-tagged on regeneration          | embargoed dandiset, mutate metadata → run → `default_storage.get_tags(path)` includes `embargoed: 'true'`                                                                                  |
 | A17 | `--show-diff` produces diff output                    | mutate metadata → run with `--show-diff` → captured stdout contains the unified-diff headers                                                                                              |
+| A19 | Already-registered DOI is adopted, not re-POSTed      | published version with `doi=None`, `get_doi` returns a matching findable record → `version.doi` set from it, manifest rewritten, `create_doi` never called                                  |
+| A20 | Registered DOI describing something else is refused   | `get_doi` returns a record whose `url` differs → `version.doi` still NULL, "not adopting" reported                                                                                          |
+| A21 | `draft`-state DOI is refused                          | `get_doi` returns `state='draft'` → not adopted, reported                                                                                                                                 |
+| A22 | `--dry-run` separates mint from adopt                 | one registered + one unregistered version → summary shows 1 to mint, 1 to adopt, nothing written                                                                                           |
 | A18 | DOI repair is skipped when DataCite is unconfigured    | published version with `doi=None`, no `DANDI_DOI_API_*` settings → run with default `--fix-doi` → `version.doi` still NULL, warning on stderr                                              |
 | P1  | Publish writes the DOI into the manifest              | publish a draft with `django_capture_on_commit_callbacks` → S3 `dandiset.jsonld` has `doi` == `version.doi` and a doi.org citation (regression test for the race fixed in #2)              |
 
@@ -296,14 +330,8 @@ no new harness is required.
   all five from a `dandiset.jsonld` mismatch sufficient? (Current design:
   any mismatch triggers full regeneration via `write_manifest_files`,
   which rewrites all five.)
-- Should DOI re-minting attempt to *recover* an existing DataCite DOI
-  (e.g. via `GET` before `POST`) so it does not fail-loud on duplicate
-  creation when `version.doi` is NULL but the DOI was actually minted in
-  a prior partially-failed run? This needs deciding *before* the sweep:
-  "minted at DataCite but not persisted in the DB" is one of the failure
-  modes #2759 covers, the DOI string is deterministic, and a `POST` for an
-  already-registered DOI is rejected by DataCite -- so those versions would
-  all report `DOI remint FAILED` and stay NULL.
+- ~~Should DOI re-minting attempt to *recover* an existing DataCite DOI?~~
+  Resolved: yes, see "DOI repair" below.
 - Do we want a periodic/scheduled invocation (celery beat) of a
   manifest-consistency audit, or is on-demand operator invocation
   sufficient?

--- a/doc/design/manifests-consistency.md
+++ b/doc/design/manifests-consistency.md
@@ -46,10 +46,12 @@ In `dandiapi/api/services/publish/__init__.py` the publish path schedules two
 ```python
 transaction.on_commit(lambda: write_manifest_files.delay(new_version.id))
 
+
 def _create_doi(version_id: int):
     version = Version.objects.get(id=version_id)
     version.doi = doi.create_doi(version)
     version.save()
+
 
 transaction.on_commit(lambda: _create_doi(new_version.id))
 ```
@@ -208,9 +210,11 @@ def _create_doi_and_write_manifests(version_id: int):
         except Exception:
             logger.exception(
                 'Minted DOI %s but failed to persist it on version %s',
-                new_doi, version_id,
+                new_doi,
+                version_id,
             )
     write_manifest_files.delay(version_id)
+
 
 transaction.on_commit(lambda: _create_doi_and_write_manifests(new_version.id))
 ```


### PR DESCRIPTION
- Closes (partially) #2759.

## Summary

- New `sync_manifest_files` management command to reconcile S3 manifest files (`dandiset.jsonld` / `assets.jsonld`) against the current database state, regenerate via `write_manifest_files` on mismatch, and (by default) re-mint NULL/placeholder DOIs on published versions.
- Fix for the publish-time race that caused freshly-published `dandiset.jsonld` files to be written to S3 *before* the DOI was minted and saved, leaving them with `doi: null` and a non-DOI citation forever.
- Design note at `doc/design/manifests-consistency.md`.
- Tests via the existing pytest + MinIO + eager-Celery harness.

The four commits are independently reviewable:

1. `doc:` add design note
2. add `sync_manifest_files` management command
3. add tests for `sync_manifest_files`
4. fix publish-time race between DOI minting and manifest writing

## Root cause (race)

`dandiapi/api/services/publish/__init__.py` registered two independent `transaction.on_commit` callbacks — one to `write_manifest_files.delay()` and one to mint the DOI synchronously. The manifest task could pick up before the DOI was committed, and nothing re-ran the manifest task after `version.doi` was saved.

The fix chains them so the DOI is minted and saved before the manifest write is enqueued. A DataCite failure no longer leaves the published version without an S3 manifest — the exception is logged and the manifest is still enqueued; `sync_manifest_files --fix-doi` can repair later.

## `sync_manifest_files` surface

```
./manage.py sync_manifest_files [DANDISET_ID ...] [-a/--all]
    [--version draft|published|all]      # default: all
    [--specific-version VER]              # overrides --version
    [--targets dandiset|assets|both]      # default: dandiset
    [--dry-run / --check]
    [--sync / --async]                    # default: --async
    [--fix-doi / --no-fix-doi]            # default: --fix-doi
    [--show-diff]
```

Comparison is semantic (parsed JSON, list of dicts for `assets.jsonld`) so it doesn't trip on whitespace / key ordering.

## Suggested operational sweep (post-deploy)

```
./manage.py sync_manifest_files --all --version published --dry-run --show-diff
./manage.py sync_manifest_files --all --version published
./manage.py sync_manifest_files --all --version draft --dry-run
./manage.py sync_manifest_files --all --version draft
```

## Test plan

- [ ] rebase/update after initial CI pass
- [x] `tox -e lint` passes on the new files.
- [ ] `docker compose up -d minio postgres rabbitmq && tox -e test -- dandiapi/api/tests/test_sync_manifest_files.py dandiapi/api/tests/test_tasks.py` is green locally; the latter is included to verify the publish fix doesn't break `test_publish_task`.
- [ ] CI passes.
- [ ] Manually run `sync_manifest_files --all --version published --dry-run --show-diff` against staging and review the diff before applying.
