### PR TITLE
Report the location and value that failed metadata validation

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from dandischema.conf import get_instance_config
 from dandischema.models import AccessType
@@ -25,6 +25,8 @@ class VersionAssetValidationError(TypedDict):
     field: str
     message: str
     path: str
+    # The value that failed validation, present only when it's a simple scalar
+    value: NotRequired[str]
 
 
 class Version(PublishableMetadataMixin, TimeStampedModel):
@@ -136,15 +138,19 @@ class Version(PublishableMetadataMixin, TimeStampedModel):
             .values('path', 'validation_errors')
         )[:50]
 
-        return list(pending_assets) + [
-            {
-                'field': error['field'],
-                'message': error['message'],
-                'path': asset['path'],
-            }
-            for asset in invalid_assets
-            for error in asset['validation_errors']
-        ]
+        invalid_asset_errors: list[VersionAssetValidationError] = []
+        for asset in invalid_assets:
+            for error in asset['validation_errors']:
+                asset_error: VersionAssetValidationError = {
+                    'field': error['field'],
+                    'message': error['message'],
+                    'path': asset['path'],
+                }
+                if 'value' in error:
+                    asset_error['value'] = error['value']
+                invalid_asset_errors.append(asset_error)
+
+        return list(pending_assets) + invalid_asset_errors
 
     @staticmethod
     def datetime_to_version(time: datetime.datetime) -> str:

--- a/dandiapi/api/services/metadata/__init__.py
+++ b/dandiapi/api/services/metadata/__init__.py
@@ -25,16 +25,50 @@ if TYPE_CHECKING:
 logger = get_task_logger(__name__)
 
 
+# Values longer than this are truncated before being stored on the error, so that
+# a single oversized string can't bloat the validation errors of every version.
+MAX_VALIDATION_ERROR_VALUE_LENGTH = 200
+
+
+def _encode_error_path(path) -> str:
+    """
+    Render the location of a validation error as a dotted path.
+
+    The path may be empty, e.g. for an error raised by a top-level
+    `@model_validator`, which attaches the error to the model root.
+    """
+    return '.'.join(str(part) for part in path)
+
+
+def _encode_error_value(value) -> str | None:
+    """
+    Render the value that failed validation, if it's simple enough to be worth showing.
+
+    Containers (a whole contributor object, say) are omitted: they're large, and the
+    error path already identifies them.
+    """
+    if not isinstance(value, str | int | float | bool):
+        return None
+    value = str(value)
+    if len(value) > MAX_VALIDATION_ERROR_VALUE_LENGTH:
+        value = value[:MAX_VALIDATION_ERROR_VALUE_LENGTH] + '\u2026'
+    return value
+
+
+def _encode_error(path, message: str, value) -> dict[str, str]:
+    error = {'field': _encode_error_path(path), 'message': message}
+    encoded_value = _encode_error_value(value)
+    if encoded_value is not None:
+        error['value'] = encoded_value
+    return error
+
+
 def _encode_pydantic_error(error) -> dict[str, str]:
-    # `loc` may be an empty tuple, e.g. for an error raised by a top-level
-    # `@model_validator`, which attaches the error to the model root. Mirror how
-    # `_encode_jsonschema_error` tolerates an empty path so we don't IndexError.
-    loc = error['loc']
-    return {'field': str(loc[0]) if loc else '', 'message': error['msg']}
+    return _encode_error(error['loc'], error['msg'], error.get('input'))
 
 
 def _encode_jsonschema_error(error: jsonschema.exceptions.ValidationError) -> dict[str, str]:
