### PR TITLE
Fix publish-time race between DOI minting and manifest writing

### DIFF
--- a/dandiapi/api/management/commands/rewrite_manifests_missing_doi.py
+++ b/dandiapi/api/management/commands/rewrite_manifests_missing_doi.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from django.core.files.storage import default_storage
+import djclick as click
+from tqdm import tqdm
+import yaml
+
+from dandiapi.api.manifests import (
+    _dandiset_jsonld_path,
+    _dandiset_yaml_path,
+    write_dandiset_jsonld,
+    write_dandiset_yaml,
+)
+from dandiapi.api.models import Version
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from django.db.models import QuerySet
+
+logger = logging.getLogger(__name__)
+
+
+def _manifests_embedding_metadata(version: Version) -> Iterator[tuple[str, Callable[[Any], Any]]]:
+    """Yield the manifest files written from `version.metadata`, with their parsers.
+
+    These are the only manifests which embed the DOI; the asset and collection
+    manifests are unaffected.
+    """
+    yield _dandiset_jsonld_path(version), json.load
+    yield _dandiset_yaml_path(version), yaml.safe_load
+
+
+def stale_manifest_paths(version: Version) -> list[str]:
+    """Return the manifest paths of `version` which don't carry the DOI from its metadata.
+
+    A manifest which is missing, unreadable, or malformed is also considered stale,
+    since rewriting it is the fix in either case.
+    """
+    expected_doi = version.metadata.get('doi')
+
+    stale = []
+    for path, load in _manifests_embedding_metadata(version):
+        try:
+            with default_storage.open(path) as manifest_file:
+                metadata = load(manifest_file)
+            manifest_doi = metadata.get('doi')
+        except Exception as e:  # noqa: BLE001
+            logger.info('Could not read manifest %s, assuming it needs rewriting: %s', path, e)
+            stale.append(path)
+            continue
+
+        if manifest_doi != expected_doi:
+            stale.append(path)
+
+    return stale
+
+
+def _find_stale_versions(version_qs: QuerySet[Version]) -> list[tuple[Version, list[str]]]:
+    """Return every published version in `version_qs` with its stale manifest paths."""
+    total_versions = version_qs.count()
+    click.echo(f'Scanning {total_versions} published versions for manifests missing their DOI...')
+
+    stale_versions: list[tuple[Version, list[str]]] = []
+    versions_without_doi = 0
+    versions_with_unpopulated_doi: list[Version] = []
+    for version in tqdm(version_qs.iterator(), total=total_versions):
+        if not version.metadata.get('doi'):
+            versions_without_doi += 1
+            if version.doi:
+                versions_with_unpopulated_doi.append(version)
+            continue
+
+        stale_paths = stale_manifest_paths(version)
+        if stale_paths:
+            stale_versions.append((version, stale_paths))
+
+    if versions_without_doi:
+        click.echo(f'\nSkipped {versions_without_doi} published versions with no DOI in metadata')
+    for version in versions_with_unpopulated_doi:
+        click.echo(
+            f'  WARNING: {version.dandiset.identifier}/{version.version} has DOI {version.doi} '
+            f'but no `doi` in its metadata, so its manifests cannot be repaired without '
+            f'modifying the published version',
+            err=True,
+        )
+
+    return stale_versions
+
+
+@click.command()
+@click.argument(
+    'dandisets',
+    type=click.INT,
+    nargs=-1,
+)
+@click.option(
+    '-a',
+    '--all',
+    'include_all',
+    is_flag=True,
+    help='Run on all dandisets.',
+)
+@click.option(
+    '--dry-run',
+    is_flag=True,
+    default=False,
+    help='Show what would be rewritten without writing anything.',
+)
+def rewrite_manifests_missing_doi(dandisets: tuple[int, ...], *, include_all: bool, dry_run: bool):
+    """
+    Rewrite the manifest files of published versions whose manifests are missing their DOI.
+
+    Publishing used to mint the DOI and write the manifest files in a race condition,
+    so the manifest could be written before the DOI was saved, leaving
+    `dandiset.jsonld`/`dandiset.yaml` on S3 without `doi` (and with a non-DOI `citation`).
+    See https://github.com/dandi/dandi-archive/issues/2759.
+
+    This command rewrites the manifest files of versions who have a DOI stored in their metadata,
+    but is missing from the existing manifest files in S3.
+
+    Versions whose metadata itself has no `doi` are reported but skipped, as there is no DOI
+    to write into their manifests.
+    """
+    if bool(dandisets) == include_all:
+        raise click.ClickException("Must specify exactly one of 'dandisets' or --all")
+
+    version_qs = (
+        Version.objects.exclude(version='draft')
+        .select_related('dandiset')
+        .order_by('dandiset_id', 'version')
+    )
+    if dandisets:
+        version_qs = version_qs.filter(dandiset_id__in=dandisets)
+
+    stale_versions = _find_stale_versions(version_qs)
+    if not stale_versions:
+        click.echo('No published versions found with manifests missing their DOI. Nothing to do.')
+        return
+
+    click.echo(f'\nProcessing {len(stale_versions)} versions with stale manifests...')
+    for processed_count, (version, stale_paths) in enumerate(stale_versions, 1):
+        click.echo(
+            f'Processing {version.dandiset.identifier}/{version.version} '
+            f'({processed_count}/{len(stale_versions)})'
+        )
+        for path in stale_paths:
+            click.echo(f'  Stale manifest: {path}')
+
+        if dry_run:
+            click.echo('  [DRY RUN] Would rewrite manifest files...')
+        else:
+            click.echo('  Rewriting manifest files...')
+            write_dandiset_yaml(version)
+            write_dandiset_jsonld(version)
+
+    if dry_run:
+        click.echo(
+            f'\n[DRY RUN] Would have rewritten manifest files for {len(stale_versions)} versions'
+        )
+    else:
+        click.echo(f'\nRewrote manifest files for {len(stale_versions)} versions')

