### PR TITLE
Fix zarr path traversal bug

### DIFF
--- a/dandiapi/zarr/models.py
+++ b/dandiapi/zarr/models.py
@@ -24,6 +24,28 @@ def zarr_s3_path(zarr_id: str, zarr_path: str = ''):
     return f'{settings.DANDI_ZARR_PREFIX_NAME}/{zarr_id}/{zarr_path}'
 
 
+def validate_zarr_path(path: str) -> str:
+    """
+    Reject zarr paths that could traverse outside the zarr archive's S3 prefix.
+
+    User-supplied paths are interpolated into an S3 key of the form
+    ``{DANDI_ZARR_PREFIX_NAME}/{zarr_id}/{path}``. django-storages' ``clean_name``
+    runs ``posixpath.normpath`` -- which collapses ``..`` -- *before* its
+    ``safe_join`` guard, and the storage ``location`` is empty, so ``safe_join``
+    only blocks escaping the (non-representable) bucket root. A ``..`` segment
+    therefore resolves to an arbitrary key elsewhere in the bucket, permitting
+    reads, overwrites, and deletes of unrelated objects. Reject any such segment.
+
+    Backslashes are normalized to forward slashes before the check because
+    ``clean_name`` performs the same replacement *after* normpath, which would
+    otherwise let a segment containing backslashes survive normpath and then
+    re-form a traversal sequence in the final key.
+    """
+    if any(segment == '..' for segment in path.replace('\\', '/').split('/')):
+        raise ValidationError('Zarr path cannot contain ".." components.')
+    return path
+
+
 # The status of the zarr ingestion (checksums, size, file count)
 class ZarrArchiveStatus(models.TextChoices):
     PENDING = 'Pending'

--- a/dandiapi/zarr/tests/test_zarr.py
+++ b/dandiapi/zarr/tests/test_zarr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.core.files.base import ContentFile
 import pytest
 from zarr_checksum.checksum import EMPTY_CHECKSUM
 
@@ -495,3 +496,59 @@ def test_zarr_explore_head(api_client):
     resp = api_client.head(f'/api/zarr/{zarr_archive.zarr_id}/files/', {'prefix': filepath})
     assert resp.status_code == 302
     assert f'/test-zarr/{zarr_archive.zarr_id}/{filepath}?' in resp.headers['Location']
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'path',
+    [
+        '../../blobs/victim-object',
+        # Backslash variant: clean_name rewrites '\' to '/' after normpath, so this
+        # resolves to the same victim key and must be rejected too.
+        '..\\../blobs/victim-object',
+        'foo/../../../blobs/victim-object',
+    ],
+)
+def test_zarr_rest_delete_file_rejects_path_traversal(api_client, path):
+    user = UserFactory.create()
+    api_client.force_authenticate(user=user)
+    zarr_archive = ZarrArchiveFactory.create(dandiset__owners=[user])
+
+    # An object living outside the attacker's zarr prefix (e.g. another dandiset's blob).
+    # '../../' walks out of 'test-zarr/<zarr_id>/' to the bucket root, so each parametrized
+    # path resolves to this key.
+    victim_key = 'blobs/victim-object'
+    ZarrArchive.storage.save(victim_key, ContentFile(b'victim'))
+    assert ZarrArchive.storage.exists(victim_key)
+
+    resp = api_client.delete(f'/api/zarr/{zarr_archive.zarr_id}/files/', [{'path': path}])
+
+    # Without the fix, delete_files resolves the traversal to the *existing* victim and
+    # deletes it (returning 204); the validator must reject the request first.
+    assert resp.status_code == 400
+    assert ZarrArchive.storage.exists(victim_key)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'prefix',
+    [
+        '../../blobs/traversed',
+        # Backslashes are normalized to '/' by django-storages,
+        # so this variant must be rejected too.
+        '..\\../blobs/traversed',
+        'a/../../b',
+        '..',
+    ],
+)
+def test_zarr_file_list_rejects_path_traversal(api_client, prefix):
+    zarr_archive = ZarrArchiveFactory.create()
+
+    resp = api_client.get(
+        f'/api/zarr/{zarr_archive.zarr_id}/files/',
+        {'prefix': prefix, 'download': True},
+    )
+    assert resp.status_code == 400
+
+    resp = api_client.head(f'/api/zarr/{zarr_archive.zarr_id}/files/', {'prefix': prefix})
+    assert resp.status_code == 400

