### PR TITLE
Reduce zarr stuckness

### DIFF
--- a/dandiapi/zarr/tasks/__init__.py
+++ b/dandiapi/zarr/tasks/__init__.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from celery import shared_task
 from celery.utils.log import get_task_logger
-from django.db import transaction
+from django.db import OperationalError, transaction
 from django.utils import timezone
+import psycopg.errors
 from zarr_checksum import compute_zarr_checksum
 from zarr_checksum.generators import S3ClientOptions, yield_files_s3
 
@@ -15,8 +16,23 @@ from dandiapi.zarr.models import ZarrArchive, ZarrArchiveStatus
 logger = get_task_logger(__name__)
 
 
-@shared_task(queue='ingest_zarr_archive', time_limit=3600)
-def ingest_zarr_archive(zarr_id: str, *, force: bool = False):
+@shared_task(
+    bind=True,
+    queue='ingest_zarr_archive',
+    time_limit=3600,
+    max_retries=3,
+    retry_backoff=True,
+)
+def ingest_zarr_archive(self, zarr_id: str, *, force: bool = False):
+    try:
+        _ingest_zarr_archive(zarr_id, force=force)
+    except OperationalError as e:
+        if isinstance(e.__cause__, psycopg.errors.DeadlockDetected):
+            raise self.retry(exc=e) from e
+        raise
+
+
+def _ingest_zarr_archive(zarr_id: str, *, force: bool = False):
     # Ensure zarr is in pending state before proceeding
     with transaction.atomic():
         zarr: ZarrArchive = ZarrArchive.objects.select_for_update().get(zarr_id=zarr_id)

--- a/dandiapi/zarr/tasks/__init__.py
+++ b/dandiapi/zarr/tasks/__init__.py
@@ -52,7 +52,7 @@ def ingest_zarr_archive(zarr_id: str, *, force: bool = False):
     with transaction.atomic():
         zarr = (
             ZarrArchive.objects.select_related('dandiset')
-            .select_for_update()
+            .select_for_update(of=['self'])
             .get(zarr_id=zarr_id, status=ZarrArchiveStatus.INGESTING)
         )
 


### PR DESCRIPTION
This PR partially addresses #2219.

It removes an accidentally introduced overbroad lock (#2111), and allows the ingestion of zarr archives to retry tasks when they fail due to deadlock, which is what happened with the latest slate of stuck zarrs.

The nature of ingesting zarrs makes for one long transaction (long as in seconds), which provides a large window of opportunity for simultaneous requests against the same resources to depend on each other.

I'd like to do a more thorough analysis of operations that conflict with each other, but for now this should significantly reduce the "zarr stuck in ingesting" problem - and otherwise there should be a deadlock error in sentry.