--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -198,38 +198,16 @@ def _publish_dandiset(dandiset_id: int, user_id: int) -> None:
 
         validate(new_version.metadata, schema_key='PublishedDandiset', json_validation=True)
 
-        # After the published version is committed, mint the DOI first and
-        # only then write the manifest files. Doing these as two independent
-        # ``on_commit`` callbacks raced — the manifest task could run before
-        # the DOI was saved, leaving ``dandiset.jsonld`` on S3 without
-        # ``doi`` (and with a non-DOI ``citation``) and never rewritten. See
-        # https://github.com/dandi/dandi-archive/issues/2759.
-        #
-        # Failures at either substep are logged distinctly but do not abort
-        # the manifest write: even a DOI-less published version is better
-        # represented by an on-S3 manifest than by nothing.
-        # ``sync_manifest_files --fix-doi`` can later remint the DOI and
-        # rewrite the manifest if either substep below was skipped or failed.
-        def _create_doi_and_write_manifests(version_id: int):
+        def _create_doi(version_id: int):
             version = Version.objects.get(id=version_id)
-            new_doi: str | None = None
-            try:
-                new_doi = doi.create_doi(version)
-            except Exception:
-                logger.exception('Failed to mint DOI for version %s', version_id)
-            if new_doi is not None:
-                try:
-                    version.doi = new_doi
-                    version.save()
-                except Exception:
-                    logger.exception(
-                        'Minted DOI %s but failed to persist it on version %s',
-                        new_doi,
-                        version_id,
-                    )
-            write_manifest_files.delay(version_id)
+            version.doi = doi.create_doi(version)
+            version.save()
 
