### PR TITLE
Fix for search in-progress indicator on the subsequent searches not being shown

### DIFF
--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -164,6 +164,7 @@
     <div
       v-else-if="searchActive && djangoDandisetRequest"
       class="mx-4 mx-md-8 mt-4 text-h6"
+      role="status"
     >
       <template v-if="loading">
         Searching&hellip;
@@ -180,6 +181,7 @@
       v-if="dandisets && dandisets.length"
       :dandisets="dandisets"
       :class="{ 'results-stale': loading }"
+      :inert="loading"
     />
     <v-container v-else>
       <v-row
@@ -285,6 +287,11 @@ watchEffect(async () => {
   latestRequest += 1;
   const thisRequest = latestRequest;
   loading.value = true;
+  // Clear the previous query's error, or its alert keeps rendering and
+  // suppresses the loading state below it for the whole of this request.
+  // `searchError` is only read in the template, so writing it here doesn't
+  // feed back into this effect.
+  searchError.value = null;
   try {
     const response = await dandiRest.dandisets(params);
     if (thisRequest !== latestRequest) {
@@ -354,10 +361,10 @@ watch(queryParams, (params) => {
 </script>
 
 <style scoped>
+/* Purely visual; `inert` on the list itself is what stops interaction. */
 .results-stale {
   opacity: 0.5;
   transition: opacity 0.2s ease;
-  pointer-events: none;
 }
 
 .btn-group--sort-options {

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -141,6 +141,17 @@
         </v-menu>
       </v-btn>
     </v-toolbar>
+    <!--
+      Immediate feedback that a request is in flight. Searches can take
+      several seconds, and without this the previous results sit on screen
+      with nothing to indicate that anything is happening.
+    -->
+    <v-progress-linear
+      :active="loading"
+      indeterminate
+      color="primary"
+      height="3"
+    />
     <v-alert
       v-if="searchActive && searchError"
       type="error"
@@ -154,11 +165,21 @@
       v-else-if="searchActive && djangoDandisetRequest"
       class="mx-4 mx-md-8 mt-4 text-h6"
     >
-      {{ djangoDandisetRequest.count }} {{ djangoDandisetRequest.count === 1 ? 'result' : 'results' }} found
+      <template v-if="loading">
+        Searching&hellip;
+      </template>
+      <template v-else>
+        {{ djangoDandisetRequest.count }} {{ djangoDandisetRequest.count === 1 ? 'result' : 'results' }} found
+      </template>
     </div>
+    <!--
+      Stale results stay mounted (rather than blanking the page) but are dimmed
+      so they don't read as the answer to the query being run.
+    -->
     <DandisetList
       v-if="dandisets && dandisets.length"
       :dandisets="dandisets"
+      :class="{ 'results-stale': loading }"
     />
     <v-container v-else>
       <v-row
@@ -168,7 +189,7 @@
       >
         <v-col>
           <v-progress-circular
-            v-if="!dandisets"
+            v-if="loading || !dandisets"
             indeterminate
           />
           <slot
@@ -241,23 +262,40 @@ const sortField = computed(() => sortingOptions[sortOption.value].djangoField);
 
 const djangoDandisetRequest: Ref<Paginated<Dandiset> | null> = ref(null);
 const searchError: Ref<string | null> = ref(null);
+const loading = ref(true);
+// Monotonically increasing id for the in-flight request. Only the newest one
+// is allowed to write results, so a slow earlier response can't overwrite a
+// newer one that already came back.
+let latestRequest = 0;
 watchEffect(async () => {
   const ordering = ((sortDir.value === -1) ? '-' : '') + sortField.value;
+  // Read every reactive dependency before the first `await`, or watchEffect
+  // won't track it.
+  const params = {
+    page: page.value,
+    page_size: DANDISETS_PER_PAGE,
+    ordering,
+    user: props.user ? 'me' : null,
+    search: searchActive.value ? route.query.search : null,
+    starred: props.starred ? true : null,
+    draft: props.user ? true : showDrafts.value,
+    empty: props.user ? true : showEmpty.value,
+    embargoed: props.user,
+  };
+  latestRequest += 1;
+  const thisRequest = latestRequest;
+  loading.value = true;
   try {
-    const response = await dandiRest.dandisets({
-      page: page.value,
-      page_size: DANDISETS_PER_PAGE,
-      ordering,
-      user: props.user ? 'me' : null,
-      search: searchActive.value ? route.query.search : null,
-      starred: props.starred ? true : null,
-      draft: props.user ? true : showDrafts.value,
-      empty: props.user ? true : showEmpty.value,
-      embargoed: props.user,
-    });
+    const response = await dandiRest.dandisets(params);
+    if (thisRequest !== latestRequest) {
+      return;
+    }
     djangoDandisetRequest.value = response.data;
     searchError.value = null;
   } catch (err) {
+    if (thisRequest !== latestRequest) {
+      return;
+    }
     // The advanced-search backend returns 400 with `{ search: "..." }` when
     // the query syntax is invalid. Surface that inline instead of letting
     // it bubble up to the global "something went wrong" snackbar.
@@ -273,6 +311,10 @@ watchEffect(async () => {
       }
     }
     throw err;
+  } finally {
+    if (thisRequest === latestRequest) {
+      loading.value = false;
+    }
   }
 });
 
@@ -312,6 +354,12 @@ watch(queryParams, (params) => {
 </script>
 
 <style scoped>
+.results-stale {
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
 .btn-group--sort-options {
   min-width: 84px;
 }


### PR DESCRIPTION
## Problem

The dandisets listing gives no feedback while a search is running. The spinner is gated on `dandisets` being undefined, and the previous response is never cleared when a new request starts, so in practice the spinner appears only on the very first page load. Any search run from an already-populated list leaves the old results sitting on screen, unchanged, until the new response arrives.

That is confusing at any latency and actively misleading at the latency we currently have: the advanced search operators can take upwards of ten seconds, during which the page looks like it has already answered the query. #2882 addresses the slowness itself; this addresses the fact that the remaining wait is invisible.

## Change

Track an explicit `loading` flag rather than inferring it from whether results exist. While a request is in flight:

- an indeterminate progress bar shows under the toolbar
- the result count is replaced with "Searching..."
- stale results stay mounted but are dimmed and non-interactive, so they do not read as the answer to the query being run

Keeping the old results visible rather than blanking the list avoids a full-page content flash on every pagination click, which is the common case and is usually fast.

## Out-of-order responses

The same change fixes a latent bug. Requests were not sequenced, so with a slow backend a fast follow-up search could be overwritten by an earlier, slower response landing after it. Requests now carry a monotonic id and only the newest may write results.

While I was in there I also hoisted the request parameters above the first `await`. They were already read synchronously, so this is not a behavior change, but it makes the `watchEffect` dependency tracking obvious rather than incidental.

## Testing

Frontend type check and lint pass. Verified manually against a local instance: the progress bar and spinner appear for the duration of a slow request and clear when it lands. I first reproduced the original bug by pointing the dev server at the production API, where `species:mouse` takes about 13 seconds, and confirmed the indicator now covers that whole window.

This is independent of #2882 and touches a different file, so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)