### PR TITLE
[DO NOT MERGE] Test CI against dandi-schema#419 consolidated models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,10 @@ dependencies = [
   # Runtime dependencies, always needed
   "boto3==1.42.97",
   "celery==5.6.3",
-  # Pin dandischema to exact version to make explicit which schema version is being used
-  "dandischema==0.12.1", # schema version 0.7.0
+  # TEMPORARY (DO NOT MERGE): pin dandischema to the dandi/dandi-schema#419
+  # `consolidate-models` branch to run this repo's CI against the consolidated
+  # models before that PR is merged and released.
+  "dandischema @ git+https://github.com/dandi/dandi-schema.git@consolidate-models",
   "django[argon2]==5.2.13",
   "django-allauth==65.16.1",
   "django-auth-style==0.15.0",
@@ -104,6 +106,11 @@ test = [
 only-include = [
   "dandiapi",
 ]
+
+# TEMPORARY (DO NOT MERGE): required so the direct git reference for
+# dandischema above (dandi/dandi-schema#419) is accepted by hatchling.
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
 only-include = [

--- a/uv.lock
+++ b/uv.lock
@@ -821,7 +821,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.97" },
     { name = "celery", specifier = "==5.6.3" },
     { name = "dandi", extras = ["extras"], marker = "extra == 'cli'", specifier = "==0.74.3" },
-    { name = "dandischema", specifier = "==0.12.1" },
+    { name = "dandischema", git = "https://github.com/dandi/dandi-schema.git?rev=consolidate-models" },
     { name = "django", extras = ["argon2"], specifier = "==5.2.13" },
     { name = "django-allauth", specifier = "==65.16.1" },
     { name = "django-auth-style", specifier = "==0.15.0" },
@@ -892,8 +892,8 @@ type = [
 
 [[package]]
 name = "dandischema"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.12.1+68.g60cc4de"
+source = { git = "https://github.com/dandi/dandi-schema.git?rev=consolidate-models#60cc4de84ffc750c694dd4062e1d3b720181ab5a" }
 dependencies = [
     { name = "jsonschema", extra = ["format"] },
     { name = "packaging" },
@@ -901,10 +901,6 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "requests" },
     { name = "zarr-checksum" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/b7/b44244184c16c1b1cc69070b53325965285b81843ad7755c429e1ffaa341/dandischema-0.12.1.tar.gz", hash = "sha256:481ed1da9481090d8000b3b2373a0d4876043f48d4cddc3364c18e0a97bd0c22", size = 98659, upload-time = "2025-11-26T20:16:58.672Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/16/959ccdc06e45781d3c41cd552baeaaf563ffb5fe240fbd24efd26b8b2b12/dandischema-0.12.1-py3-none-any.whl", hash = "sha256:88f84cefd7883ce15d5c2f6b92411b1d00fd76468b77950fff25381e17eaab44", size = 118561, upload-time = "2025-11-26T20:16:57.121Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -892,8 +892,8 @@ type = [
 
 [[package]]
 name = "dandischema"
-version = "0.12.1+68.g60cc4de"
-source = { git = "https://github.com/dandi/dandi-schema.git?rev=consolidate-models#60cc4de84ffc750c694dd4062e1d3b720181ab5a" }
+version = "0.12.1+79.g99c09bf"
+source = { git = "https://github.com/dandi/dandi-schema.git?rev=consolidate-models#99c09bf9c19d4d310c2b60d93cdf5ea944985178" }
 dependencies = [
     { name = "jsonschema", extra = ["format"] },
     { name = "packaging" },

--- a/uv.lock
+++ b/uv.lock
@@ -892,8 +892,8 @@ type = [
 
 [[package]]
 name = "dandischema"
-version = "0.12.1+79.g99c09bf"
-source = { git = "https://github.com/dandi/dandi-schema.git?rev=consolidate-models#99c09bf9c19d4d310c2b60d93cdf5ea944985178" }
+version = "0.12.1+82.g227cdd0"
+source = { git = "https://github.com/dandi/dandi-schema.git?rev=consolidate-models#227cdd018a62bb9782089e7049cf17daced9417f" }
 dependencies = [
     { name = "jsonschema", extra = ["format"] },
     { name = "packaging" },
@@ -3286,8 +3286,8 @@ name = "secretstorage"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or platform_machine == 'arm64' or sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or platform_machine == 'arm64' or sys_platform != 'darwin'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/9f/11ef35cf1027c1339552ea7bfe6aaa74a8516d8b5caf6e7d338daf54fd80/secretstorage-3.4.0.tar.gz", hash = "sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c", size = 19748, upload-time = "2025-09-09T16:42:13.859Z" }
 wheels = [


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This is a throwaway PR whose only purpose is to run this repository's CI against the consolidated `Dandiset`/`Asset` publication models proposed in dandi/dandi-schema#419, before that PR is merged and released. Close it once CI has reported.

## What it does

The single commit temporarily repoints the `dandischema` dependency at the `consolidate-models` branch of `dandi/dandi-schema` (pinned in `uv.lock` to the exact commit) and adds `tool.hatch.metadata.allow-direct-references = true` so the direct git reference is accepted.

## Why

dandi-schema#419's own CI already runs the archive/dandi-cli integration with the consolidated models on the client side. What it does **not** run is this repository's own test suite. This PR closes that gap:

- **`backend-ci`** runs the archive's own publication-validation tests (the factory- and hand-built metadata validated against `PublishedDandiset` / `PublishedAsset`) against the consolidated models.
- **`cli-integration`** builds the archive image with the consolidated models while running dandi-cli with a released `dandischema` on the client. A green run demonstrates that the consolidation does not force dandi-cli and dandi-archive to upgrade `dandischema` in lockstep at the code level.

Note that `DANDI_SCHEMA_VERSION` coordination between the services at release time is a separate matter and is unaffected by what this PR verifies.

## Test plan

- [x] `backend-ci` passes against the consolidated models.
- [x] `cli-integration` passes (consolidated server + released client).
- [ ] Close this PR without merging.