-        transaction.on_commit(lambda: _create_doi_and_write_manifests(new_version.id))
+        # Call _create_doi before writing manifest files, so that the new DOI is included in the
+        # manifests. If DOI creation fails, proceed to writing manifests anyway, to maintain
+        # existing behavior.
+        transaction.on_commit(lambda: _create_doi(new_version.id), robust=True)
+        transaction.on_commit(lambda: write_manifest_files.delay(new_version.id))
 
         user = User.objects.get(id=user_id)
         audit.publish_dandiset(

--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import logging
 from typing import TYPE_CHECKING
 
 from dandischema.conf import get_instance_config
@@ -28,6 +29,8 @@ from dandiapi.api.tasks import write_manifest_files
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
+
+logger = logging.getLogger(__name__)
 
 
 def publish_asset(*, asset: Asset) -> None:
@@ -195,16 +198,38 @@ def _publish_dandiset(dandiset_id: int, user_id: int) -> None:
 
         validate(new_version.metadata, schema_key='PublishedDandiset', json_validation=True)
 
-        # Write updated manifest files and create DOI after
-        # published version has been committed to DB.
-        transaction.on_commit(lambda: write_manifest_files.delay(new_version.id))
-
-        def _create_doi(version_id: int):
+        # After the published version is committed, mint the DOI first and
+        # only then write the manifest files. Doing these as two independent
+        # ``on_commit`` callbacks raced — the manifest task could run before
+        # the DOI was saved, leaving ``dandiset.jsonld`` on S3 without
+        # ``doi`` (and with a non-DOI ``citation``) and never rewritten. See
+        # https://github.com/dandi/dandi-archive/issues/2759.
+        #
+        # Failures at either substep are logged distinctly but do not abort
+        # the manifest write: even a DOI-less published version is better
+        # represented by an on-S3 manifest than by nothing.
+        # ``sync_manifest_files --fix-doi`` can later remint the DOI and
+        # rewrite the manifest if either substep below was skipped or failed.
+        def _create_doi_and_write_manifests(version_id: int):
             version = Version.objects.get(id=version_id)
-            version.doi = doi.create_doi(version)
-            version.save()
+            new_doi: str | None = None
+            try:
+                new_doi = doi.create_doi(version)
+            except Exception:
+                logger.exception('Failed to mint DOI for version %s', version_id)
+            if new_doi is not None:
+                try:
+                    version.doi = new_doi
+                    version.save()
+                except Exception:
+                    logger.exception(
+                        'Minted DOI %s but failed to persist it on version %s',
+                        new_doi,
+                        version_id,
+                    )
+            write_manifest_files.delay(version_id)
 
-        transaction.on_commit(lambda: _create_doi(new_version.id))
+        transaction.on_commit(lambda: _create_doi_and_write_manifests(new_version.id))
 
         user = User.objects.get(id=user_id)
         audit.publish_dandiset(

--- a/dandiapi/api/services/publish/__init__.py
+++ b/dandiapi/api/services/publish/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import datetime
-import logging
 from typing import TYPE_CHECKING
 
 from dandischema.conf import get_instance_config
@@ -29,8 +28,6 @@ from dandiapi.api.tasks import write_manifest_files
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
-
-logger = logging.getLogger(__name__)
 
 
 def publish_asset(*, asset: Asset) -> None:

--- a/dandiapi/api/tests/test_rewrite_manifests_missing_doi.py
+++ b/dandiapi/api/tests/test_rewrite_manifests_missing_doi.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+
+from django.core.files.storage import default_storage
+from django.forms.models import model_to_dict
+import djclick as click
+import pytest
+import yaml
+
+from dandiapi.api.management.commands.rewrite_manifests_missing_doi import (
+    rewrite_manifests_missing_doi,
+    stale_manifest_paths,
+)
+from dandiapi.api.manifests import _dandiset_jsonld_path, _dandiset_yaml_path
+from dandiapi.api.models import Version
+from dandiapi.api.tasks import write_manifest_files
+from dandiapi.api.tests.factories import PublishedVersionFactory
+
+
+def _written_manifests(version: Version) -> tuple[dict, dict]:
+    with default_storage.open(_dandiset_jsonld_path(version)) as f:
+        dandiset_jsonld = json.load(f)
+    with default_storage.open(_dandiset_yaml_path(version)) as f:
+        dandiset_yaml = yaml.safe_load(f)
+
+    return dandiset_jsonld, dandiset_yaml
+
+
+@pytest.fixture
+def version_with_doi_less_manifests():
+    """Publish a version whose on-S3 manifests were written before its DOI was saved.
+
+    This reproduces the dandi/dandi-archive#2759 race: the DOI is committed on the
+    version, but the manifests still carry the pre-DOI metadata.
+    """
+    version: Version = PublishedVersionFactory.create()
+    doi = version.doi
+
+    # Write the manifests from a DOI-less version, exactly as the racing manifest task did.
+    # `_populate_metadata` only ever adds `doi`, so it has to be stripped explicitly.
+    version.doi = None
+    version.metadata = {k: v for k, v in version.metadata.items() if k != 'doi'}
+    version.save()
+    write_manifest_files(version.id)
+
+    # ...and only then save the minted DOI.
+    version.doi = doi
+    version.save()
+
+    return version
+
+
+@pytest.mark.django_db
+def test_stale_manifest_paths_detects_missing_doi(version_with_doi_less_manifests):
+    version = version_with_doi_less_manifests
+
+    assert stale_manifest_paths(version) == [
+        _dandiset_jsonld_path(version),
+        _dandiset_yaml_path(version),
+    ]
+
+
+@pytest.mark.django_db
+def test_stale_manifest_paths_ignores_current_manifests():
+    version: Version = PublishedVersionFactory.create()
+    write_manifest_files(version.id)
+
+    assert stale_manifest_paths(version) == []
+
+
+@pytest.mark.django_db
+def test_stale_manifest_paths_detects_missing_manifests():
+    version: Version = PublishedVersionFactory.create()
+
+    # No manifests have been written at all.
+    assert stale_manifest_paths(version) == [
+        _dandiset_jsonld_path(version),
+        _dandiset_yaml_path(version),
+    ]
+
+
+@pytest.mark.django_db
+def test_rewrite_manifests_missing_doi(version_with_doi_less_manifests):
+    version = version_with_doi_less_manifests
+
+    rewrite_manifests_missing_doi('--all')
+
+    dandiset_jsonld, dandiset_yaml = _written_manifests(version)
+    assert dandiset_jsonld['doi'] == version.doi
+    assert dandiset_yaml['doi'] == version.doi
+    assert version.doi in dandiset_jsonld['citation']
+    assert stale_manifest_paths(version) == []
+
+
+@pytest.mark.django_db
+def test_rewrite_manifests_missing_doi_dry_run(version_with_doi_less_manifests):
+    version = version_with_doi_less_manifests
+
+    rewrite_manifests_missing_doi('--all', '--dry-run')
+
+    dandiset_jsonld, dandiset_yaml = _written_manifests(version)
+    assert 'doi' not in dandiset_jsonld
+    assert 'doi' not in dandiset_yaml
+
+
+@pytest.mark.django_db
+def test_rewrite_manifests_missing_doi_leaves_published_version_untouched(
+    version_with_doi_less_manifests,
+):
+    """Published versions are immutable; only the manifest files may be rewritten."""
+    version = version_with_doi_less_manifests
+    original_fields = model_to_dict(version)
+    original_modified = version.modified
+
+    rewrite_manifests_missing_doi('--all')
+
+    version.refresh_from_db()
+    assert model_to_dict(version) == original_fields
+    assert version.modified == original_modified
+
+
+@pytest.mark.django_db
+def test_rewrite_manifests_missing_doi_skips_versions_with_unpopulated_metadata_doi(
+    version_with_doi_less_manifests,
+):
+    """A DOI absent from the metadata can't be written into the manifest without a re-save."""
+    version = version_with_doi_less_manifests
+
+    # Bypass `Version.save` so the row has a DOI its metadata doesn't reflect.
+    Version.objects.filter(id=version.id).update(
+        metadata={k: v for k, v in version.metadata.items() if k != 'doi'}
+    )
+    version.refresh_from_db()
+
+    rewrite_manifests_missing_doi('--all')
+
+    # The version is left alone, and so are its manifests.
+    version.refresh_from_db()
+    assert 'doi' not in version.metadata
+    dandiset_jsonld, dandiset_yaml = _written_manifests(version)
+    assert 'doi' not in dandiset_jsonld
+    assert 'doi' not in dandiset_yaml
+
+
+@pytest.mark.django_db
+def test_rewrite_manifests_missing_doi_skips_versions_without_doi():
+    version: Version = PublishedVersionFactory.create(doi=None)
+    write_manifest_files(version.id)
+
+    rewrite_manifests_missing_doi('--all')
+
+    dandiset_jsonld, _ = _written_manifests(version)
+    assert 'doi' not in dandiset_jsonld
+
+
+@pytest.mark.django_db
+def test_rewrite_manifests_missing_doi_skips_drafts(draft_version: Version):
+    write_manifest_files(draft_version.id)
+
+    rewrite_manifests_missing_doi('--all')
+
+    # The draft has no DOI, and must not be picked up as a published version.
+    dandiset_jsonld, _ = _written_manifests(draft_version)
+    assert 'doi' not in dandiset_jsonld
+
+
+@pytest.mark.django_db
+def test_rewrite_manifests_missing_doi_filters_by_dandiset(version_with_doi_less_manifests):
+    version = version_with_doi_less_manifests
+    other_version: Version = PublishedVersionFactory.create()
+
+    rewrite_manifests_missing_doi(str(other_version.dandiset.id))
+
+    # Only the requested dandiset was considered.
+    assert stale_manifest_paths(version) != []
+
+
+@pytest.mark.django_db
+def test_rewrite_manifests_missing_doi_requires_a_target():
+    with pytest.raises(
+        click.ClickException, match="Must specify exactly one of 'dandisets' or --all"
+    ):
+        rewrite_manifests_missing_doi()

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dandischema.conf import get_instance_config
+from dandischema.consts import DANDI_SCHEMA_VERSION
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.forms.models import model_to_dict
@@ -20,7 +21,10 @@ from zarr_checksum.generators import ZarrArchiveFile
 from dandiapi.api import tasks
 from dandiapi.api.manifests import _dandiset_jsonld_path
 from dandiapi.api.models import Asset, Version
-from dandiapi.api.tests.factories import DraftVersionFactory, UserFactory
+from dandiapi.api.services.asset import _add_asset_to_version
+from dandiapi.api.services.metadata import validate_asset_metadata, validate_version_metadata
+from dandiapi.api.services.publish import _lock_dandiset_for_publishing
+from dandiapi.api.tests.factories import AssetBlobFactory, DraftVersionFactory, UserFactory
 from dandiapi.zarr.models import ZarrArchiveStatus
 
 from .fuzzy import DEFAULT_WAS_ASSOCIATED_WITH, HTTP_URL_RE, URN_RE, UTC_ISO_TIMESTAMP_RE
@@ -452,26 +456,46 @@ def test_publish_task(
     assert new_published_asset.metadata == old_published_asset.metadata
 
 
+@pytest.fixture
+def publishing_dandiset():
+    """Create a draft version locked for publishing, and return it with its owner."""
+    user = UserFactory.create()
+    draft_version: Version = DraftVersionFactory.create(
+        status=Version.Status.VALID, dandiset__owners=[user]
+    )
+    asset = _add_asset_to_version(
+        version=draft_version,
+        asset_blob=AssetBlobFactory(),
+        zarr_archive=None,
+        metadata={
+            'path': 'foo.txt',
+            'schemaVersion': DANDI_SCHEMA_VERSION,
+            'schemaKey': 'Asset',
+            'encodingFormat': 'application/x-nwb',
+        },
+    )
+    validate_asset_metadata(asset=asset)
+    validate_version_metadata(version=draft_version)
+
+    _lock_dandiset_for_publishing(user=user, dandiset=draft_version.dandiset)
+    draft_version.refresh_from_db()
+
+    return draft_version, user
+
+
 @pytest.mark.django_db
 def test_publish_task_writes_doi_into_manifest(
-    draft_asset_factory,
-    published_asset_factory,
-    django_capture_on_commit_callbacks,
+    publishing_dandiset, django_capture_on_commit_callbacks
 ):
     """The published dandiset.jsonld must carry the DOI minted at publish time.
 
     Regression test for dandi/dandi-archive#2759: the manifest write used to be
-    enqueued from an ``on_commit`` callback independent of the one minting the
-    DOI, so it could run before ``version.doi`` was saved -- leaving ``doi:
-    null`` and a non-DOI ``citation`` in the on-S3 manifest forever.
+    enqueued from an ``on_commit`` callback registered *before* the one minting
+    the DOI, so the Celery task could run before ``version.doi`` was saved --
+    leaving ``doi: null`` and a non-DOI ``citation`` in the on-S3 manifest
+    forever.
     """
-    user = UserFactory.create()
-    draft_version: Version = DraftVersionFactory.create(
-        status=Version.Status.PUBLISHING, dandiset__owners=[user]
-    )
-    draft_version.assets.set(
-        [draft_asset_factory(status=Asset.Status.VALID), published_asset_factory()]
-    )
+    draft_version, user = publishing_dandiset
 
     with django_capture_on_commit_callbacks(execute=True):
         tasks.publish_dandiset_task(draft_version.dandiset.id, user.id)
@@ -485,3 +509,32 @@ def test_publish_task_writes_doi_into_manifest(
     assert manifest['doi'] == published_version.doi
     assert published_version.doi in manifest['citation']
     assert manifest == published_version.metadata
+
+
+@pytest.mark.django_db
+def test_publish_task_writes_manifest_without_doi_when_minting_fails(
+    publishing_dandiset, django_capture_on_commit_callbacks, mocker
+):
+    """A DataCite failure must not block publishing or writing the manifest.
+
+    ``_create_doi`` is registered with ``on_commit(..., robust=True)``, so an
+    exception there is swallowed (and logged) rather than propagating -- the
+    publish is already committed by that point, and ``write_manifest_files``
+    is still enqueued right after.
+    """
+    draft_version, user = publishing_dandiset
+    mocker.patch('dandiapi.api.doi.create_doi', side_effect=RuntimeError('DataCite is down'))
+
+    with django_capture_on_commit_callbacks(execute=True):
+        tasks.publish_dandiset_task(draft_version.dandiset.id, user.id)
+
+    published_version: Version = draft_version.dandiset.versions.exclude(version='draft').get()
+    assert not published_version.doi
+
+    with default_storage.open(_dandiset_jsonld_path(published_version)) as f:
+        manifest = json.loads(f.read())
+
+    assert not manifest.get('doi')
+
+    draft_version.refresh_from_db()
+    assert draft_version.status == Version.Status.PUBLISHED

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import hashlib
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,7 @@ from zarr_checksum.checksum import EMPTY_CHECKSUM
 from zarr_checksum.generators import ZarrArchiveFile
 
 from dandiapi.api import tasks
+from dandiapi.api.manifests import _dandiset_jsonld_path
 from dandiapi.api.models import Asset, Version
 from dandiapi.api.tests.factories import DraftVersionFactory, UserFactory
 from dandiapi.zarr.models import ZarrArchiveStatus
@@ -448,3 +450,38 @@ def test_publish_task(
     assert new_published_asset.path == old_published_asset.path
     assert new_published_asset.blob == old_published_asset.blob
     assert new_published_asset.metadata == old_published_asset.metadata
+
+
+@pytest.mark.django_db
+def test_publish_task_writes_doi_into_manifest(
+    draft_asset_factory,
+    published_asset_factory,
+    django_capture_on_commit_callbacks,
+):
+    """The published dandiset.jsonld must carry the DOI minted at publish time.
+
+    Regression test for dandi/dandi-archive#2759: the manifest write used to be
+    enqueued from an ``on_commit`` callback independent of the one minting the
+    DOI, so it could run before ``version.doi`` was saved -- leaving ``doi:
+    null`` and a non-DOI ``citation`` in the on-S3 manifest forever.
+    """
+    user = UserFactory.create()
+    draft_version: Version = DraftVersionFactory.create(
+        status=Version.Status.PUBLISHING, dandiset__owners=[user]
+    )
+    draft_version.assets.set(
+        [draft_asset_factory(status=Asset.Status.VALID), published_asset_factory()]
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        tasks.publish_dandiset_task(draft_version.dandiset.id, user.id)
+
+    published_version: Version = draft_version.dandiset.versions.exclude(version='draft').get()
+    assert published_version.doi
+
+    with default_storage.open(_dandiset_jsonld_path(published_version)) as f:
+        manifest = json.loads(f.read())
+
+    assert manifest['doi'] == published_version.doi
+    assert published_version.doi in manifest['citation']
+    assert manifest == published_version.metadata


### PR DESCRIPTION
Split out of #2862 so it can land on its own; that PR keeps the broader `sync_manifest_files` command and the design note.

Addresses (partially) #2759.

## The race

`_publish_dandiset` registered two independent `transaction.on_commit` callbacks, with `write_manifest_files.delay()` registered *first* and the DOI minting second. `on_commit` callbacks run in registration order, so the manifest task was handed to Celery before `_create_doi` had run its DataCite request and `version.save()` — a worker could write `dandiset.jsonld` from a version whose metadata still lacked the DOI, and nothing re-ran the manifest task afterwards. The published manifest keeps `doi: null` and a non-DOI `citation` forever.

The fix is just the ordering: register `_create_doi` first, then the manifest write. `robust=True` on the DOI callback keeps a DataCite failure from blocking the manifest write, preserving the old behavior where the two were independent.

Two regression tests cover it: the manifest carries the minted DOI on a normal publish, and a DataCite failure still leaves the version published with a (DOI-less) manifest on S3.

## Repairing the versions already affected

`rewrite_manifests_missing_doi` (added by @jjnesbitt) rewrites `dandiset.jsonld` / `dandiset.yaml` for published versions whose on-S3 manifests don't carry the DOI their metadata has — the two manifests that embed it. A version is also treated as stale if its manifest is missing or unreadable, since rewriting is the fix either way.

It deliberately touches nothing but S3: versions whose *metadata* has no `doi` are reported and skipped rather than re-saved, keeping published versions immutable.

<details>
<summary>Failure modes</summary>

- `create_doi` raises → Django logs the callback failure (`robust=True`), `version.doi` stays NULL, and the manifest is still written.
- A version with a `doi` column but no `doi` in its metadata can't be repaired from the manifest side alone; the command warns about those instead of modifying the published version.

Future hardening, not included here: make the DOI step a real Celery task with `autoretry_for=(requests.RequestException,)` so transient DataCite failures recover on their own instead of needing an operator sweep.
</details>

## Test plan

- [x] `ruff check` / `ruff format --check` clean (ruff 0.16.3, as pinned on master).
- [x] CI green on `9bef509` — `test`, both `test (3.13, …)` matrix jobs, E2E, lint and build-image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V31tV7K7jzN5HFbizSo9pF