### PR TITLE
Centralize `/api/info` calls + cleaner production/sandbox identification

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -79,12 +79,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, type PropType } from 'vue';
+import { computed, type PropType } from 'vue';
 import { useRoute } from 'vue-router';
 import moment from 'moment';
 import { filesize } from 'filesize';
 import StarButton from '@/components/StarButton.vue';
-import { dandiRest } from '@/rest';
+import { useInstanceStore } from '@/stores/instance';
 
 import type { Version } from '@/types';
 import { DANDISETS_PER_PAGE } from '@/utils/constants';
@@ -97,12 +97,10 @@ defineProps({
 });
 
 const route = useRoute();
-const archiveName = ref<string>('');
 
-onMounted(async () => {
-  const info = await dandiRest.info();
-  archiveName.value = info.instance_config.instance_name;
-});
+const instanceStore = useInstanceStore();
+instanceStore.load();
+const archiveName = computed(() => instanceStore.instanceName ?? '');
 
 // current position in search result set = items on prev pages + position on current page
 function getPos(index: number) {

--- a/web/src/components/FileBrowser/FileUploadInstructions.vue
+++ b/web/src/components/FileBrowser/FileUploadInstructions.vue
@@ -48,20 +48,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed } from 'vue';
 import { useDandisetStore } from '@/stores/dandiset';
+import { useInstanceStore } from '@/stores/instance';
 import { dandiDocumentationUrl } from '@/utils/constants';
-import { dandiRest } from '@/rest';
 
 const store = useDandisetStore();
 const dandisetIdentifier = computed(() => store.dandiset?.dandiset.identifier);
 
