### PR TITLE
Fix embargo funding and end date parameters on Dandiset creation

### DIFF
--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -14,11 +14,7 @@ import type {
   DandisetSearchResult,
   IncompleteUpload,
 } from '@/types';
-import type {
-  Dandiset as DandisetMetadata,
-  DandisetContributors,
-  Organization,
-} from '@/types/schema';
+import type { Dandiset as DandisetMetadata } from '@/types/schema';
 import { useDandisetStore } from '@/stores/dandiset';
 import qs from 'querystring';
 
@@ -233,34 +229,23 @@ const dandiRest = {
       embargoEndDate?: string;
     }
   ) {
+    // Parameter names match CreateDandisetQueryParameterSerializer on the
+    // server, which also adds the funding source as a Funder contributor.
     const params: { embargo: boolean; [key: string]: any } = { embargo: true };
 
-    // Add embargo-specific parameters
     if (embargoData.hasAward) {
       if (embargoData.fundingSource) {
-        params.fundingSource = embargoData.fundingSource;
+        params.funding_source = embargoData.fundingSource;
       }
       if (embargoData.awardNumber) {
-        params.awardNumber = embargoData.awardNumber;
+        params.award_number = embargoData.awardNumber;
       }
-    } else if (embargoData.embargoEndDate) {
-      params.embargoEndDate = embargoData.embargoEndDate;
+    }
+    if (embargoData.embargoEndDate) {
+      params.embargo_end_date = embargoData.embargoEndDate;
     }
 
-    // If we have award information, add it as a contributor in the metadata
-    let updatedMetadata = metadata;
-    if (embargoData.hasAward && embargoData.fundingSource) {
-      const award: Organization = {
-        name: embargoData.fundingSource,
-        schemaKey: 'Organization',
-        awardNumber: embargoData.awardNumber,
-        roleName: ['dcite:Funder'],
-      };
-      const contributor: DandisetContributors = [...(metadata.contributor || []), award];
-      updatedMetadata = { ...metadata, contributor };
-    }
-
-    return this.createDandiset(name, updatedMetadata, { params });
+    return this.createDandiset(name, metadata, { params });
   },
   async saveDandiset(
     identifier: string,

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -154,9 +154,11 @@
               v-model="awardNumber"
               label="Grant/Award number"
               :counter="120"
+              required
               variant="outlined"
               density="compact"
               class="mb-4"
+              :rules="awardNumberRules"
             />
 
             <div class="text-h5 mb-2">
@@ -260,12 +262,18 @@ const saveDisabled = computed(
   () => !name.value
       || !description.value
       || (!embargoed.value && !license.value)
-      || (embargoed.value && hasAward.value && (!fundingSource.value || !grantEndDate.value || !isGrantEndDateValid.value))
+      || (embargoed.value && hasAward.value
+        && (!fundingSource.value || !awardNumber.value || !grantEndDate.value || !isGrantEndDateValid.value))
       || (embargoed.value && !hasAward.value && !embargoEndDate.value),
 );
 
 const fundingSourceRules = computed(
   () => [(v: string) => !!v || 'Funding source is required'],
+);
+
+// The server rejects a funding source without an award number.
+const awardNumberRules = computed(
+  () => [(v: string) => !!v || 'Award number (or project name) is required'],
 );
 
 const grantEndDateRules = computed(() => [
@@ -317,12 +325,11 @@ async function registerDandiset() {
   }
 
   if (embargoed.value) {
-    // Handle embargoed dandiset creation with new structure
     const embargoData = {
       hasAward: hasAward.value,
-      funding_source: hasAward.value ? fundingSource.value : undefined,
-      award_number: hasAward.value ? awardNumber.value : undefined,
-      embargo_end_date: hasAward.value ? grantEndDate.value : embargoEndDate.value,
+      fundingSource: hasAward.value ? fundingSource.value : undefined,
+      awardNumber: hasAward.value ? awardNumber.value : undefined,
+      embargoEndDate: hasAward.value ? grantEndDate.value : embargoEndDate.value,
     };
 
     const { data } = await dandiRest.createEmbargoedDandiset(name.value, metadata, embargoData);


### PR DESCRIPTION
The embargo fields on the Dandiset creation form have not been reaching the server. The form passes `funding_source`, `award_number`, and `embargo_end_date` to `createEmbargoedDandiset`, which reads `fundingSource`, `awardNumber`, and `embargoEndDate`, so all three were undefined. The helper then sends camelCase query parameters, while `CreateDandisetQueryParameterSerializer` reads snake_case, so even the values it did have would have been ignored. The only parameter that got through was `embargo=true`. Every embargoed Dandiset created through the form since #2462 has therefore received the default two-year embargo rather than the grant end date, and no funder was recorded.

This aligns the three layers on the names the server serializer reads. The client no longer adds the funder as a contributor itself, since `create_embargoed_dandiset` does that when it receives the funding source. The award number is now required when an award is given, which matches the server-side validation; the form already asks for a project name when there is no number.

One related server-side issue I have not touched here: `create_embargoed_dandiset` builds the contributor list from the raw request metadata rather than the normalized metadata, so the contact person the server adds by default is dropped when a funding source is supplied. The existing test asserts that result. Now that the funding source actually reaches the server, that is worth fixing separately.

Split out from #2917, which builds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181P1YxVoFttcfqrdWr2mqu
