### PR TITLE
Unify multipart upload endpoints

### DIFF
--- a/dandiapi/api/models/upload.py
+++ b/dandiapi/api/models/upload.py
@@ -68,16 +68,16 @@ class Upload(models.Model):  # noqa: DJ008
 
     @classmethod
     def initialize_zarr_multipart_upload(cls, etag, size, zarr: ZarrArchive, chunk_key: str):
-        object_key = zarr.s3_path(chunk_key.lstrip('/'))
-        upload, attrs = cls.initialize_multipart_upload(
-            etag=etag, size=size, dandiset=zarr.dandiset, object_key=object_key
-        )
-
         if size <= ZARR_MULTIPART_UPLOAD_THRESHOLD:
             raise ValidationError(
                 f'Zarr files below {ZARR_MULTIPART_UPLOAD_THRESHOLD} bytes in size'
                 ' must be uploaded via single part upload.'
             )
+
+        object_key = zarr.s3_path(chunk_key.lstrip('/'))
+        upload, attrs = cls.initialize_multipart_upload(
+            etag=etag, size=size, dandiset=zarr.dandiset, object_key=object_key
+        )
 
         # Tack on zarr and remove dandiset from instantiated (but not yet saved) Upload
         upload.dandiset = None

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -586,7 +586,7 @@ def test_upload_initialize_zarr_required(api_client):
     api_client.force_authenticate(user=user)
 
     resp = api_client.post(
-        '/api/uploads/zarr/initialize/',
+        '/api/uploads/initialize/',
         {
             'contentSize': 123,
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
@@ -606,7 +606,7 @@ def test_upload_initialize_zarr_file_size_limit(api_client):
     chunk_key = '0/0/1'
 
     resp = api_client.post(
-        '/api/uploads/zarr/initialize/',
+        '/api/uploads/initialize/',
         {
             'contentSize': ZARR_MULTIPART_UPLOAD_THRESHOLD,
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
@@ -617,7 +617,7 @@ def test_upload_initialize_zarr_file_size_limit(api_client):
     assert resp.status_code == 400
 
     resp = api_client.post(
-        '/api/uploads/zarr/initialize/',
+        '/api/uploads/initialize/',
         {
             'contentSize': ZARR_MULTIPART_UPLOAD_THRESHOLD + 1,
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
@@ -643,7 +643,7 @@ def test_upload_initialize_zarr(api_client, embargoed):
     chunk_key = '0/chunk'
 
     resp = api_client.post(
-        '/api/uploads/zarr/initialize/',
+        '/api/uploads/initialize/',
         {
             'contentSize': content_size,
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
@@ -668,7 +668,7 @@ def test_upload_initialize_zarr_not_found(api_client):
     api_client.force_authenticate(user=user)
 
     resp = api_client.post(
-        '/api/uploads/zarr/initialize/',
+        '/api/uploads/initialize/',
         {
             'contentSize': ZARR_MULTIPART_UPLOAD_THRESHOLD + 1,
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
@@ -689,7 +689,7 @@ def test_upload_complete_zarr(api_client):
     content_size = ZARR_MULTIPART_UPLOAD_THRESHOLD + 1
 
     assert api_client.post(
-        f'/api/uploads/zarr/{zarr_upload.upload_id}/complete/',
+        f'/api/uploads/{zarr_upload.upload_id}/complete/',
         {'parts': [{'part_number': 1, 'size': content_size, 'etag': 'test-etag'}]},
     ).data == {
         'complete_url': HTTP_URL_RE,
@@ -709,7 +709,7 @@ def test_upload_validate_zarr(api_client):
     zarr = ZarrArchiveFactory.create(status=ZarrArchiveStatus.COMPLETE, checksum=EMPTY_CHECKSUM)
     zarr_upload = ZarrUploadFactory.create(zarr=zarr)
 
-    resp = api_client.post(f'/api/uploads/zarr/{zarr_upload.upload_id}/validate/')
+    resp = api_client.post(f'/api/uploads/{zarr_upload.upload_id}/validate/')
     assert resp.status_code == 200
     assert resp.data is None
 
@@ -731,7 +731,7 @@ def test_upload_initialize_and_complete_zarr(api_client):
     content_size = ZARR_MULTIPART_UPLOAD_THRESHOLD + 1
 
     initialization = api_client.post(
-        '/api/uploads/zarr/initialize/',
+        '/api/uploads/initialize/',
         {
             'contentSize': content_size,
             'digest': {'algorithm': 'dandi:dandi-etag', 'value': 'f' * 32 + '-1'},
@@ -755,7 +755,7 @@ def test_upload_initialize_and_complete_zarr(api_client):
         )
 
     completion = api_client.post(
-        f'/api/uploads/zarr/{upload_id}/complete/',
+        f'/api/uploads/{upload_id}/complete/',
         {'parts': transferred_parts},
     ).data
 

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -436,6 +436,8 @@ def test_upload_validate(api_client, upload):
         'etag': upload.etag,
         'sha256': None,
         'size': upload.size,
+        'zarr_id': None,
+        'chunk_key': None,
     }
 
     # Verify that a new AssetBlob was created
@@ -462,6 +464,8 @@ def test_upload_validate_embargo(api_client, embargoed_upload_factory):
         'etag': embargoed_upload.etag,
         'sha256': None,
         'size': embargoed_upload.size,
+        'zarr_id': None,
+        'chunk_key': None,
     }
 
     # Verify that a new embargoed AssetBlob was created
@@ -698,8 +702,9 @@ def test_upload_complete_zarr(api_client):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_upload_validate_zarr(api_client):
-    """Validating a zarr upload returns 200 with no body."""
+@pytest.mark.parametrize('chunk_key', ['.zattrs', '0/0/0'])
+def test_upload_validate_zarr(api_client, chunk_key):
+    """Validating a zarr upload returns the zarr ID and chunk key."""
     from zarr_checksum.checksum import EMPTY_CHECKSUM
 
     from dandiapi.zarr.models import ZarrArchiveStatus
@@ -707,11 +712,19 @@ def test_upload_validate_zarr(api_client):
     user = UserFactory.create()
     api_client.force_authenticate(user=user)
     zarr = ZarrArchiveFactory.create(status=ZarrArchiveStatus.COMPLETE, checksum=EMPTY_CHECKSUM)
-    zarr_upload = ZarrUploadFactory.create(zarr=zarr)
+
+    zarr_upload = ZarrUploadFactory.create(zarr=zarr, blob__filename=zarr.s3_path(chunk_key))
 
     resp = api_client.post(f'/api/uploads/{zarr_upload.upload_id}/validate/')
     assert resp.status_code == 200
-    assert resp.data is None
+    assert resp.data == {
+        'blob_id': None,
+        'etag': None,
+        'sha256': None,
+        'size': None,
+        'zarr_id': str(zarr.zarr_id),
+        'chunk_key': chunk_key,
+    }
 
     assert not Upload.objects.exists()
 

--- a/dandiapi/api/views/__init__.py
+++ b/dandiapi/api/views/__init__.py
@@ -15,9 +15,6 @@ from .upload import (
     upload_complete_view,
     upload_initialize_view,
     upload_validate_view,
-    zarr_upload_complete_view,
-    zarr_upload_initialize_view,
-    zarr_upload_validate_view,
 )
 from .users import users_list_view, users_me_view, users_search_view
 from .version import VersionViewSet
@@ -47,7 +44,4 @@ __all__ = [
     'users_list_view',
     'users_me_view',
     'users_search_view',
-    'zarr_upload_complete_view',
-    'zarr_upload_initialize_view',
-    'zarr_upload_validate_view',
 ]

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -42,7 +42,9 @@ class DigestSerializer(serializers.Serializer):
 
 class UploadInitializationRequestSerializer(serializers.Serializer):
     contentSize = serializers.IntegerField(min_value=1)  # noqa: N815
-    digest = DigestSerializer(required=False)
+    digest = DigestSerializer()
+
+    # Unioned fields
     dandiset = DandisetIdentifierField(required=False)
     zarr_id = serializers.UUIDField(required=False)
     chunk_key = serializers.CharField(required=False)

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -110,6 +110,19 @@ class UploadCompletionResponseSerializer(serializers.Serializer):
     body = serializers.CharField(trim_whitespace=False)
 
 
+class UploadValidationResponseSerializer(AssetBlobSerializer):
+    # Zarr fields, null for asset blob uploads. The inherited AssetBlob
+    # fields are likewise null for zarr uploads.
+    zarr_id = serializers.UUIDField(allow_null=True, default=None)
+    chunk_key = serializers.CharField(allow_null=True, default=None)
+
+    class Meta(AssetBlobSerializer.Meta):
+        fields = [*AssetBlobSerializer.Meta.fields, 'zarr_id', 'chunk_key']
+        # Default the inherited AssetBlob fields to null so the zarr case only
+        # needs to supply its own fields.
+        extra_kwargs = {field: {'default': None} for field in AssetBlobSerializer.Meta.fields}
+
+
 @swagger_auto_schema(
     method='POST',
     operation_summary='Fetch an existing asset blob by digest, if it exists.',
@@ -255,7 +268,7 @@ def upload_complete_view(request: AuthenticatedRequest, upload_id: str) -> HttpR
 @swagger_auto_schema(
     method='POST',
     responses={
-        200: AssetBlobSerializer,
+        200: UploadValidationResponseSerializer,
         400: 'The specified upload has not completed or has failed.',
     },
 )
@@ -280,6 +293,11 @@ def upload_validate_view(request: AuthenticatedRequest, upload_id: str) -> HttpR
         # This raises an exception if unsuccessful
         upload.validate_successful()
 
+        # Grab this data before calling upload.delete
+        if upload.blob.name is None:
+            raise ValueError('Upload blob name is None')
+        chunk_key = upload.blob.name.removeprefix(zarr.s3_path(''))
+
         with transaction.atomic():
             upload.delete()
 
@@ -287,7 +305,10 @@ def upload_validate_view(request: AuthenticatedRequest, upload_id: str) -> HttpR
             zarr.mark_pending()
             zarr.save()
 
-        return Response(None, status=status.HTTP_200_OK)
+        response_serializer = UploadValidationResponseSerializer(
+            {'zarr_id': zarr.zarr_id, 'chunk_key': chunk_key}
+        )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
 
     dandiset = typing.cast('Dandiset', upload.dandiset)
     if upload.embargoed and not is_dandiset_owner(dandiset, request.user):
@@ -319,5 +340,5 @@ def upload_validate_view(request: AuthenticatedRequest, upload_id: str) -> HttpR
     # Start calculating the sha256 in the background
     calculate_sha256.delay(asset_blob.blob_id)
 
-    response_serializer = AssetBlobSerializer(asset_blob)
+    response_serializer = UploadValidationResponseSerializer(asset_blob)
     return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -40,9 +40,25 @@ class DigestSerializer(serializers.Serializer):
     value = serializers.CharField()
 
 
-class CommonUploadSerializer(serializers.Serializer):
+class UploadInitializationRequestSerializer(serializers.Serializer):
     contentSize = serializers.IntegerField(min_value=1)  # noqa: N815
     digest = DigestSerializer(required=False)
+    dandiset = DandisetIdentifierField(required=False)
+    zarr_id = serializers.UUIDField(required=False)
+    chunk_key = serializers.CharField(required=False)
+
+    def validate(self, data):
+        has_dandiset = 'dandiset' in data
+        has_zarr = 'zarr_id' in data or 'chunk_key' in data
+
+        if has_dandiset and has_zarr:
+            raise ValidationError('Only one of dandiset or zarr_id/chunk_key may be specified.')
+        if not has_dandiset and not has_zarr:
+            raise ValidationError('Either dandiset or zarr_id/chunk_key must be specified.')
+        if has_zarr and ('zarr_id' not in data or 'chunk_key' not in data):
+            raise ValidationError('Both zarr_id and chunk_key must be specified.')
+
+        return data
 
     def get_digest_data(self) -> tuple[str, int]:
         """Return a tuple of (etag, content_size), raising an exception if invalid."""
@@ -55,15 +71,6 @@ class CommonUploadSerializer(serializers.Serializer):
             raise ValidationError('Unsupported Digest Type')
 
         return digest['value'], data['contentSize']
-
-
-class ZarrUploadInitializationRequestSerializer(CommonUploadSerializer):
-    zarr_id = serializers.UUIDField()
-    chunk_key = serializers.CharField()
-
-
-class UploadInitializationRequestSerializer(CommonUploadSerializer):
-    dandiset = DandisetIdentifierField()
 
 
 class PartInitializationResponseSerializer(serializers.Serializer):
@@ -145,6 +152,8 @@ def upload_initialize_view(request: AuthenticatedRequest) -> HttpResponseBase:
 
     A list of parts will be returned, each of which has a presigned upload URL and a size.
     This URL communicates directly with the object store so the client can upload bytes directly.
+    Either `dandiset` or `zarr_id`/`chunk_key` must be specified, to upload a regular asset blob
+    or a chunk of a zarr file, respectively.
 
     https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html
     """
@@ -152,11 +161,17 @@ def upload_initialize_view(request: AuthenticatedRequest) -> HttpResponseBase:
     request_serializer.is_valid(raise_exception=True)
 
     etag, content_size = request_serializer.get_digest_data()
+    data: dict = request_serializer.validated_data
 
-    dandiset = get_object_or_404(
-        get_visible_dandisets(request.user),
-        id=request_serializer.validated_data['dandiset'],
-    )
+    # Since the serializer does validation, we know the serializer data contains either the full
+    # dandiset case, or the full zarr case. We can simply check against zarr_id.
+    zarr_archive: ZarrArchive | None = None
+    if 'zarr_id' in data:
+        zarr_archive = get_object_or_404(ZarrArchive, zarr_id=data['zarr_id'])
+        dandiset = zarr_archive.dandiset
+    else:
+        dandiset = get_object_or_404(get_visible_dandisets(request.user), id=data['dandiset'])
+
     if not is_dandiset_owner(dandiset, request.user):
         raise NotAllowedError
 
@@ -164,36 +179,44 @@ def upload_initialize_view(request: AuthenticatedRequest) -> HttpResponseBase:
     if dandiset.unembargo_in_progress:
         raise DandisetUnembargoInProgressError
 
-    logger.info(
-        'Starting upload initialization of size %s, ETag %s to dandiset %s',
-        content_size,
-        etag,
-        dandiset,
-    )
+    if zarr_archive is None:
+        existing_asset_blob = AssetBlob.objects.filter(etag=etag).first()
+        if existing_asset_blob is not None:
+            return Response(
+                'Blob already exists.',
+                status=status.HTTP_409_CONFLICT,
+                headers={'Location': str(existing_asset_blob.blob_id)},
+            )
 
-    existing_asset_blob = AssetBlob.objects.filter(etag=etag).first()
-    if existing_asset_blob is not None:
-        return Response(
-            'Blob already exists.',
-            status=status.HTTP_409_CONFLICT,
-            headers={'Location': str(existing_asset_blob.blob_id)},
+        upload, initialization = Upload.initialize_multipart_upload(etag, content_size, dandiset)
+        logger.info(
+            'AssetBlob upload initialized (size %s, ETag %s, dandiset %s)',
+            content_size,
+            etag,
+            dandiset,
         )
+    else:
+        upload, initialization = Upload.initialize_zarr_multipart_upload(
+            etag, content_size, zarr=zarr_archive, chunk_key=data['chunk_key']
+        )
+        logger.info('Zarr upload initialized for chunk %s', data['chunk_key'])
 
-    logger.info('Blob with ETag %s does not yet exist', etag)
-
-    upload, initialization = Upload.initialize_multipart_upload(etag, content_size, dandiset)
-    logger.info('Upload of ETag %s initialized', etag)
     upload.save()
     logger.info('Upload of ETag %s saved', etag)
 
     response_serializer = UploadInitializationResponseSerializer(initialization)
-    logger.info('Upload of ETag %s serialized', etag)
     return Response(response_serializer.data)
 
 
-# This view is used identically in two separate views. The reason for this is solely so that the
-# swagger page can add "of a zarr file" to the description of the zarr multipart upload endpoint.
-def _upload_complete_view(request: AuthenticatedRequest, upload_id: str) -> HttpResponseBase:
+@swagger_auto_schema(
+    method='POST',
+    request_body=UploadCompletionRequestSerializer,
+    responses={200: UploadCompletionResponseSerializer},
+)
+@api_view(['POST'])
+@parser_classes([JSONParser])
+@permission_classes([IsApproved])
+def upload_complete_view(request: AuthenticatedRequest, upload_id: str) -> HttpResponseBase:
     """
     Complete a multipart upload.
 
@@ -206,7 +229,8 @@ def _upload_complete_view(request: AuthenticatedRequest, upload_id: str) -> Http
     parts: list[TransferredPart] = request_serializer.save()
 
     upload: Upload = get_object_or_404(Upload, upload_id=upload_id)
-    if upload.embargoed and not is_dandiset_owner(upload.dandiset, request.user):
+    dandiset = upload.dandiset or typing.cast('ZarrArchive', upload.zarr).dandiset
+    if upload.embargoed and not is_dandiset_owner(dandiset, request.user):
         raise Http404 from None
 
     completion = TransferredParts(
@@ -228,25 +252,6 @@ def _upload_complete_view(request: AuthenticatedRequest, upload_id: str) -> Http
 
 @swagger_auto_schema(
     method='POST',
-    request_body=UploadCompletionRequestSerializer,
-    responses={200: UploadCompletionResponseSerializer},
-)
-@api_view(['POST'])
-@parser_classes([JSONParser])
-@permission_classes([IsApproved])
-def upload_complete_view(request: AuthenticatedRequest, upload_id: str) -> HttpResponseBase:
-    """
-    Complete a multipart upload.
-
-    After all data has been uploaded using the URLs provided by initialize, this endpoint must
-    be called to create the object in the object store. A presigned URL that performs the
-    completion is returned, as the completion might take several minutes for large files.
-    """
-    return _upload_complete_view(request=request, upload_id=upload_id)
-
-
-@swagger_auto_schema(
-    method='POST',
     responses={
         200: AssetBlobSerializer,
         400: 'The specified upload has not completed or has failed.',
@@ -257,11 +262,31 @@ def upload_complete_view(request: AuthenticatedRequest, upload_id: str) -> HttpR
 @permission_classes([IsApproved])
 def upload_validate_view(request: AuthenticatedRequest, upload_id: str) -> HttpResponseBase:
     """
-    Verify that an upload completed successfully and mint a new AssetBlob.
+    Verify that an upload completed successfully.
 
-    Also starts the asynchronous checksum calculation process.
+    For a regular asset blob upload, this mints a new AssetBlob and starts the asynchronous
+    checksum calculation process. For a zarr chunk upload, this marks the zarr archive as
+    pending, since a new file has been added to it.
     """
-    upload = get_object_or_404(Upload, upload_id=upload_id, dandiset__isnull=False)
+    upload = get_object_or_404(Upload, upload_id=upload_id)
+
+    if upload.zarr is not None:
+        zarr = typing.cast('ZarrArchive', upload.zarr)
+        if upload.embargoed and not is_dandiset_owner(zarr.dandiset, request.user):
+            raise Http404 from None
+
+        # This raises an exception if unsuccessful
+        upload.validate_successful()
+
+        with transaction.atomic():
+            upload.delete()
+
+            # Zarr must be marked pending since a new file is now added
+            zarr.mark_pending()
+            zarr.save()
+
+        return Response(None, status=status.HTTP_200_OK)
+
     dandiset = typing.cast('Dandiset', upload.dandiset)
     if upload.embargoed and not is_dandiset_owner(dandiset, request.user):
         raise Http404 from None
@@ -294,93 +319,3 @@ def upload_validate_view(request: AuthenticatedRequest, upload_id: str) -> HttpR
 
     response_serializer = AssetBlobSerializer(asset_blob)
     return Response(response_serializer.data, status=status.HTTP_200_OK)
-
-
-@swagger_auto_schema(
-    method='POST',
-    request_body=ZarrUploadInitializationRequestSerializer,
-    responses={200: UploadInitializationResponseSerializer},
-)
-@api_view(['POST'])
-@parser_classes([JSONParser])
-@permission_classes([IsApproved])
-def zarr_upload_initialize_view(request: AuthenticatedRequest) -> HttpResponseBase:
-    """
-    Initialize a multipart upload of a zarr file.
-
-    A list of parts will be returned, each of which has a presigned upload URL and a size.
-    This URL communicates directly with the object store so the client can upload bytes directly.
-
-    https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html
-    """
-    request_serializer = ZarrUploadInitializationRequestSerializer(data=request.data)
-    request_serializer.is_valid(raise_exception=True)
-
-    etag, content_size = request_serializer.get_digest_data()
-
-    data: dict = request_serializer.validated_data
-    zarr_archive = get_object_or_404(ZarrArchive, zarr_id=data['zarr_id'])
-    dandiset = zarr_archive.dandiset
-    chunk_key = data['chunk_key']
-
-    if not is_dandiset_owner(dandiset, request.user):
-        raise NotAllowedError
-
-    # Ensure dandiset not in the process of unembargo
-    if dandiset.unembargo_in_progress:
-        raise DandisetUnembargoInProgressError
-
-    upload, initialization = Upload.initialize_zarr_multipart_upload(
-        etag, content_size, zarr=zarr_archive, chunk_key=chunk_key
-    )
-    upload.save()
-
-    logger.info('Zarr upload initialized for chunk %s', chunk_key)
-    response_serializer = UploadInitializationResponseSerializer(initialization)
-    return Response(response_serializer.data)
-
-
-@swagger_auto_schema(
-    method='POST',
-    request_body=UploadCompletionRequestSerializer,
-    responses={200: UploadCompletionResponseSerializer},
-)
-@api_view(['POST'])
-@parser_classes([JSONParser])
-@permission_classes([IsApproved])
-def zarr_upload_complete_view(request: AuthenticatedRequest, upload_id: str) -> HttpResponseBase:
-    """
-    Complete a multipart upload of a zarr file.
-
-    After all data has been uploaded using the URLs provided by initialize, this endpoint must
-    be called to create the object in the object store. A presigned URL that performs the
-    completion is returned, as the completion might take several minutes for large files.
-    """
-    return _upload_complete_view(request=request, upload_id=upload_id)
-
-
-@swagger_auto_schema(
-    method='POST',
-    responses={200: None},
-)
-@api_view(['POST'])
-@parser_classes([JSONParser])
-@permission_classes([IsApproved])
-def zarr_upload_validate_view(request: AuthenticatedRequest, upload_id: str) -> HttpResponseBase:
-    """Verify that a multipart zarr file upload completed successfully."""
-    upload = get_object_or_404(Upload, upload_id=upload_id, zarr__isnull=False)
-    zarr = typing.cast('ZarrArchive', upload.zarr)
-    if upload.embargoed and not is_dandiset_owner(zarr.dandiset, request.user):
-        raise Http404 from None
-
-    # This raises an exception if unsuccessful
-    upload.validate_successful()
-
-    with transaction.atomic():
-        upload.delete()
-
-        # Zarr must be marked pending since a new file is now added
-        zarr.mark_pending()
-        zarr.save()
-
-    return Response(None, status=status.HTTP_200_OK)

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -35,9 +35,6 @@ from dandiapi.api.views import (
     users_me_view,
     users_search_view,
     webdav,
-    zarr_upload_complete_view,
-    zarr_upload_initialize_view,
-    zarr_upload_validate_view,
 )
 from dandiapi.search.views import search_genotypes, search_species
 from dandiapi.zarr.views import ZarrViewSet
@@ -85,19 +82,6 @@ api_urlpatterns = [
         rf'^api/uploads/{UPLOAD_ID_URLPATTERN}/validate/$',
         upload_validate_view,
         name='upload-validate',
-    ),
-    path(
-        'api/uploads/zarr/initialize/', zarr_upload_initialize_view, name='zarr-upload-initialize'
-    ),
-    re_path(
-        rf'api/uploads/zarr/{UPLOAD_ID_URLPATTERN}/complete/',
-        zarr_upload_complete_view,
-        name='zarr-upload-complete',
-    ),
-    re_path(
-        rf'^api/uploads/zarr/{UPLOAD_ID_URLPATTERN}/validate/$',
-        zarr_upload_validate_view,
-        name='zarr-upload-validate',
     ),
     path('api/users/me/', users_me_view),
     path('api/users/search/', users_search_view),


### PR DESCRIPTION
This PR unifies the zarr and asset blob multipart upload endpoints into the singular existing assetblob upload endpoint. The prior change in #2784 was merged to master, but not deployed to production. 

This change is intended to be backwards compatible with the CLI, as it simply extends the fields present in both the upload initialize and upload complete endpoints. The existing CLI PR (https://github.com/dandi/dandi-cli/pull/1839) that was pointed at the previous change in #2784 can either be reworked, or replaced with a new PR.