-const instanceName = ref<string>('');
-
-onMounted(async () => {
-  const info = await dandiRest.info();
-  instanceName.value = info.instance_config.instance_name.toLowerCase();
-});
+const instanceStore = useInstanceStore();
+instanceStore.load();
+const instanceName = computed(() => instanceStore.instanceName?.toLowerCase() ?? '');
 
 if (dandisetIdentifier.value === undefined) {
   throw new Error('store.dandiset must be defined');

--- a/web/src/stores/dandiset.ts
+++ b/web/src/stores/dandiset.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 import RefParser from '@apidevtools/json-schema-ref-parser';
 
 import { dandiRest, user } from '@/rest';
+import { useInstanceStore } from '@/stores/instance';
 import type { User, Version } from '@/types';
 import { draftVersion } from '@/utils/constants';
 import { fixSchema } from '@/utils/schema';
@@ -110,8 +111,13 @@ export const useDandisetStore = defineStore('dandiset', {
       }
     },
     async fetchSchema() {
-      const { schema_url: schemaUrl } = await dandiRest.info();
-      const res = await axios.get(schemaUrl);
+      const instanceStore = useInstanceStore();
+      await instanceStore.load();
+      if (instanceStore.info === null) {
+        throw new Error('Could not retrieve server info!');
+      }
+
+      const res = await axios.get(instanceStore.info.schema_url);
 
       if (res.status !== 200) {
         throw new Error('Could not retrieve Dandiset Schema!');

--- a/web/src/stores/instance.ts
+++ b/web/src/stores/instance.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia';
+
+import { dandiRest } from '@/rest';
+import type { Info } from '@/types';
+
+// Values of DJANGO_DANDI_INSTANCE_NAME for the DANDI-operated deployments,
+// reported by the server at /api/info/.
+const PRODUCTION_INSTANCE_NAME = 'DANDI';
+const SANDBOX_INSTANCE_NAME = 'DANDI-SANDBOX';
+
+// Shared by all callers of load() so the request is only made once per session.
+let infoRequest: Promise<Info> | undefined;
+
+interface State {
+  info: Info | null;
+}
+
+export const useInstanceStore = defineStore('instance', {
+  state: (): State => ({
+    info: null,
+  }),
+  getters: {
+    instanceName: (state) => state.info?.instance_config.instance_name,
+    // Until /api/info/ has been fetched successfully, the instance is not considered
+    // production or sandbox, so features gated on these getters fail closed.
+    isProduction(): boolean {
+      return this.instanceName === PRODUCTION_INSTANCE_NAME;
+    },
+    isSandbox(): boolean {
+      return this.instanceName === SANDBOX_INSTANCE_NAME;
+    },
+  },
+  actions: {
+    async load() {
+      if (this.info) {
+        return;
+      }
+      if (infoRequest === undefined) {
+        infoRequest = dandiRest.info();
+      }
+      try {
+        this.info = await infoRequest;
+      } catch (error) {
+        // Leave the instance identity unknown; clearing the shared request
+        // lets a later call retry.
+        console.error('Error fetching server instance info:', error);
+        infoRequest = undefined;
+      }
+    },
+  },
+});

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -130,17 +130,21 @@
   </v-menu>
 </template>
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useDandisetStore } from '@/stores/dandiset';
+import { useInstanceStore } from '@/stores/instance';
 import CopyText from '@/components/CopyText.vue';
 import { dandiDocumentationUrl } from '@/utils/constants';
-import { dandiRest } from '@/rest';
+
+const instanceStore = useInstanceStore();
+instanceStore.load();
 
 function downloadCommand(identifier: string, version: string): string {
-  // Use the special 'DANDI:' url prefix if appropriate.
+  // Use the special 'DANDI:' url prefix if the dandiset lives on the production
+  // instance, since that is the instance the CLI resolves those IDs against.
   const generalUrl = `${window.location.origin}/dandiset/${identifier}`;
   const dandiUrl = `DANDI:${identifier}`;
-  const url = window.location.origin == 'https://dandiarchive.org' ? dandiUrl : generalUrl;
+  const url = instanceStore.isProduction ? dandiUrl : generalUrl;
 
   // Prepare a url suffix to specify a specific version (or not).
   const versionPath = version ? `/${version}` : '';
@@ -154,13 +158,8 @@ const currentDandiset = computed(() => store.dandiset);
 const publishedVersions = computed(() => store.versions);
 const currentVersion = computed(() => store.version);
 
-const cliMinimalVersion = ref<string>();
-const cliRequiresPython = ref<string>();
-onMounted(async () => {
-  const info = await dandiRest.info();
-  cliMinimalVersion.value = info['cli-minimal-version'];
-  cliRequiresPython.value = info['cli-requires-python'];
-});
+const cliMinimalVersion = computed(() => instanceStore.info?.['cli-minimal-version']);
+const cliRequiresPython = computed(() => instanceStore.info?.['cli-requires-python']);
 
 const selectedDownloadOption = ref('draft');
 const selectedVersion = ref(0);

--- a/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
+++ b/web/src/views/DandisetLandingView/ExternalDandisetServicesDialog.vue
@@ -78,8 +78,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useDandisetStore } from '@/stores/dandiset';
+import { useInstanceStore } from '@/stores/instance';
 
 const store = useDandisetStore();
+const instanceStore = useInstanceStore();
+instanceStore.load();
 
 const currentDandiset = computed(() => store.dandiset);
 
@@ -92,14 +95,10 @@ const neurosiftURL = computed(() => {
     throw new Error('Dandiset metadata is undefined');
   }
 
-  if (!currentDandiset.value.metadata.url) {
-    throw new Error('Dandiset metadata.url is undefined');
-  }
-
   const metadata = currentDandiset.value.metadata;
   const dandisetId = currentDandiset.value.dandiset.identifier;
   const dandisetVersion = metadata.version;
-  const stagingParam = metadata.url!.startsWith('https://sandbox.dandiarchive.org/') ? '&staging=1' : '';
+  const stagingParam = instanceStore.isSandbox ? '&staging=1' : '';
 
   return `https://neurosift.app/dandiset/${dandisetId}?dandisetVersion=${dandisetVersion}${stagingParam}`;
 });


### PR DESCRIPTION
The frontend previously identified the deployment by string-matching hardcoded hosts (window.location.origin or metadata.url). The server already names itself via /api/info/ instance_config.instance_name (`DANDI` for production, `DANDI-SANDBOX` for sandbox, `DEV-DANDI` in development, and `DANDI-ADHOC` as the default when nothing is provided), so this PR updates the web client to cache that in a Pinia store and derive isProduction/isSandbox from it. 

The motivation for this change is that we currently have several areas of the frontend where we need to do things conditionally depending on whether we're running in production or sandbox, and all of them handle it by hardcoding URL strings and/or dynamically calling the `/api/info` endpoint. #2873 needs this behavior too, and adds more undesirable one-off logic for this. Also, we've discussed having some sort of indicator banner on sandbox to identify it as such (#748); this would also enable doing that in a clean way.

Downstream archives like EMBER can tweak the production/sandbox identifier strings as needed. I opted not to do this in this PR, but we could even make them configurable via environment variables as we do for similar values on the server.

This also converges the four separate dandiRest.info() call sites on one shared request.