### PR TITLE
Fix frontend lint command

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm ci
 
       - name: Lint Vue app
-        run: npm run lint --no-fix
+        run: npm run lint
 
       - name: Type-check Vue app
         run: npm run type-check

--- a/web/README.md
+++ b/web/README.md
@@ -21,7 +21,7 @@ To be useful, this app requires a server component, which you can run locally; s
 To fix the code formatting and check for common errors, run:
 
 ```bash
-npm run lint
+npm run format
 ```
 
 ### Schema Migration

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "type-check": "vue-tsc --build --force",
-    "lint": "eslint . --fix --max-warnings=0",
+    "lint": "eslint . --max-warnings=0",
+    "format": "eslint . --max-warnings=0 --fix",
     "migrate": "tsx src/migrate.ts"
   },
   "dependencies": {

--- a/web/src/components/DLP/HowToCiteTab.vue
+++ b/web/src/components/DLP/HowToCiteTab.vue
@@ -68,8 +68,14 @@
         </div>
         <div class="copy-block mb-4">
           <div class="copy-block-content">
-            <pre v-if="isCodeFormat" class="citation-text-code">{{ currentCitation }}</pre>
-            <span v-else class="citation-text">{{ currentCitation }}</span>
+            <pre
+              v-if="isCodeFormat"
+              class="citation-text-code"
+            >{{ currentCitation }}</pre>
+            <span
+              v-else
+              class="citation-text"
+            >{{ currentCitation }}</span>
             <v-btn
               icon
               size="small"
@@ -224,7 +230,6 @@
             </v-chip>
           </p>
         </div>
-
       </v-card-text>
     </v-card>
   </div>


### PR DESCRIPTION
The lint command was actually just formatting the code, which would succeed and not commit the changes, so we would never know that there are linting errors. The intended workflow is to error if there are things that need change.