### PR TITLE
Add a redirect directive for hub.dandiarchive.org

### DIFF
--- a/redirector/netlify.toml
+++ b/redirector/netlify.toml
@@ -12,3 +12,8 @@ status = 301
 from = "https://api-staging.dandiarchive.org/*"
 to = "https://api.sandbox.dandiarchive.org/:splat"
 status = 308
+
+[[redirects]]
+from = "https://hub.dandiarchive.org/*"
+to = "https://docs.dandiarchive.org/user-guide-using/dandi-hub/"
+status = 302


### PR DESCRIPTION
Replaces #2877

This PR adds a redirection directive to the "Netlify redirector" app to 302 requests from hub.dandiarchive.org to the user docs (in honor of sunsetting DANDI Hub). We use 302 in case we want to use the hub subdomain in the future for something else.