-    return {'field': '.'.join([str(p) for p in error.path]), 'message': error.message}
+    return _encode_error(error.path, error.message, error.instance)
 
 
 def _collect_validation_errors(

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -18,6 +18,7 @@ from zarr_checksum.generators import ZarrArchiveFile
 
 from dandiapi.api import tasks
 from dandiapi.api.models import Asset, Version
+from dandiapi.api.services.metadata import MAX_VALIDATION_ERROR_VALUE_LENGTH
 from dandiapi.api.tests.factories import DraftVersionFactory, UserFactory
 from dandiapi.zarr.models import ZarrArchiveStatus
 
@@ -137,7 +138,7 @@ def test_validate_asset_metadata_malformed_keywords(draft_asset: Asset):
 
     assert draft_asset.status == Asset.Status.INVALID
     assert draft_asset.validation_errors == [
-        {'field': 'keywords', 'message': "'foo' is not of type 'array'"}
+        {'field': 'keywords', 'message': "'foo' is not of type 'array'", 'value': 'foo'}
     ]
 
 
@@ -273,8 +274,67 @@ def test_validate_version_metadata_malformed_license(asset: Asset):
 
     assert draft_version.status == Version.Status.INVALID
     assert draft_version.validation_errors == [
-        {'field': 'license', 'message': "'foo' is not of type 'array'"}
+        {'field': 'license', 'message': "'foo' is not of type 'array'", 'value': 'foo'}
     ]
+
+
+@pytest.mark.django_db
+def test_validate_version_metadata_malformed_contributor_name(asset: Asset):
+    draft_version = DraftVersionFactory.create()
+    draft_version.assets.add(asset)
+
+    # The name of a Person contributor must be given as "Family, Given"
+    draft_version.metadata['contributor'][0]['name'] = 'Yemini Eviatar'
+    draft_version.save()
+
+    tasks.validate_version_metadata_task(draft_version.id)
+
+    draft_version.refresh_from_db()
+
+    assert draft_version.status == Version.Status.INVALID
+    assert len(draft_version.validation_errors) == 1
+    error = draft_version.validation_errors[0]
+    # The error must identify which contributor failed, not just the `contributor` field
+    assert error['field'] == 'contributor.0.Person.name'
+    assert error['value'] == 'Yemini Eviatar'
+    assert error['message'].startswith('String should match pattern')
+
+
+@pytest.mark.django_db
+def test_validate_version_metadata_long_value_truncated(asset: Asset):
+    draft_version = DraftVersionFactory.create()
+    draft_version.assets.add(asset)
+
+    name = 'x' * (MAX_VALIDATION_ERROR_VALUE_LENGTH + 10)
+    draft_version.metadata['contributor'][0]['name'] = name
+    draft_version.save()
+
+    tasks.validate_version_metadata_task(draft_version.id)
+
+    draft_version.refresh_from_db()
+
+    assert draft_version.status == Version.Status.INVALID
+    assert draft_version.validation_errors[0]['value'] == (
+        name[:MAX_VALIDATION_ERROR_VALUE_LENGTH] + '\u2026'
+    )
+
+
+@pytest.mark.django_db
+def test_validate_version_metadata_no_value_for_containers(asset: Asset):
+    draft_version = DraftVersionFactory.create()
+    draft_version.assets.add(asset)
+
+    del draft_version.metadata['contributor'][0]['name']
+    draft_version.save()
+
+    tasks.validate_version_metadata_task(draft_version.id)
+
+    draft_version.refresh_from_db()
+
+    assert draft_version.status == Version.Status.INVALID
+    # The failing value here is the whole contributor object, which is too large to be
+    # worth showing, so only the location and the message are reported
+    assert all('value' not in error for error in draft_version.validation_errors)
 
 
 @pytest.mark.django_db

--- a/web/src/components/DLP/ValidationErrorDialog.vue
+++ b/web/src/components/DLP/ValidationErrorDialog.vue
@@ -40,10 +40,7 @@
                 </v-icon>
               </v-list-item>
 
-              <template v-if="error.field">
-                {{ error.field }}:
-              </template>
-              {{ error.message }}
+              {{ formatValidationError(error) }}
             </v-list-item>
             <v-divider />
           </div>
@@ -79,10 +76,7 @@
                 <!-- Inline single errors -->
                 <template v-if="errors.length === 1">
                   <strong>{{ path }}</strong>
-                  <template v-if="errors[0].field">
-                    {{ errors[0].field }} -
-                  </template>
-                  {{ errors[0].message }}
+                  {{ formatValidationError(errors[0]) }}
                 </template>
 
                 <!-- Group multiple asset errors -->
@@ -103,10 +97,7 @@
                         </v-icon>
                       </v-list-item>
 
-                      <template v-if="error.field">
-                        {{ error.field }}:
-                      </template>
-                      {{ error.message }}
+                      {{ formatValidationError(error) }}
                     </v-list-item>
                   </v-list-group>
                 </template>
@@ -168,8 +159,19 @@ const groupedAssetValidationErrors = computed(() => {
   return path_asset_map;
 });
 
+// Render an error as "<path>: <message> (value: <offending value>)", omitting the
+// path and the value when the backend didn't supply them.
+function formatValidationError(error: ValidationError): string {
+  const field = error.field ? `${error.field}: ` : '';
+  const value = error.value === undefined ? '' : ` (value: ${JSON.stringify(error.value)})`;
+  return `${field}${error.message}${value}`;
+}
+
 function getValidationErrorIcon(errorField: string): string {
-  const icons = Object.keys(VALIDATION_ICONS).filter((field) => errorField.includes(field));
+  // Icons are keyed by top-level field, so only the head of the error path is matched
+  // ("contributor" in "contributor.0.Person.name").
+  const topLevelField = errorField.split('.')[0];
+  const icons = Object.keys(VALIDATION_ICONS).filter((field) => topLevelField.includes(field));
   if (icons.length > 0) {
     return (VALIDATION_ICONS as any)[icons[0]];
   }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -32,6 +32,8 @@ export interface ValidationError {
   field: string,
   message: string,
   path: string,
+  // The value that failed validation, present only when it's a simple scalar
+  value?: string,
 }
 
 export interface Version {


### PR DESCRIPTION
Closes #2901.

A metadata validation error previously showed only the top-level field and the message, so an error on one element of a list gave the user no way to tell which element was at fault. On https://dandiarchive.org/dandiset/000981/draft the entire error reads:

```
contributor: String should match pattern '^([\w\s\-\.']+),\s+([\w\s\-\.']+)$'
```

with 15 contributors to choose from.

## Changes

`_encode_pydantic_error` keeps the full `loc` as a dotted path rather than only its first element, and both encoders now carry the value that failed validation through to the UI in a new optional `value` key. The value is included only when it is a simple scalar, and is truncated at 200 characters: a container, a whole contributor object for instance, is large and is already identified by the path.

The same error now reads:

```
contributor.9.Person.name: String should match pattern '^([\w\s\-\.']+),\s+([\w\s\-\.']+)$' (value: "Yemini Eviatar")
```

Since the path may now be dotted, the icon lookup in the validation error dialog matches against its first segment rather than the whole path, so that `contributor.9.Person.name` still gets the contributor icon rather than the one keyed on `name`.

The three renderings of an error in `ValidationErrorDialog.vue` are consolidated into a single `formatValidationError` helper, which incidentally makes the inline single-asset-error case use the same `field: message` separator as the other two rather than `field - message`.

`value` is a new optional key on the error objects stored in the `validation_errors` JSON column. Errors already in the database simply won't have it, and both the type and the frontend treat it as optional, so no migration or backfill is needed.

## Testing

Added tests covering the contributor case that motivated this, the truncation of long values, and the omission of container values. The existing assertions on `keywords` and `license` errors are updated to include the new key. `tox -e test` passes in full (864 tests), as do `tox -e lint`, `npm run lint`, and `npm run type-check`. `tox -e type` fails on this branch, but it fails on `master` as well, with one fewer error here than there and none of them in the code this PR touches.

## Errors Stored Before This Change

Nothing needs to be migrated. An error stored under the old encoding has `field` and `message` but no `value`, and every reader treats `value` as optional: the frontend renders `field: message` exactly as before, and the passthrough in `Version.asset_validation_errors` copies `value` only when the key is present. The icon lookup is also unaffected, since splitting an undotted path on `.` returns the path itself.

Those errors will not gain the added detail until the object is revalidated, though. The scheduled validation tasks only pick up versions and assets in `PENDING` status, so a dandiset already sitting at `INVALID` keeps its stored error until its metadata is edited and the status resets. If it would be worth applying the improvement retroactively, that would be a separate one-off job to re-queue validation for everything currently `INVALID`, and I have left it out of this PR.
