### PR TITLE
e2e: reduce flakiness of playwright tests

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,5 @@ skip = .git,node_modules,dist,venv,.venv,.mypy_cache,.tox,package-lock.json,uv.l
 # got answer/re-solution
 # dictionary = .codespell_dict
 builtin = clear
-# ignore-words-list =
+# afterAll: Jest/Playwright test hook name, not a typo for "after all"
+ignore-words-list = afterall

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
-    workers: 4,
+    workers: 2,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/e2e/tests/dandisetLandingPage.spec.ts
+++ b/e2e/tests/dandisetLandingPage.spec.ts
@@ -43,7 +43,9 @@ test.describe("dandiset landing page", async () => {
     await newPage.waitForTimeout(250);
     await newPage.getByRole("dialog").getByRole("button").nth(1).click();
     await newPage.getByRole("button", { name: "Done" }).click();
-    await expect(newPage.getByText(otherUserName)).toHaveCount(1);
+    // Saving the owner change and re-rendering the owners list is an async
+    // round-trip; give it more room than the default 5s expect timeout.
+    await expect(newPage.getByText(otherUserName)).toHaveCount(1, { timeout: 15000 });
     await context.close();
   });
   test("navigate to an invalid dandiset URL", async ({ page }) => {

--- a/e2e/tests/dandisetLandingPage.spec.ts
+++ b/e2e/tests/dandisetLandingPage.spec.ts
@@ -4,6 +4,9 @@ import { faker } from "@faker-js/faker";
 
 test.describe("dandiset landing page", async () => {
   test("add an owner to the dandiset", async ({ page, browser }) => {
+    // This test does 2 full user signups, a dandiset registration, and a dialog
+    // interaction; under concurrent workers the default 30s budget is too tight.
+    test.slow();
     // Create a user to add as an owner later
     const {
       email: otherUserEmail,

--- a/e2e/tests/dandisetLandingPage.spec.ts
+++ b/e2e/tests/dandisetLandingPage.spec.ts
@@ -43,8 +43,8 @@ test.describe("dandiset landing page", async () => {
     await newPage.waitForTimeout(250);
     await newPage.getByRole("dialog").getByRole("button").nth(1).click();
     await newPage.getByRole("button", { name: "Done" }).click();
-    // Saving the owner change and re-rendering the owners list is an async
-    // round-trip; give it more room than the default 5s expect timeout.
+    // With high concurrency, the default timeout of 5s was not enough, raising the
+    // timeout reduces flakiness of this assertion.
     await expect(newPage.getByText(otherUserName)).toHaveCount(1, { timeout: 15000 });
     await context.close();
   });
@@ -55,11 +55,9 @@ test.describe("dandiset landing page", async () => {
   });
 
   test.describe("how to cite tab", () => {
-    // These tests only read the "How to Cite" tab of a single dandiset, so a fresh
-    // user + dandiset is registered once for the whole block instead of once per
-    // test. Registering per-test (7x) under 4-way parallelism was overloading the
-    // backend and causing frequent beforeEach timeouts; this also requires the
-    // tests to run serially, since they now share one page.
+    // Run these tests serially so we can create a single user + dandiset for the entire
+    // set, instead of creating a fresh user + dandiset per-test. This reduces load on the
+    // test server, which can cause flaky behavior.
     test.describe.configure({ mode: "serial" });
 
     let dandisetId: string | undefined;

--- a/e2e/tests/dandisetLandingPage.spec.ts
+++ b/e2e/tests/dandisetLandingPage.spec.ts
@@ -15,10 +15,10 @@ test.describe("dandiset landing page", async () => {
     } = await registerNewUser(page);
     const otherUserName = `${otherUserFirstname} ${otherUserLastName}`;
     const otherUserInitials = `${otherUserFirstname.charAt(0)}${otherUserLastName.charAt(0)}`;
-    // Right after signup the header can transiently render the avatar button more
-    // than once (exact cause not isolated), producing a strict-mode violation on
-    // this locator; .first() sidesteps it regardless of the mechanism.
-    await page.getByRole("button", { name: otherUserInitials }).first().click();
+    // By default, getByRole does case-insensitive substring matches. If the user initials
+    // appear as a substring in some other button on the page, this can cause issues finding
+    // the avatar icon, so we have to use `exact: true`.
+    await page.getByRole("button", { name: otherUserInitials, exact: true }).click();
     await page.getByText(LOGOUT_BUTTON_TEXT).click();
 
     // Create a fresh browser context and page

--- a/e2e/tests/dandisetLandingPage.spec.ts
+++ b/e2e/tests/dandisetLandingPage.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { clientUrl, registerNewUser, LOGOUT_BUTTON_TEXT, registerDandiset } from "../utils.ts";
 import { faker } from "@faker-js/faker";
 
@@ -50,16 +50,29 @@ test.describe("dandiset landing page", async () => {
   });
 
   test.describe("how to cite tab", () => {
-    let dandisetId: string | undefined;
+    // These tests only read the "How to Cite" tab of a single dandiset, so a fresh
+    // user + dandiset is registered once for the whole block instead of once per
+    // test. Registering per-test (7x) under 4-way parallelism was overloading the
+    // backend and causing frequent beforeEach timeouts; this also requires the
+    // tests to run serially, since they now share one page.
+    test.describe.configure({ mode: "serial" });
 
-    test.beforeEach(async ({ page }) => {
+    let dandisetId: string | undefined;
+    let page: Page;
+
+    test.beforeAll(async ({ browser }) => {
+      page = await browser.newPage();
       await registerNewUser(page);
       const dandisetName = faker.lorem.words();
       const dandisetDescription = faker.lorem.sentences();
       dandisetId = await registerDandiset(page, dandisetName, dandisetDescription);
     });
 
-    test("navigate to the How to Cite tab", async ({ page }) => {
+    test.afterAll(async () => {
+      await page.close();
+    });
+
+    test("navigate to the How to Cite tab", async () => {
       // Click the "How to Cite" tab
       await page.getByRole("tab", { name: "How to Cite" }).click();
 
@@ -67,7 +80,7 @@ test.describe("dandiset landing page", async () => {
       await expect(page.getByText("How to Cite this Dataset")).toBeVisible();
     });
 
-    test("displays draft warning for unpublished dandisets", async ({ page }) => {
+    test("displays draft warning for unpublished dandisets", async () => {
       await page.getByRole("tab", { name: "How to Cite" }).click();
 
       await expect(
@@ -78,7 +91,7 @@ test.describe("dandiset landing page", async () => {
       ).toBeVisible();
     });
 
-    test("displays all expected sections", async ({ page }) => {
+    test("displays all expected sections", async () => {
       await page.getByRole("tab", { name: "How to Cite" }).click();
 
       // Check all section headers are present
@@ -89,7 +102,7 @@ test.describe("dandiset landing page", async () => {
       await expect(page.getByRole("heading", { name: "License" })).toBeVisible();
     });
 
-    test("displays DANDI identifier with correct format", async ({ page }) => {
+    test("displays DANDI identifier with correct format", async () => {
       await page.getByRole("tab", { name: "How to Cite" }).click();
 
       // The identifier should follow the format DANDI:<id>/draft
@@ -97,14 +110,14 @@ test.describe("dandiset landing page", async () => {
       await expect(page.getByText("DANDI Archive RRID: SCR_017571")).toBeVisible();
     });
 
-    test("displays citation format selector", async ({ page }) => {
+    test("displays citation format selector", async () => {
       await page.getByRole("tab", { name: "How to Cite" }).click();
 
       // The format dropdown should be visible with APA 7th as default
       await expect(page.getByText("APA 7th")).toBeVisible();
     });
 
-    test("displays guide link", async ({ page }) => {
+    test("displays guide link", async () => {
       await page.getByRole("tab", { name: "How to Cite" }).click();
 
       await expect(
@@ -112,7 +125,7 @@ test.describe("dandiset landing page", async () => {
       ).toBeVisible();
     });
 
-    test("can switch back to Overview tab", async ({ page }) => {
+    test("can switch back to Overview tab", async () => {
       await page.getByRole("tab", { name: "How to Cite" }).click();
       await expect(page.getByText("How to Cite this Dataset")).toBeVisible();
 

--- a/e2e/tests/dandisetLandingPage.spec.ts
+++ b/e2e/tests/dandisetLandingPage.spec.ts
@@ -12,7 +12,10 @@ test.describe("dandiset landing page", async () => {
     } = await registerNewUser(page);
     const otherUserName = `${otherUserFirstname} ${otherUserLastName}`;
     const otherUserInitials = `${otherUserFirstname.charAt(0)}${otherUserLastName.charAt(0)}`;
-    await page.getByRole("button", { name: otherUserInitials }).click();
+    // Right after signup the header can transiently render the avatar button more
+    // than once (exact cause not isolated), producing a strict-mode violation on
+    // this locator; .first() sidesteps it regardless of the mechanism.
+    await page.getByRole("button", { name: otherUserInitials }).first().click();
     await page.getByText(LOGOUT_BUTTON_TEXT).click();
 
     // Create a fresh browser context and page

--- a/e2e/tests/registerDandiset.spec.ts
+++ b/e2e/tests/registerDandiset.spec.ts
@@ -15,7 +15,10 @@ test.describe("dandiset registration page", async () => {
     await page.locator(".v-select").filter({ hasText: "License" }).click();
     await page.getByRole("option", { name: "spdx:CC0-" }).click();
     await page.getByRole("button", { name: "Register Dandiset" }).click();
+    // Wait for the post-submit redirect to land on the new dandiset's page before
+    // asserting on its content, instead of racing the default 5s expect timeout.
+    await page.waitForURL(/\/dandiset\/\d+$/);
 
-    await expect(page.getByText("Licenses: spdx:CC0-")).toHaveCount(1);
+    await expect(page.getByText("Licenses: spdx:CC0-")).toHaveCount(1, { timeout: 15000 });
   });
 });

--- a/e2e/tests/registerDandiset.spec.ts
+++ b/e2e/tests/registerDandiset.spec.ts
@@ -10,7 +10,9 @@ test.describe("dandiset registration page", async () => {
     await page.getByLabel("Title").fill("My Dandiset");
     await page.getByLabel("Description").click();
     await page.getByLabel("Description").fill("My Dandiset Description");
-    await page.locator('div:nth-child(3) > .v-input__control > .v-field > .v-field__field > .v-field__input').click()
+    // Vuetify's v-select sets aria-label="Open" on its input, which overrides the
+    // associated <label> in accessible-name computation, so getByLabel can't find it.
+    await page.locator(".v-select").filter({ hasText: "License" }).click();
     await page.getByRole("option", { name: "spdx:CC0-" }).click();
     await page.getByRole("button", { name: "Register Dandiset" }).click();
 

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -59,7 +59,9 @@ async function registerDandiset(page: Page, name: string, description: string) {
   await page.locator(".v-select").filter({ hasText: "License" }).click();
   await page.getByRole("option", { name: "spdx:CC0-" }).click();
   await page.getByRole("button", { name: "Register Dandiset" }).click();
-  await page.waitForTimeout(1000);
+  // Wait for the post-submit redirect to land on the new dandiset's page before
+  // reading the id out of the URL, instead of racing a fixed timeout.
+  await page.waitForURL(/\/dandiset\/\d+$/);
   const dandisetId = await page.url().split("/").pop();
   return dandisetId;
 }

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -54,7 +54,9 @@ async function registerDandiset(page: Page, name: string, description: string) {
   await page.getByLabel("Title").fill(name);
   await page.getByLabel("Description").click();
   await page.getByLabel("Description").fill(description);
-  await page.locator('div:nth-child(3) > .v-input__control > .v-field > .v-field__field > .v-field__input').click()
+  // Vuetify's v-select sets aria-label="Open" on its input, which overrides the
+  // associated <label> in accessible-name computation, so getByLabel can't find it.
+  await page.locator(".v-select").filter({ hasText: "License" }).click();
   await page.getByRole("option", { name: "spdx:CC0-" }).click();
   await page.getByRole("button", { name: "Register Dandiset" }).click();
   await page.waitForTimeout(1000);

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,4 +1,4 @@
-import { type Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { faker } from "@faker-js/faker";
 
 const TEST_USER_INITIALS = "AA";
@@ -27,15 +27,21 @@ async function registerNewUser(page: Page) {
   await page.getByPlaceholder("Password (again)").click();
   await page.getByPlaceholder("Password (again)").fill(password);
   await page.getByRole("button", { name: "Sign Up" }).click();
+  // The next page's submit button is enabled by a plain keyup listener registered
+  // on DOMContentLoaded (see questionnaire_form.html), not a framework-bound
+  // model. click({ force: true }) skips Playwright's normal readiness checks, so
+  // without this wait we can start typing before that listener is even attached,
+  // and the button never enables.
+  await page.waitForLoadState("domcontentloaded");
+  // locator.fill() doesn't dispatch keyup either, so type the names out with
+  // pressSequentially() instead.
   await page.getByLabel("First Name").click({ force: true });
-  await page.getByLabel("First Name").fill(firstname);
+  await page.getByLabel("First Name").pressSequentially(firstname);
   await page.getByLabel("Last Name").click({ force: true });
-  await page.getByLabel("Last Name").fill(lastname);
-  await page.keyboard.press(" ");  // Using locator.fill does not enable to button for some reason
-  await page.waitForTimeout(1000);
-  await page.keyboard.press("Backspace");
-  await page.waitForTimeout(1000);
-  await page.getByRole("button").click();
+  await page.getByLabel("Last Name").pressSequentially(lastname);
+  const submitButton = page.getByRole("button");
+  await expect(submitButton).toBeEnabled();
+  await submitButton.click();
 
   return { email, firstname, lastname, password };
 }


### PR DESCRIPTION
### Problem
While spinning up for development on the `dandi-archive` repo, I noticed inconsistent test runs for the playwright end-to-end tests.

### Changes
This PR implements several changes to the e2e test suite to improve performance (by, e.g. utilizing `beforeAll` hooks to reduce API activity), make selectors behave more correctly/consistently, increase certain timeouts to help race conditions, and reduce the number of workers in order to decrease contention and load on the test server.

Testing was done locally by running the project in "native development" mode. Over the course of 30 pre-change runs of the e2e test suite I saw a pass rate of 88%. With the changes the pass rate is now 99.7% (over 20 runs). This should reduce time spent retrying failed tests in CI, and generally improve this set of tests.