### PR TITLE
fix: import `migrate` from `dandischema.metadata`

### DIFF
--- a/dandiapi/api/management/commands/migrate_published_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_published_version_metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from difflib import ndiff
 from pprint import pformat
 
-from dandischema import migrate
+from dandischema.metadata import migrate
 import djclick as click
 
 from dandiapi.api.models import Version


### PR DESCRIPTION
`./manage.py migrate_published_version_metadata` fails at import time with `ImportError` and cannot run at all.

`dandischema` 0.12.0 ([dandi-schema#294](https://github.com/dandi/dandi-schema/pull/294)) stopped re-exporting `migrate` at the package root, but this command still does `from dandischema import migrate`. The sibling `migrate_version_metadata` command already uses the correct `from dandischema.metadata import migrate`.

Nothing in the test suite imports this module, which is why it went unnoticed.

## Test plan

- [x] Confirmed the `ImportError` on `master` under the current `dandischema==0.12.1` pin, and that the module imports cleanly after the change.
- [x] `ruff check` and `ruff format --check` pass.