--- a/dandiapi/zarr/tests/test_zarr_upload.py
+++ b/dandiapi/zarr/tests/test_zarr_upload.py
@@ -79,6 +79,35 @@ def test_zarr_rest_upload_start_not_an_owner(api_client):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    'path',
+    [
+        '../../blobs/traversed',
+        # Backslashes are normalized to '/' by django-storages' clean_name *after*
+        # normpath runs, so this variant must be rejected too.
+        '..\\../blobs/traversed',
+        'foo/../../../blobs/traversed',
+        '..',
+    ],
+)
+def test_zarr_rest_upload_start_rejects_path_traversal(api_client, path):
+    """A '..' in an upload path must be rejected before a presigned PUT is minted."""
+    user = UserFactory.create()
+    api_client.force_authenticate(user=user)
+    zarr_archive = ZarrArchiveFactory.create(dandiset__owners=[user])
+
+    resp = api_client.post(
+        f'/api/zarr/{zarr_archive.zarr_id}/files/',
+        [{'path': path, 'base64md5': 'DMF1ucDxtqgxw5niaXcmYQ=='}],
+    )
+    assert resp.status_code == 400
+
+    # No upload should have been started; the zarr is untouched.
+    zarr_archive.refresh_from_db()
+    assert zarr_archive.status == ZarrArchiveStatus.PENDING
+
+
+@pytest.mark.django_db
 def test_zarr_rest_finalize(
     api_client,
     zarr_file_factory,

--- a/dandiapi/zarr/views/__init__.py
+++ b/dandiapi/zarr/views/__init__.py
@@ -20,7 +20,7 @@ from dandiapi.api.services.exceptions import DandiError
 from dandiapi.api.services.permissions.dandiset import get_visible_dandisets, is_dandiset_owner
 from dandiapi.api.views.pagination import DandiPagination
 from dandiapi.api.views.serializers import DandisetIdentifierField
-from dandiapi.zarr.models import ZarrArchive, ZarrArchiveStatus
+from dandiapi.zarr.models import ZarrArchive, ZarrArchiveStatus, validate_zarr_path
 from dandiapi.zarr.tasks import ingest_zarr_archive
 
 if TYPE_CHECKING:
@@ -31,12 +31,12 @@ logger = logging.getLogger(__name__)
 
 
 class ZarrFileCreationSerializer(serializers.Serializer):
-    path = serializers.CharField()
+    path = serializers.CharField(validators=[validate_zarr_path])
     base64md5 = serializers.CharField()
 
 
 class ZarrDeleteFileRequestSerializer(serializers.Serializer):
-    path = serializers.CharField()
+    path = serializers.CharField(validators=[validate_zarr_path])
 
 
 class ZarrArchiveSerializer(serializers.ModelSerializer):
@@ -102,7 +102,7 @@ class ZarrListSerializer(serializers.ModelSerializer):
 
 class ZarrExploreInputSerializer(serializers.Serializer):
     after = serializers.CharField(default='')
-    prefix = serializers.CharField(default='')
+    prefix = serializers.CharField(default='', validators=[validate_zarr_path])
     limit = serializers.IntegerField(min_value=0, max_value=1000, default=1000)
     download = serializers.BooleanField(default=False)
 


### PR DESCRIPTION
The zarr file endpoints interpolate a user-supplied path into an S3 key of the form `zarr/<zarr_id>/<path>`. django-storages' `clean_name` runs `posixpath.normpath` (which collapses `..`) *before* its `safe_join` guard, and the storage `location` is empty, so a `..` segment escapes the zarr prefix and resolves to an arbitrary key in the shared bucket. ([This is intended behavior](https://github.com/jschneier/django-storages/blob/85928d63673190af4d689c9cad0e2ffaca21480a/storages/backends/s3.py#L520)) 

This lets anyone with a dandi account overwrite/delete arbitrary objects in the bucket, as well as potentially read embargoed data if they have the object key.

This PR adds a validator that rejects any `..` segment to the relevant serializers.