### PR TITLE
Attach `dependencies` label to renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,4 +3,5 @@
   extends: [
     'github>kitware-resonant/.github:renovate-project.json5',
   ],
+  "labels": ["dependencies"],
 }


### PR DESCRIPTION
`dependencies` is the correct label for `auto` for this type of PR, and will ensure they should up in release notes as dependency updates rather than bug fixes.