### PR TITLE
Redirect hub.dandiarchive.org to docs.dandiarchive.org/user-guide-using/dandi-hub

### DIFF
--- a/redirector/netlify.toml
+++ b/redirector/netlify.toml
@@ -16,5 +16,5 @@ status = 308
 # The DANDI JupyterHub has been taken down.
 [[redirects]]
 from = "https://hub.dandiarchive.org/*"
-to = "https://notebooks.dandiarchive.org/"
+to = "https://docs.dandiarchive.org/user-guide-using/dandi-hub/"
 status = 302

--- a/redirector/netlify.toml
+++ b/redirector/netlify.toml
@@ -13,7 +13,7 @@ from = "https://api-staging.dandiarchive.org/*"
 to = "https://api.sandbox.dandiarchive.org/:splat"
 status = 308
 
-# The DandiHub JupyterHub has been taken down.
+# The DANDI JupyterHub has been taken down.
 [[redirects]]
 from = "https://hub.dandiarchive.org/*"
 to = "https://notebooks.dandiarchive.org/"

--- a/redirector/netlify.toml
+++ b/redirector/netlify.toml
@@ -12,3 +12,9 @@ status = 301
 from = "https://api-staging.dandiarchive.org/*"
 to = "https://api.sandbox.dandiarchive.org/:splat"
 status = 308
+
+# The DandiHub JupyterHub has been taken down.
+[[redirects]]
+from = "https://hub.dandiarchive.org/*"
+to = "https://notebooks.dandiarchive.org/"
+status = 302


### PR DESCRIPTION
## CAUTION: ORDER MATTERS 

0.  Merge the graveyard page https://github.com/dandi/dandi-docs/pull/243
1. **This PR merges and deploys.** Open question for @waxlamp: retarget this at `release`?
2. **Add `hub.dandiarchive.org` as a domain alias** on the redirect project in Netlify.
3. **Add the Route53 record** in dandi-infrastructure: CNAME `hub` -> `redirect-dandiarchive-org.netlify.com`
   github.com/dandi/dandi-infrastructure/pull/282

Redirects `hub.dandiarchive.org` to the DANDI Hub retirement notice in the docs, per @yarikoptic's suggestion.

302 rather than 301 in case we need to use the subdomain again.

Two questions:

1. The gui netlify project (the one that does the redirect) deploys  `release`, which is ~120 commits behind `master`, so merging here doesn't activate anything until the next release. Should I open this against `release`  instead?
2. I've deleted the R53 route for now. ~Once this merges, I'll add the DNS record back, and then add `hub.dandiarchive.org` as a domain alias on the redirect project in Netlify.~ (infra PR instead)
