### PR TITLE
Make redirection directives less confusing

### DIFF
--- a/redirector/api-staging.dandiarchive.org/README.md
+++ b/redirector/api-staging.dandiarchive.org/README.md
@@ -1,0 +1,5 @@
+# What is this?
+
+This Netlify site redirects api-staging.dandiarchive.org requests to
+api.sandbox.dandiarchive.org, to provide support for legacy URLs after the name
+change.

--- a/redirector/api-staging.dandiarchive.org/netlify.toml
+++ b/redirector/api-staging.dandiarchive.org/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "https://api-staging.dandiarchive.org/*"
+to = "https://api.sandbox.dandiarchive.org/:splat"
+status = 308

--- a/redirector/gui-staging.dandiarchive.org/README.md
+++ b/redirector/gui-staging.dandiarchive.org/README.md
@@ -1,0 +1,5 @@
+# What is this?
+
+This Netlify site redirects gui-staging.dandiarchive.org requests to
+sandbox.dandiarchive.org, to provide support for legacy URLs after the name
+change.

--- a/redirector/gui-staging.dandiarchive.org/netlify.toml
+++ b/redirector/gui-staging.dandiarchive.org/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "https://gui-staging.dandiarchive.org/*"
+to = "https://sandbox.dandiarchive.org/:splat"
+status = 301

--- a/redirector/gui.dandiarchive.org/README.md
+++ b/redirector/gui.dandiarchive.org/README.md
@@ -1,0 +1,3 @@
+# What is this?
+
+This Netlify site redirects all requests from gui.dandiarchive.org to dandiarchive.org. This is to provide backwards compatibility to anybody using legacy `gui.dandiarchive.org` URLs.

--- a/redirector/gui.dandiarchive.org/netlify.toml
+++ b/redirector/gui.dandiarchive.org/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "https://gui.dandiarchive.org/*"
+to = "https://dandiarchive.org/:splat"
+status = 301

--- a/redirector/hub.dandiarchive.org/README.md
+++ b/redirector/hub.dandiarchive.org/README.md
@@ -1,0 +1,5 @@
+# What is this?
+
+This Netlify site redirects hub.dandiarchive.org requests to
+https://docs.dandiarchive.org/user-guide-using/dandi-hub/, to implement
+sunsetting of DANDIHub.

--- a/redirector/hub.dandiarchive.org/netlify.toml
+++ b/redirector/hub.dandiarchive.org/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "https://hub.dandiarchive.org/*"
+to = "https://docs.dandiarchive.org/user-guide-using/dandi-hub/"
+status = 302


### PR DESCRIPTION
This PR splits apart the four redirects in `redirector/netlify.toml` into four subdirectories, each handling one redirect. This better matches the structure of our redirection Netlify apps, of which there are four, and which currently rely solely on domain matching to execute the correct redirection rule.

Reasons for doing this:
- less confusing for devs: each subdirectory handles one redirect and can be matched (by build directory) to one Netlify app
- less "blast radius" when there's a problem: a single typo anywhere in the unified netlify.toml file could cause up to all four of the redirections to stop working

Reasons not to do this:
- too many files / too much repetition to replace something that seems to be working
- we might want instead to unify all the Netlify redirector apps into a single app that has multiple hostnames associated to it (in something of an opposite move from this PR)

I am not sure whether this approach is better, if we should leave well enough alone, or if we should leave this as is and unify the Netlify apps into one. Accepting opinions 🙂 

(_Note:_ This leaves the original netlify.toml file in place so as not to disrupt Netlify's live operations at the moment. A later PR can remove that after the Netlify apps have been repointed to the new locations.)